### PR TITLE
Add e2e_key db to dendrite config

### DIFF
--- a/dockerfiles/dendrite.yaml
+++ b/dockerfiles/dendrite.yaml
@@ -102,6 +102,7 @@ database:
     public_rooms_api: "file:dendrite_publicroomsapi.db"
     appservice: "file:dendrite_appservice.db"
     naffka: "file:dendrite_naffka.db"
+    e2e_key: "file:dendrite_e2e_key.db"
 
 # The TCP host:port pairs to bind the internal HTTP APIs to.
 # These shouldn't be exposed to the public internet.


### PR DESCRIPTION
It was missing, causing issues.

Done with a community hat:
```
Signed-off-by: Travis Ralston <travis@t2bot.io>
```