### PR TITLE
Add the media_nofilename tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,11 @@ logout_test.go 0/4 tests
 media_admin_quarantine_test.go 0/1 tests
 media_ascii_test.go 0/5 tests
 media_config_test.go 0/1 tests
-media_nofilename_test.go 0/3 tests
+media_nofilename_test.go 3/3 tests
+    ✓ Can upload without a file name
+    ✓ Can download without a file name locally
+    ✓ Can download without a file name over federation
+
 media_thumbnail_test.go 0/2 tests
 media_unicode_test.go 0/5 tests
 media_urlpreview_test.go 0/1 tests
@@ -232,5 +236,5 @@ torture_json_test.go 0/3 tests
 user_directory_private_test.go 0/3 tests
 user_directory_public_test.go 0/7 tests
 
-TOTAL: 8/694 tests converted
+TOTAL: 11/694 tests converted
 ```

--- a/internal/must/must.go
+++ b/internal/must/must.go
@@ -119,7 +119,7 @@ func NotEqualStr(t *testing.T, got, want, msg string) {
 func StartWithStr(t *testing.T, got, wantPrefix, msg string) {
 	t.Helper()
 	if !strings.HasPrefix(got, wantPrefix) {
-		t.Errorf("StartWithStr: #{msg}: got '#{got}' without prefix '#{wantPrefix}'")
+		t.Errorf("StartWithStr: %s: got '%s' without prefix '%s'", msg, got, wantPrefix)
 	}
 }
 

--- a/internal/must/must.go
+++ b/internal/must/must.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/matrix-org/complement/internal/match"
@@ -111,6 +112,14 @@ func NotEqualStr(t *testing.T, got, want, msg string) {
 	t.Helper()
 	if got == want {
 		t.Errorf("NotEqualStr %s: got '%s', but didn't want it", msg, got)
+	}
+}
+
+// StartWithStr ensures that got starts with wantPrefix else logs an error.
+func StartWithStr(t *testing.T, got, wantPrefix, msg string) {
+	t.Helper()
+	if !strings.HasPrefix(got, wantPrefix) {
+		t.Errorf("StartWithStr: #{msg}: got '#{got}' without prefix '#{wantPrefix}'")
 	}
 }
 

--- a/tests/media_nofilename_test.go
+++ b/tests/media_nofilename_test.go
@@ -1,0 +1,59 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/matrix-org/complement/internal/b"
+	"github.com/matrix-org/complement/internal/federation"
+	"github.com/matrix-org/complement/internal/must"
+)
+
+// Can handle uploads and remote/local downloads without a file name
+func TestMediaWithoutFileName(t *testing.T) {
+	deployment := Deploy(t, "media_repo", b.BlueprintAlice)
+	defer deployment.Destroy(t)
+
+	srv := federation.NewServer(t, deployment,
+		federation.HandleMediaRequests(),
+	)
+	cancel := srv.Listen()
+	defer cancel()
+
+	userID := "@alice:hs1"
+	file := []byte("Hello World!")
+	fileName := ""
+	contentType := "text/plain"
+
+	t.Run("parallel", func(t *testing.T) {
+		t.Run("Can upload without a file name", func(t *testing.T) {
+			t.Parallel()
+			alice := deployment.Client(t, "hs1", userID)
+			mxc := alice.UploadContent(t, file, fileName, contentType)
+			must.NotEqualStr(t, mxc, "", "did not return an MXC URI")
+			must.StartWithStr(t, mxc, "mxc://", "returned invalid MXC URI")
+		})
+		t.Run("Can download without a file name locally", func(t *testing.T) {
+			t.Parallel()
+			alice := deployment.Client(t, "hs1", userID)
+			mxc := alice.UploadContent(t, file, fileName, contentType)
+			must.NotEqualStr(t, mxc, "", "did not return an MXC URI")
+			must.StartWithStr(t, mxc, "mxc://", "returned invalid MXC URI")
+			b, ct := alice.DownloadContent(t, mxc)
+			must.EqualStr(t, ct, contentType, "wrong Content-Type returned")
+			must.EqualStr(t, string(b), string(file), "wrong file content returned")
+		})
+		t.Run("Can download without a file name over federation", func(t *testing.T) {
+			t.Parallel()
+			alice := deployment.Client(t, "hs1", userID)
+
+			// We know to expect a text/plain response like this from the HandleMediaRequests docs
+			wantContentType := "text/plain"
+			wantResponse := "Hello from the other side"
+
+			b, ct := alice.DownloadContent(t, fmt.Sprintf("mxc://%s/%s", srv.ServerName, "PlainTextFile"))
+			must.EqualStr(t, ct, wantContentType, "wrong Content-Type returned")
+			must.EqualStr(t, string(b), wantResponse, "wrong file content returned")
+		})
+	})
+}


### PR DESCRIPTION
One of hopefully many PRs to add the media tests to Complement.

Tested with Dendrite and passes.

Done with a community hat:
```
Signed-off-by: Travis Ralston <travis@t2bot.io>
```