### PR TITLE
Prevent the Dendrite dockerfile from exiting prematurely

### DIFF
--- a/dockerfiles/Dendrite.Dockerfile
+++ b/dockerfiles/Dendrite.Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:1.13-stretch as build
-RUN apt-get update && apt-get install sqlite3
+RUN apt-get update && apt-get install -y sqlite3
 WORKDIR /build
 
 # pull files from branches


### PR DESCRIPTION
I found that when building the dendrite docker image, the build process will exit prematurely if `apt install` doesn't receive a confirmation.

```
$ docker build -t complement-dendrite -f Dendrite.Dockerfile .
Sending build context to Docker daemon   16.9kB
Step 1/14 : FROM golang:1.13-stretch as build
 ---> 89c634cd9763
Step 2/14 : RUN apt-get update && apt-get install sqlite3
 ---> Running in 68910f2a1eda
Ign:1 http://deb.debian.org/debian stretch InRelease
Get:2 http://security.debian.org/debian-security stretch/updates InRelease [53.0 kB]
Get:3 http://deb.debian.org/debian stretch-updates InRelease [93.6 kB]
Get:4 http://deb.debian.org/debian stretch Release [118 kB]
Get:5 http://deb.debian.org/debian stretch Release.gpg [2410 B]
Get:6 http://security.debian.org/debian-security stretch/updates/main amd64 Packages [567 kB]
Get:7 http://deb.debian.org/debian stretch-updates/main amd64 Packages [2596 B]
Get:8 http://deb.debian.org/debian stretch/main amd64 Packages [7080 kB]
Fetched 7916 kB in 2s (3809 kB/s)
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
The following additional packages will be installed:
  libsqlite3-0
Suggested packages:
  sqlite3-doc
The following NEW packages will be installed:
  sqlite3
The following packages will be upgraded:
  libsqlite3-0
1 upgraded, 1 newly installed, 0 to remove and 4 not upgraded.
Need to get 1356 kB of archives.
After this operation, 2357 kB of additional disk space will be used.
Do you want to continue? [Y/n] Abort.
The command '/bin/sh -c apt-get update && apt-get install sqlite3' returned a non-zero code: 1
```