### PR TITLE
Add CA generation and mount it to /ca in containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,36 @@ $ COMPLEMENT_BASE_IMAGE=complement-dendrite:latest go test -timeout 30s -run '^(
 - The homeserver needs to `200 OK` requests to `GET /_matrix/client/versions`.
 - The homeserver needs to manage its own storage within the image.
 - The homeserver needs to accept the server name given by the environment variable `SERVER_NAME` at runtime.
+- The homeserver can use the CA certificate mounted at /ca to create its own TLS cert (see [Complement PKI](README.md#complement-pki)).
 
 #### Why 'Complement'?
 
 Because **M**<sup>*C*</sup> = **1** - **M**
+
+#### Complement PKI
+
+As the Matrix federation protocol expects federation endpoints to be served with valid TLS certs,
+Complement will create a self-signed CA cert to use for creating valid TLS certs in homeserver containers.
+
+To enabled it pass `COMPLEMENT_CA=true` to complement or the docker container.
+If not used, the homeserver needs to not validate the cert when federating.
+To check whether complements runs in PKI mode, `COMPLEMENT_CA` is passed through to the homeserver containers.
+
+The public key to add to the trusted cert store (e.g., /etc/ca-certificates) is mounted at: `/ca/ca.crt`
+The private key to sign the created TLS cert is mounted at: `/ca/ca.key`
+
+For example, to sign your certificate for the homeserver, run at each container start (Ubuntu):
+```
+openssl genrsa -out $SERVER_NAME.key 2048
+openssl req -new -sha256 -key $SERVER_NAME.key -subj "/C=US/ST=CA/O=MyOrg, Inc./CN=$SERVER_NAME" -out $SERVER_NAME.csr
+openssl x509 -req -in $SERVER_NAME.csr -CA /ca/ca.crt -CAkey /ca/ca.key -CAcreateserial -out $SERVER_NAME.crt -days 1 -sha256
+```
+
+To add the CA cert to your trust store (Ubuntu):
+```
+cp /root/ca.crt /usr/local/share/ca-certificates/complement.crt
+update-ca-certificates
+```
 
 #### Sytest parity
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Because **M**<sup>*C*</sup> = **1** - **M**
 As the Matrix federation protocol expects federation endpoints to be served with valid TLS certs,
 Complement will create a self-signed CA cert to use for creating valid TLS certs in homeserver containers.
 
-To enabled it pass `COMPLEMENT_CA=true` to complement or the docker container.
+To enable it pass `COMPLEMENT_CA=true` to complement or the docker container.
 If not used, the homeserver needs to not validate the cert when federating.
 To check whether complements runs in PKI mode, `COMPLEMENT_CA` is passed through to the homeserver containers.
 

--- a/dockerfiles/ComplementCIBuildkite.Dockerfile
+++ b/dockerfiles/ComplementCIBuildkite.Dockerfile
@@ -8,3 +8,5 @@ FROM golang:1.15-buster
 RUN curl -fsSL https://get.docker.com -o get-docker.sh && sh get-docker.sh
 ADD https://github.com/matrix-org/complement/archive/master.tar.gz .
 RUN tar -xzf master.tar.gz && cd complement-master && go mod download 
+
+VOLUME [ "/ca" ]

--- a/internal/docker/builder.go
+++ b/internal/docker/builder.go
@@ -43,7 +43,7 @@ var (
 	HostnameRunningComplement = "host.docker.internal"
 	// HostnameRunningDocker is the hostname of the docker daemon from the perspective of Complement.
 	HostnameRunningDocker = "localhost"
-	// CACertificateDirContainer is the volume that is shared among all containers an contains the CA certs.
+	// CACertificateDirContainer is the volume that is shared among all containers and contains the CA certs.
 	CACertificateDirContainer = "/ca"
 )
 

--- a/internal/docker/builder.go
+++ b/internal/docker/builder.go
@@ -301,11 +301,11 @@ func getCaVolume(docker *client.Client, ctx context.Context) (map[string]struct{
 	var caMount []mount.Mount
 
 	if os.Getenv("CI") == "true" {
-		// When in CI, complement itself is a container with the CA volume mounted at /ca.
-		// We need to mount this volume to all homeserver containers
-		// to synchronize the CA cert. Needed to establish trust among all containers.
+		// When in CI, Complement itself is a container with the CA volume mounted at /ca.
+		// We need to mount this volume to all homeserver containers to synchronize the CA cert.
+		// This is needed to establish trust among all containers.
 		
-		// Get volume mounted at /ca, first get the container ID
+		// Get volume mounted at /ca. First we get the container ID
 		// /proc/1/cpuset should be /docker/<containerId>
 		cpuset, err := ioutil.ReadFile("/proc/1/cpuset")
 		if err != nil {
@@ -328,7 +328,7 @@ func getCaVolume(docker *client.Client, ctx context.Context) (map[string]struct{
 			}
 		}
 		if volumeName == "" {
-			// We did not find a volume. Possible cause this container is created without a volume,
+			// We did not find a volume. This container might be created without a volume,
 			// or CI=true is passed but we are not running in a container.
 			// todo: log that we do not provide a CA volume mount?
 			return map[string]struct{}{}, []mount.Mount{}, nil
@@ -345,7 +345,7 @@ func getCaVolume(docker *client.Client, ctx context.Context) (map[string]struct{
 			}
 		}
 	} else {
-		// When not in CI, our CA cert is placed in the current wd.
+		// When not in CI, our CA cert is placed in the current working dir.
 		// We bind mount this directory to all homeserver containers.
 		cwd, err := os.Getwd()
 		if err != nil {

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -30,15 +30,19 @@ func TestMain(m *testing.M) {
 	}
 	// remove any old images/containers/networks in case we died horribly before
 	builder.Cleanup()
+
+	if os.Getenv("COMPLEMENT_CA") == "true" {
+		log.Printf("Running with Complement CA")
+		// make sure CA certs are generated
+		_, _, err = federation.GetOrCreateCaCert()
+		if err != nil {
+			fmt.Printf("Error: %s", err)
+			os.Exit(1)
+		}
+	}
+
 	// we use GMSL which uses logrus by default. We don't want those logs in our test output unless they are Serious.
 	logrus.SetLevel(logrus.ErrorLevel)
-
-	// make sure CA certs are generated
-	_, _, err = federation.GetOrCreateCaCert()
-	if err != nil {
-		fmt.Printf("Error: %s", err)
-		os.Exit(1)
-	}
 
 	exitCode := m.Run()
 	builder.Cleanup()

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/matrix-org/complement/internal/b"
 	"github.com/matrix-org/complement/internal/config"
 	"github.com/matrix-org/complement/internal/docker"
+	"github.com/matrix-org/complement/internal/federation"
 	"github.com/sirupsen/logrus"
 )
 
@@ -31,6 +32,14 @@ func TestMain(m *testing.M) {
 	builder.Cleanup()
 	// we use GMSL which uses logrus by default. We don't want those logs in our test output unless they are Serious.
 	logrus.SetLevel(logrus.ErrorLevel)
+
+	// make sure CA certs are generated
+	_, _, err = federation.GetOrCreateCaCert()
+	if err != nil {
+		fmt.Printf("Error: %s", err)
+		os.Exit(1)
+	}
+
 	exitCode := m.Run()
 	builder.Cleanup()
 	os.Exit(exitCode)


### PR DESCRIPTION
This PR adds support for CA generation in complement.

The Outbound Federation server will create a CA cert either in `$PWD/ca` or if run in CI in the Volume mounted to `/ca`.
On container deploy, depending on CI or not, either `$PWD/ca` is bind mounted to `/ca` or the `/ca` Volume of complement is mounted to `/ca` in homeserver containers.