### PR TITLE
Store synapse's database somewhere other than a volume

### DIFF
--- a/dockerfiles/synapse/homeserver.yaml
+++ b/dockerfiles/synapse/homeserver.yaml
@@ -32,7 +32,9 @@ listeners:
 database:
   name: "sqlite3"
   args:
-    database: "/data/homeserver.db"
+    # We avoid /data, as it is a volume and is not transferred when the container is committed,
+    # which is a fundamental necessity in complement.
+    database: "/conf/homeserver.db"
 
 ## Federation ##
 


### PR DESCRIPTION
`/data` is a volume in the Synapse docker image. Volumes are not copiedover when committing a container to an image (this resulted in https://github.com/matrix-org/synapse/issues/8421, where we saw that running Synapse instances seemed to lack the users we had just created on them in the blueprint stage). Thus, we should store the database somewhere else, so that it is copied correctly when a blueprint is used for a single test run.

An alternative fix is to just not create a volume (we don't need it when running complement tests), however this would require creating an separate dockerfile from the one we're using from the Synapse repo now, which is much more annoying.