### PR TITLE
Turn off certificate verification for Synapse temporarily

### DIFF
--- a/dockerfiles/synapse/homeserver.yaml
+++ b/dockerfiles/synapse/homeserver.yaml
@@ -38,6 +38,12 @@ database:
 
 ## Federation ##
 
+# disable verification of federation certificates
+#
+# TODO: this is temporary until https://github.com/matrix-org/complement/pull/28 lands and
+# allows homeservers spun up by complement access to the complement CA certificate to trust
+federation_verify_certificates: false
+
 # trust certs signed by the dummy CA
 federation_custom_ca_list:
 - /ca/ca.crt


### PR DESCRIPTION
This is necessary until homeserver containers can get access to the dummy CA that's used to create the certificate Complement federation instances are using. Synapse can't trust those entities over federation until this happens, so let's disable verification for now.

A proper fix should be possible after #28 or similar lands.