### PR TITLE
Up the default version check iterations from 50 to 100

### DIFF
--- a/dockerfiles/Synapse.Dockerfile
+++ b/dockerfiles/Synapse.Dockerfile
@@ -9,7 +9,7 @@
 # To use it:
 #
 # (cd dockerfiles && docker build -t complement-synapse -f Synapse.Dockerfile .)
-# COMPLEMENT_VERSION_CHECK_ITERATIONS=100 COMPLEMENT_BASE_IMAGE=complement-synapse go test -v ./tests
+# COMPLEMENT_BASE_IMAGE=complement-synapse go test -v ./tests
 
 FROM matrixdotorg/synapse:latest
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,7 +18,7 @@ func NewConfigFromEnvVars() *Complement {
 	cfg.BaseImageURI = os.Getenv("COMPLEMENT_BASE_IMAGE")
 	cfg.BaseImageArgs = strings.Split(os.Getenv("COMPLEMENT_BASE_IMAGE_ARGS"), " ")
 	cfg.DebugLoggingEnabled = os.Getenv("COMPLEMENT_DEBUG") == "1"
-	cfg.VersionCheckIterations = parseEnvWithDefault("COMPLEMENT_VERSION_CHECK_ITERATIONS", 50)
+	cfg.VersionCheckIterations = parseEnvWithDefault("COMPLEMENT_VERSION_CHECK_ITERATIONS", 100)
 	if cfg.BaseImageURI == "" {
 		panic("COMPLEMENT_BASE_IMAGE must be set")
 	}


### PR DESCRIPTION
To help out poor homeservers like Synapse which take some time to start up the python interpreter. Otherwise tests become flaky as the homeserver only starts up quick enough around half the time.