### PR TITLE
Federation: return 'Content-Type' header of 'application/json' by default 

### DIFF
--- a/internal/federation/server.go
+++ b/internal/federation/server.go
@@ -78,6 +78,13 @@ func NewServer(t *testing.T, deployment *docker.Deployment, opts ...func(*Server
 			fetcher,
 		},
 	}
+	srv.mux.Use(func(h http.Handler) http.Handler {
+		// Return a json Content-Type header to all requests by default
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Add("Content-Type", "application/json")
+			h.ServeHTTP(w, r)
+		})
+	})
 	srv.mux.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		if srv.UnexpectedRequestsAreErrors {
 			t.Errorf("Server.UnexpectedRequestsAreErrors=true received unexpected request to server: %s %s", req.Method, req.URL.Path)


### PR DESCRIPTION
Fixes https://github.com/matrix-org/complement/issues/32

Causes the federation server to return a `Content-Type` header with a value of "application/json" by default for all requests. Exceptions to this rule should override the header in their handler function.

I've confirmed that Dendrite still passes all tests even with this change.