### PR TITLE
TestRoomCreationReportsEventsToMyself: Provide an empty json dict to /createRoom instead of no body

### DIFF
--- a/tests/rooms_state_test.go
+++ b/tests/rooms_state_test.go
@@ -24,7 +24,7 @@ func TestRoomCreationReportsEventsToMyself(t *testing.T) {
 
 	userID := "@alice:hs1"
 	alice := deployment.Client(t, "hs1", userID)
-	roomID := alice.CreateRoom(t, nil)
+	roomID := alice.CreateRoom(t, struct{}{})
 
 	t.Run("parallel", func(t *testing.T) {
 		// sytest: Room creation reports m.room.create to myself


### PR DESCRIPTION
As Synapse would otherwise complain that the provided body (of nothing) would not be JSON:

```
    client.go:200: Making POST request to http://localhost:33066/_matrix/client/r0/createRoom?access_token=xxx
    client.go:200: Request body: null
    client.go:266: POST /_matrix/client/r0/createRoom => 400 Bad Request (8.18542ms)
    client.go:200: HTTP/1.1 400 Bad Request
        Transfer-Encoding: chunked
        Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Authorization
        Access-Control-Allow-Methods: GET, HEAD, POST, PUT, DELETE, OPTIONS
        Access-Control-Allow-Origin: *
        Cache-Control: no-cache, no-store, must-revalidate
        Content-Type: application/json
        Date: Mon, 09 Nov 2020 13:34:38 GMT
        Server: Synapse/1.22.1
        
        41
        {"errcode":"M_BAD_JSON","error":"Content must be a JSON object."}
        0
```

I considered just changing `client.Do` to treat a `nil` `jsonBody` parameter as `struct{}{}`, but then realised that there probably are cases where we we want to test without sending a JSON body :)

I've confirmed that Dendrite still passes all tests even with this change.