### PR TITLE
Allow specifying server_name parameter values when joining a room

### DIFF
--- a/tests/federation_room_get_missing_events_test.go
+++ b/tests/federation_room_get_missing_events_test.go
@@ -44,7 +44,7 @@ func TestOutboundFederationIgnoresMissingEventWithBadJSONForRoomVersion6(t *test
 	roomAlias := srv.MakeAliasMapping("flibble", room.RoomID)
 	// join the room
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	alice.JoinRoom(t, roomAlias)
+	alice.JoinRoom(t, roomAlias, nil)
 
 	latestEvent := room.Timeline[len(room.Timeline)-1]
 

--- a/tests/federation_room_join_test.go
+++ b/tests/federation_room_join_test.go
@@ -53,9 +53,9 @@ func TestJoinViaRoomIDAndServerName(t *testing.T) {
 	charlie := srv.UserID("charlie")
 	serverRoom := srv.MustMakeRoom(t, ver, federation.InitialRoomEvents(ver, charlie))
 
-	// join the room by room ID alone - the server will need to extract the domain for this to work.
+	// join the room by room ID, providing the serverName to join via
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	alice.JoinRoom(t, serverRoom.RoomID)
+	alice.JoinRoom(t, serverRoom.RoomID, []string{srv.ServerName})
 
 	// remove the make/send join paths from the Complement server to force HS2 to join via HS1
 	acceptMakeSendJoinRequests = false

--- a/tests/federation_room_send_test.go
+++ b/tests/federation_room_send_test.go
@@ -36,7 +36,7 @@ func TestOutboundFederationSend(t *testing.T) {
 
 	// join the room
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	alice.JoinRoom(t, roomAlias)
+	alice.JoinRoom(t, roomAlias, nil)
 
 	wantEventType := "m.room.message"
 


### PR DESCRIPTION
This PR adds a `serverName` argument to `CSAPI.JoinRoom`, allowing clients to populate [the `server_name` query parameter](https://matrix.org/docs/spec/client_server/r0.6.1#post-matrix-client-r0-join-roomidoralias).

Additionally useful for homeservers that don't parse server names from room IDs.

Fixes: https://github.com/matrix-org/complement/issues/39

Aside: I didn't put any newlines between logical blocks of code as the rest of the codebase doesn't do this, even though I sort of wanted to. Is there a general code style for complement defined anywhere?