### PR TITLE
Fix null prev_events and auth_events fields from being sent to homeservers

### DIFF
--- a/internal/federation/server.go
+++ b/internal/federation/server.go
@@ -129,9 +129,10 @@ func (s *Server) MakeAliasMapping(aliasLocalpart, roomID string) string {
 func (s *Server) MustMakeRoom(t *testing.T, roomVer gomatrixserverlib.RoomVersion, events []b.Event) *ServerRoom {
 	roomID := fmt.Sprintf("!%d:%s", len(s.rooms), s.ServerName)
 	room := &ServerRoom{
-		RoomID:  roomID,
-		Version: roomVer,
-		State:   make(map[string]*gomatrixserverlib.Event),
+		RoomID:             roomID,
+		Version:            roomVer,
+		State:              make(map[string]*gomatrixserverlib.Event),
+		ForwardExtremities: make([]string, 0),
 	}
 	// sign all these events
 	for _, ev := range events {

--- a/internal/federation/server_room.go
+++ b/internal/federation/server_room.go
@@ -34,6 +34,9 @@ func (r *ServerRoom) AddEvent(ev *gomatrixserverlib.Event) {
 
 // AuthEvents returns the state event IDs of the auth events which authenticate this event
 func (r *ServerRoom) AuthEvents(sn gomatrixserverlib.StateNeeded) (eventIDs []string) {
+	// Guard against returning a nil string slice
+	eventIDs = make([]string, 0)
+
 	appendIfExists := func(evType, stateKey string) {
 		ev := r.CurrentState(evType, stateKey)
 		if ev == nil {


### PR DESCRIPTION
When performing a `/send_join` request, Complement was responding with 'null' entries for `prev_events` and `auth_events` inside of the state events. Instead of `null`, these should've been empty arrays. It came down to nil slices being inserted into interfaces and `json.Marshal` turning those into `null` values instead. Synapse choked on this, leading to the need to track down the bug.

Thanks to @Kegsay who tracked down the causes so quickly!