### PR TITLE
Add a handler for federation transactions

### DIFF
--- a/internal/federation/handle.go
+++ b/internal/federation/handle.go
@@ -345,6 +345,7 @@ func HandleTransactionRequests(pduCallback func(gomatrixserverlib.Event), eduCal
 					log.Printf("complement: Transaction '%s': Failed to extract room ID from event: %s", transaction.TransactionID, err.Error())
 					// We don't know the event ID at this point so we can't return the
 					// failure in the PDU results
+					continue
 				}
 
 				// Retrieve the room version from the server
@@ -357,11 +358,13 @@ func HandleTransactionRequests(pduCallback func(gomatrixserverlib.Event), eduCal
 				event, err := gomatrixserverlib.NewEventFromUntrustedJSON(pdu, roomVersion)
 				if err != nil {
 					// We were unable to verify or process this event.
-					// Tell the sending server that we accepted it anyways, as we're just looking to populate the timeline here
 					log.Printf(
 						"complement: Transaction '%s': Unable to process event '%s': %s",
 						transaction.TransactionID, event.EventID(), err.Error(),
 					)
+
+					// We still don't know the event ID, and cannot add the failure to the PDU results
+					continue
 				}
 
 				// Store this PDU in the room's timeline

--- a/internal/federation/handle.go
+++ b/internal/federation/handle.go
@@ -298,6 +298,7 @@ func HandleTransactionRequests(pduCallback func(gomatrixserverlib.Event), eduCal
 					"complement: Transaction '%s': HTTP Code %d. Invalid http request: %s",
 					transactionID, errResp.Code, errResp.JSON,
 				)
+
 				w.WriteHeader(errResp.Code)
 				b, _ := json.Marshal(errResp.JSON)
 				w.Write(b)
@@ -312,6 +313,7 @@ func HandleTransactionRequests(pduCallback func(gomatrixserverlib.Event), eduCal
 					"complement: Transaction '%s': Unable to unmarshal transaction body bytes into Transaction object: %s",
 					transaction.TransactionID, err.Error(),
 				)
+
 				errResp := util.MessageResponse(400, err.Error())
 				w.WriteHeader(errResp.Code)
 				b, _ := json.Marshal(errResp.JSON)
@@ -327,6 +329,7 @@ func HandleTransactionRequests(pduCallback func(gomatrixserverlib.Event), eduCal
 					"complement: Transaction '%s': Transaction too large. PDUs: %d/50, EDUs: %d/100",
 					transaction.TransactionID, (transaction.PDUs), len(transaction.EDUs),
 				)
+
 				errResp := util.MessageResponse(400, "Transactions are limited to 50 PDUs and 100 EDUs")
 				w.WriteHeader(errResp.Code)
 				b, _ := json.Marshal(errResp.JSON)
@@ -343,6 +346,7 @@ func HandleTransactionRequests(pduCallback func(gomatrixserverlib.Event), eduCal
 				}
 				if err := json.Unmarshal(pdu, &header); err != nil {
 					log.Printf("complement: Transaction '%s': Failed to extract room ID from event: %s", transaction.TransactionID, err.Error())
+
 					// We don't know the event ID at this point so we can't return the
 					// failure in the PDU results
 					continue

--- a/internal/federation/handle.go
+++ b/internal/federation/handle.go
@@ -281,7 +281,7 @@ func HandleMediaRequests(mediaIds map[string]func(w http.ResponseWriter)) func(*
 }
 
 // HandleTransactionRequests is an option which will process GET /_matrix/federation/v1/send/{transactionID} requests universally when requested.
-// eventCallback is a function that will be called and passed each event that is received in the transaction
+// pduCallback and eduCallback are functions that if non-nil will be called and passed each PDU or EDU event received in the transaction
 func HandleTransactionRequests(pduCallback func(gomatrixserverlib.Event), eduCallback func(gomatrixserverlib.EDU)) func(*Server) {
 	return func(srv *Server) {
 		srv.mux.Handle("/_matrix/federation/v1/send/{transactionID}", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -327,7 +327,7 @@ func HandleTransactionRequests(pduCallback func(gomatrixserverlib.Event), eduCal
 			if len(transaction.PDUs) > 50 || len(transaction.EDUs) > 100 {
 				log.Printf(
 					"complement: Transaction '%s': Transaction too large. PDUs: %d/50, EDUs: %d/100",
-					transaction.TransactionID, (transaction.PDUs), len(transaction.EDUs),
+					transaction.TransactionID, len(transaction.PDUs), len(transaction.EDUs),
 				)
 
 				errResp := util.MessageResponse(400, "Transactions are limited to 50 PDUs and 100 EDUs")

--- a/internal/federation/handle.go
+++ b/internal/federation/handle.go
@@ -355,6 +355,8 @@ func HandleTransactionRequests(pduCallback func(gomatrixserverlib.Event), eduCal
 				// Retrieve the room version from the server
 				room := srv.rooms[header.RoomID]
 				if room == nil {
+					// An invalid room ID may have been provided
+					log.Printf("complement: Transaction '%s': Failed to find local room: %s", transaction.TransactionID, header.RoomID)
 					continue
 				}
 				roomVersion := gomatrixserverlib.RoomVersion(room.Version)

--- a/internal/federation/handle.go
+++ b/internal/federation/handle.go
@@ -374,6 +374,6 @@ func HandleTransactionRequests() func(*Server) {
 			}
 			w.WriteHeader(200)
 			w.Write(resp)
-		}))
+		})).Methods("PUT")
 	}
 }


### PR DESCRIPTION
Add a handler which can accept a federation transaction, validate the PDUs and return errors in the case of failing to process a given PDU.

EDUs are accepted but we currently don't do anything with them.

This grew out of trying to fix `TestOutboundFederationIgnoresMissingEventWithBadJSONForRoomVersion6` for Synapse. The test would fail because as soon as Synapse joined the room, it would start trying to send presence EDUs to the new server. Rather than disabling presence, I thought it would be better to write a proper handler for it.

I'll use this handler for that test (and possibly others) in a separate PR.