### PR TITLE
Update tests to use the new federation transaction handler

### DIFF
--- a/tests/federation_room_get_missing_events_test.go
+++ b/tests/federation_room_get_missing_events_test.go
@@ -34,6 +34,8 @@ func TestOutboundFederationIgnoresMissingEventWithBadJSONForRoomVersion6(t *test
 	srv := federation.NewServer(t, deployment,
 		federation.HandleKeyRequests(),
 		federation.HandleMakeSendJoinRequests(),
+		// Handle any transactions that the homeserver may send when connecting to another homeserver (such as presence)
+		federation.HandleTransactionRequests(nil, nil),
 	)
 	cancel := srv.Listen()
 	defer cancel()

--- a/tests/federation_room_send_test.go
+++ b/tests/federation_room_send_test.go
@@ -1,12 +1,11 @@
 package tests
 
 import (
-	"encoding/json"
-	"net/http"
 	"testing"
 	"time"
 
 	"github.com/matrix-org/complement/internal/b"
+	"github.com/matrix-org/complement/internal/docker"
 	"github.com/matrix-org/complement/internal/federation"
 	"github.com/matrix-org/gomatrixserverlib"
 )
@@ -22,48 +21,39 @@ func TestOutboundFederationSend(t *testing.T) {
 	deployment := Deploy(t, "federation_send", b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
+	waiter := NewWaiter()
+	wantEventType := "m.room.message"
+
+	// create a remote homeserver
 	srv := federation.NewServer(t, deployment,
 		federation.HandleKeyRequests(),
 		federation.HandleMakeSendJoinRequests(),
+		federation.HandleTransactionRequests(
+			// listen for PDU events in transactions
+			func(ev gomatrixserverlib.Event) {
+				defer waiter.Finish()
+
+				if ev.Type() != wantEventType {
+					t.Errorf("Wrong event type, got %s want %s", ev.Type(), wantEventType)
+				}
+			},
+			nil,
+		),
 	)
 	cancel := srv.Listen()
 	defer cancel()
 
+	// the remote homeserver creates a public room
 	ver := gomatrixserverlib.RoomVersionV5
 	charlie := srv.UserID("charlie")
 	serverRoom := srv.MustMakeRoom(t, ver, federation.InitialRoomEvents(ver, charlie))
 	roomAlias := srv.MakeAliasMapping("flibble", serverRoom.RoomID)
 
-	// join the room
+	// the local homeserver joins the room
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	alice.JoinRoom(t, roomAlias, nil)
+	alice.JoinRoom(t, roomAlias, []string{docker.HostnameRunningComplement})
 
-	wantEventType := "m.room.message"
-
-	waiter := NewWaiter()
-
-	// TODO: Have a nicer api shape than just http.Handler
-	srv.Mux().Handle("/_matrix/federation/v1/send/{txnID}", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		defer waiter.Finish()
-		var body gomatrixserverlib.Transaction
-		if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
-			t.Errorf("failed to decode /send body: %s", err)
-			w.WriteHeader(500)
-			return
-		}
-		if len(body.PDUs) != 1 {
-			t.Fatalf("got %d pdus, want %d", len(body.PDUs), 1)
-		}
-		ev, err := gomatrixserverlib.NewEventFromUntrustedJSON(body.PDUs[0], ver)
-		if err != nil {
-			t.Fatalf("PDU failed NewEventFromUntrustedJSON checks: %s", err)
-		}
-		if ev.Type() != wantEventType {
-			t.Errorf("Wrong event type, got %s want %s", ev.Type(), wantEventType)
-		}
-		w.WriteHeader(200)
-	})).Methods("PUT")
-
+	// the local homeserver sends an event into the room
 	alice.SendEventSynced(t, serverRoom.RoomID, b.Event{
 		Type: wantEventType,
 		Content: map[string]interface{}{
@@ -71,5 +61,7 @@ func TestOutboundFederationSend(t *testing.T) {
 			"body":    "Hello world!",
 		},
 	})
+
+	// the remote homeserver then waits for the desired event to appear in a transaction
 	waiter.Wait(t, 5*time.Second)
 }


### PR DESCRIPTION
Updates the following tests to use the new transaction handler introduced in #47:

* `TestOutboundFederationSend` - This test failed with Synapse with the inline transaction handler. Not entirely sure why, the handler function was just never called.
* `TestOutboundFederationIgnoresMissingEventWithBadJSONForRoomVersion6` - Synapse will attempt to send presence to the remote homeserver. The test would fail if not expecting this.

Based on ~~#47.~~