### PR TITLE
Check the mimetype, not the whole Content-Type header on media download

### DIFF
--- a/tests/media_nofilename_test.go
+++ b/tests/media_nofilename_test.go
@@ -57,7 +57,11 @@ func TestMediaWithoutFileName(t *testing.T) {
 			b, ct := alice.DownloadContent(t, mxc)
 
 			// Check the Content-Type response header.
-			// Homeservers are free to add other directives. All we want to check is the mimetype.
+			// NOTSPEC: There is ambiguity over whether the homeserver is allowed to change the
+			// Content-Type header here from what is sent by the client during upload. Synapse does
+			// so, and there are benefits to doing so, but the spec needs to pick a side.
+			// For now, we're operating under the assumption that homeservers are free to add other
+			// directives. All we're going to check is the mime-type.
 			mimeType := strings.Split(ct, ";")[0]
 			must.EqualStr(
 				t, mimeType, contentType,
@@ -76,7 +80,11 @@ func TestMediaWithoutFileName(t *testing.T) {
 			b, ct := alice.DownloadContent(t, fmt.Sprintf("mxc://%s/%s", srv.ServerName, remoteMediaId))
 
 			// Check the Content-Type response header.
-			// Homeservers are free to add other directives. All we want to check is the mimetype.
+			// NOTSPEC: There is ambiguity over whether the homeserver is allowed to change the
+			// Content-Type header here from what is sent by the client during upload. Synapse does
+			// so, and there are benefits to doing so, but the spec needs to pick a side.
+			// For now, we're operating under the assumption that homeservers are free to add other
+			// directives. All we're going to check is the mime-type.
 			mimeType := strings.Split(ct, ";")[0]
 			must.EqualStr(
 				t, mimeType, contentType,


### PR DESCRIPTION
Fixes https://github.com/matrix-org/complement/issues/49

By checking just the mimetype instead of an exact string match, homeservers are allowed to add charsets and other directives if they choose. As long as the mimetype stays the same, we're happy.

A comment on the original issue states that the spec is a bit vague about this, and that ideally it would be more explicit about what should happen here. At the moment though this is all we're going to test as it matches the expected behaviour from homeservers.

cc @turt2live