### PR TITLE
Add find-lint.sh script

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,7 +4,7 @@
 # options for analysis running
 run:
   # default concurrency is a available CPU number
-  concurrency: 4
+  #concurrency: 4
 
   # timeout for analysis, e.g. 30s, 5m, default is 1m
   timeout: 20m

--- a/build/README.md
+++ b/build/README.md
@@ -1,0 +1,8 @@
+# Dev Scripts
+
+These are a collection of scripts that should be helpful for those developing
+on Complement.
+
+See `find-lint.sh` for environment variables that control linter resource
+usage.
+

--- a/build/scripts/find-lint.sh
+++ b/build/scripts/find-lint.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# Runs the linters against complement
+
+# The linters can take a lot of resources and are slow, so they can be
+# configured using the following environment variables:
+#
+# - `COMPLEMENT_LINT_CONCURRENCY` - number of concurrent linters to run,
+#   golangci-lint defaults this to NumCPU
+# - `GOGC` - how often to perform garbage collection during golangci-lint runs.
+#   Essentially a ratio of memory/speed. See https://golangci-lint.run/usage/performance/#memory-usage
+#   for more info.
+
+
+cd `dirname $0`/..
+
+args=""
+if [ ${1:-""} = "fast" ]
+then args="--fast"
+fi
+
+if [[ -v COMPLEMENT_LINT_CONCURRENCY ]]; then
+  args="${args} --concurrency $COMPLEMENT_LINT_CONCURRENCY"
+fi
+
+echo "Installing golangci-lint..."
+
+# Make a backup of go.{mod,sum} first
+cp go.mod go.mod.bak && cp go.sum go.sum.bak
+go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.33.0
+echo ""
+
+# Build the code
+# This shouldn't be required, but can help eliminate errors.
+# See https://github.com/golangci/golangci-lint/issues/825 for an error that can occur if
+# the code isn't build first.
+echo "Building complement..."
+go build -tags="*" ./...
+
+# Capture exit code to ensure go.{mod,sum} is restored before exiting
+exit_code=0
+
+# Run linting
+echo "Looking for lint..."
+(golangci-lint run $args ./internal/... ./tests/... && echo "No issues found :)") || exit_code=1
+
+# Restore go.{mod,sum}
+mv go.mod.bak go.mod && mv go.sum.bak go.sum
+
+exit $exit_code

--- a/build/scripts/find-lint.sh
+++ b/build/scripts/find-lint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -eu
 
 # Runs the linters against complement
 

--- a/internal/federation/handle.go
+++ b/internal/federation/handle.go
@@ -339,12 +339,12 @@ func HandleTransactionRequests(pduCallback func(gomatrixserverlib.Event), eduCal
 
 			// Construct a response and fill as we process each PDU
 			response := gomatrixserverlib.RespSend{}
-			response.PDUs = make(map[string]gomatrixserverlib.PDUResult, 0)
+			response.PDUs = make(map[string]gomatrixserverlib.PDUResult)
 			for _, pdu := range transaction.PDUs {
 				var header struct {
 					RoomID string `json:"room_id"`
 				}
-				if err := json.Unmarshal(pdu, &header); err != nil {
+				if err = json.Unmarshal(pdu, &header); err != nil {
 					log.Printf("complement: Transaction '%s': Failed to extract room ID from event: %s", transaction.TransactionID, err.Error())
 
 					// We don't know the event ID at this point so we can't return the
@@ -361,7 +361,8 @@ func HandleTransactionRequests(pduCallback func(gomatrixserverlib.Event), eduCal
 				}
 				roomVersion := gomatrixserverlib.RoomVersion(room.Version)
 
-				event, err := gomatrixserverlib.NewEventFromUntrustedJSON(pdu, roomVersion)
+				var event gomatrixserverlib.Event
+				event, err = gomatrixserverlib.NewEventFromUntrustedJSON(pdu, roomVersion)
 				if err != nil {
 					// We were unable to verify or process this event.
 					log.Printf(


### PR DESCRIPTION
This PR adds a find-lint.sh script in a new `build/scripts/` directory, similar to [Dendrite](https://github.com/matrix-org/dendrite/tree/master/build/scripts).

I also realised during this PR that the `DENDRITE_LINT_CONCURRENCY` env var mentioned in Dendrite's find-lint.sh script doesn't actually get used anywhere :) 

Have fixed that in this one, and will PR a fix to Dendrite's after this one is approved.

I also had a couple other things to fix:

- We were accidentally setting the default lint concurrency to 4 CPUs, when really it should be number of available system CPUs.
- Some unlinted code got into master since the lint PR (#52) last had master merged into it. So I've fixed those up here as well.

The intention for this script is to be called by both developers and by CI. Reviewable commit-by-commit.