### PR TITLE
Disable ratelimiting in Synapse

### DIFF
--- a/dockerfiles/synapse/homeserver.yaml
+++ b/dockerfiles/synapse/homeserver.yaml
@@ -51,3 +51,43 @@ federation_custom_ca_list:
 # unblacklist RFC1918 addresses
 federation_ip_range_blacklist: []
 
+# Disable server rate-limiting
+rc_federation:
+  window_size: 1000
+  sleep_limit: 10
+  sleep_delay: 500
+  reject_limit: 99999
+  concurrent: 3
+
+rc_message:
+  per_second: 9999
+  burst_count: 9999
+
+rc_registration:
+  per_second: 9999
+  burst_count: 9999
+
+rc_login:
+  address:
+    per_second: 9999
+    burst_count: 9999
+  account:
+    per_second: 9999
+    burst_count: 9999
+  failed_attempts:
+    per_second: 9999
+    burst_count: 9999
+
+rc_admin_redaction:
+  per_second: 9999
+  burst_count: 9999
+
+rc_joins:
+  local:
+    per_second: 9999
+    burst_count: 9999
+  remote:
+    per_second: 9999
+    burst_count: 9999
+
+federation_rr_transactions_per_room_per_second: 9999


### PR DESCRIPTION
We were starting to hit rate limiting in longer tests (like knocking).

The same is essentially done in Sytest: https://github.com/matrix-org/sytest/blob/6e08c8f1744134f9148d3802b070968d308d7abe/lib%2FSyTest%2FHomeserver%2FSynapse.pm#L191-L227