### PR TITLE
Add user_query_keys_test.go to Synapse's blacklist

### DIFF
--- a/tests/user_query_keys_test.go
+++ b/tests/user_query_keys_test.go
@@ -1,3 +1,7 @@
+// +build !synapse_blacklist
+
+// Rationale for being included in Synapse's blacklist: https://github.com/matrix-org/complement/issues/38
+
 package tests
 
 import (


### PR DESCRIPTION
See https://github.com/matrix-org/complement/issues/38 for context.

Ended up having to use `synapse_blacklist` instead of `synapse-blacklist` as golang doesn't allow `-` to be part of build tags.