### PR TITLE
Fix incorrect path in find-lint script

### DIFF
--- a/build/scripts/find-lint.sh
+++ b/build/scripts/find-lint.sh
@@ -12,7 +12,7 @@
 #   for more info.
 
 
-cd `dirname $0`/..
+cd `dirname $0`/../..
 
 args=""
 if [ ${1:-""} = "fast" ]

--- a/tests/federation_room_join_test.go
+++ b/tests/federation_room_join_test.go
@@ -8,12 +8,13 @@ import (
 
 	"github.com/matrix-org/gomatrixserverlib"
 
+	"github.com/tidwall/sjson"
+
 	"github.com/matrix-org/complement/internal/b"
 	"github.com/matrix-org/complement/internal/docker"
 	"github.com/matrix-org/complement/internal/federation"
 	"github.com/matrix-org/complement/internal/match"
 	"github.com/matrix-org/complement/internal/must"
-	"github.com/tidwall/sjson"
 )
 
 // This tests that joining a room with ?server_name= works correctly.


### PR DESCRIPTION
Moved this script around towards the end of its development, and didn't notice that the depth of it had changed. The things you miss when you don't have CI :)

Also fixed one more lint error that came up. No idea why that wasn't an issue before.