### PR TITLE
Handle transactions sent during UnverifiableEvents test

### DIFF
--- a/tests/federation_room_join_test.go
+++ b/tests/federation_room_join_test.go
@@ -98,6 +98,7 @@ func TestJoinFederatedRoomWithUnverifiableEvents(t *testing.T) {
 	srv := federation.NewServer(t, deployment,
 		federation.HandleKeyRequests(),
 		federation.HandleMakeSendJoinRequests(),
+		federation.HandleTransactionRequests(nil, nil),
 	)
 	srv.UnexpectedRequestsAreErrors = false
 	cancel := srv.Listen()


### PR DESCRIPTION
Once again Synapse likes to send presence when it joins a room. I wonder if we should perhaps make `federation.HandleTransactionRequests(nil, nil)` the default for new servers, with the ability to override it if desired?

The only thing I worry about there is that you may want a test that 404's on transactions.  Maybe at that point we could just extend HandleTransactionRequests to return custom responses.