### PR TITLE
Add a new dockerfile for worker-mode synapse

### DIFF
--- a/dockerfiles/SynapseWorkers.Dockerfile
+++ b/dockerfiles/SynapseWorkers.Dockerfile
@@ -46,12 +46,8 @@ ENTRYPOINT \
   SYNAPSE_REPORT_STATS=no \
   # Set postgres authentication details which will be placed in the homeserver config file
   POSTGRES_PASSWORD=somesecret POSTGRES_USER=postgres POSTGRES_HOST=localhost \
-  # Note: This list currently includes all worker types other than federation_sender, as
-  # Synapse fails to send federation transactions with it enabled.
-  # https://github.com/matrix-org/synapse/issues/9192
-  SYNAPSE_WORKERS=pusher,user_dir,media_repository,appservice,synchrotron,federation_reader,federation_inbound \
-  # To use all available workers:
-  #SYNAPSE_WORKERS=* \
+  # Use all available worker types
+  SYNAPSE_WORKERS=* \
   # Run the script that writes the necessary config files and starts supervisord, which in turn
   # starts everything else
   /configure_workers_and_start.py

--- a/dockerfiles/SynapseWorkers.Dockerfile
+++ b/dockerfiles/SynapseWorkers.Dockerfile
@@ -2,10 +2,6 @@
 # as well as sets up the homeserver so that it is ready for testing via Complement
 FROM matrixdotorg/synapse:workers
 
-# Tell Complement that we are using its custom CA
-# TODO: This doesn't seem to actually enable COMPLEMENT_CA...
-ENV COMPLEMENT_CA=true
-
 # Download a caddy server to stand in front of nginx and terminate TLS using Complement's
 # custom CA.
 # We include this near the top of the file in order to cache the result.

--- a/dockerfiles/SynapseWorkers.Dockerfile
+++ b/dockerfiles/SynapseWorkers.Dockerfile
@@ -25,9 +25,6 @@ RUN pg_ctlcluster 11 main start &&  su postgres -c "echo \
 # and the disabling of rate-limiting
 COPY synapse/workers-shared.yaml /conf/workers/shared.yaml
 
-# Generate a signing key
-RUN generate_signing_key.py -o /conf/server.signing.key
-
 WORKDIR /root
 
 # Copy the caddy config

--- a/dockerfiles/SynapseWorkers.Dockerfile
+++ b/dockerfiles/SynapseWorkers.Dockerfile
@@ -1,0 +1,64 @@
+# This dockerfile builds on top of Dockerfile-worker and includes a built-in postgres instance
+# as well as sets up the homeserver so that it is ready for testing via Complement
+FROM matrixdotorg/synapse:workers
+
+# Tell Complement that we are using its custom CA
+ENV COMPLEMENT_CA=true
+
+# Install postgresql
+RUN apt-get update
+RUN apt-get install -y postgresql
+
+# Configure a user and create a database for Synapse
+RUN pg_ctlcluster 11 main start &&  su postgres -c "echo \
+ \"ALTER USER postgres PASSWORD 'somesecret'; \
+ CREATE DATABASE synapse \
+  ENCODING 'UTF8' \
+  LC_COLLATE='C' \
+  LC_CTYPE='C' \
+  template=template0;\" | psql" && pg_ctlcluster 11 main stop
+
+# Modify the shared homeserver config with postgres support, certificate setup
+# and the disabling of rate-limiting
+COPY synapse/workers-shared.yaml /conf/workers/shared.yaml
+
+# Set up TLS certificates using the custom CA
+COPY keys/* /ca/
+
+# SSL key for the server (can't make the cert until we know the server name)
+RUN openssl genrsa -out /conf/server.tls.key 2048
+
+# Generate a signing key
+RUN generate_signing_key.py -o /conf/server.signing.key
+
+WORKDIR /root
+
+# Download a caddy server to stand in front of nginx and terminate TLS using Complement's
+# custom CA
+RUN curl -OL "https://github.com/caddyserver/caddy/releases/download/v2.3.0/caddy_2.3.0_linux_amd64.tar.gz" && \
+  tar xzf caddy_2.3.0_linux_amd64.tar.gz && rm caddy_2.3.0_linux_amd64.tar.gz
+
+# Copy the caddy config
+COPY synapse/caddy.complement.json /root/caddy.json
+
+# Expose caddy's listener ports
+EXPOSE 8008 8448
+
+ENTRYPOINT \
+  # Replace the server name in the caddy config
+  sed -i "s/{{ server_name }}/${SERVER_NAME}/g" /root/caddy.json && \
+  # Start postgres
+  pg_ctlcluster 11 main start > /dev/null 2>&1 && \
+  # Start caddy
+  /root/caddy start --config /root/caddy.json > /dev/null 2>&1 && \
+  # Set the server name of the homeserver
+  SYNAPSE_SERVER_NAME=${SERVER_NAME} \
+  # No need to report stats here
+  SYNAPSE_REPORT_STATS=no \
+  # Set postgres authentication details which will be placed in the homeserver config file
+  POSTGRES_PASSWORD=somesecret POSTGRES_USER=postgres POSTGRES_HOST=localhost \
+  # Use all available workers
+  SYNAPSE_WORKERS=* \
+  # The script that write the necessary config files and starts supervisord, which in turn
+  # starts everything else
+  /configure_workers_and_start.py

--- a/dockerfiles/SynapseWorkers.Dockerfile
+++ b/dockerfiles/SynapseWorkers.Dockerfile
@@ -3,6 +3,7 @@
 FROM matrixdotorg/synapse:workers
 
 # Tell Complement that we are using its custom CA
+# TODO: This doesn't seem to actually enable COMPLEMENT_CA...
 ENV COMPLEMENT_CA=true
 
 # Download a caddy server to stand in front of nginx and terminate TLS using Complement's
@@ -52,8 +53,12 @@ ENTRYPOINT \
   SYNAPSE_REPORT_STATS=no \
   # Set postgres authentication details which will be placed in the homeserver config file
   POSTGRES_PASSWORD=somesecret POSTGRES_USER=postgres POSTGRES_HOST=localhost \
-  # Use all available workers
-  SYNAPSE_WORKERS=* \
-  # The script that write the necessary config files and starts supervisord, which in turn
+  # Note: This list currently includes all worker types other than federation_sender, as
+  # Synapse fails to send federation transactions with it enabled.
+  # https://github.com/matrix-org/synapse/issues/9192
+  SYNAPSE_WORKERS=pusher,user_dir,media_repository,appservice,synchrotron,federation_reader,federation_inbound \
+  # To use all available workers:
+  #SYNAPSE_WORKERS=* \
+  # Run the script that writes the necessary config files and starts supervisord, which in turn
   # starts everything else
   /configure_workers_and_start.py

--- a/dockerfiles/synapse/caddy.complement.json
+++ b/dockerfiles/synapse/caddy.complement.json
@@ -25,7 +25,7 @@
                             "handler": "reverse_proxy",
                             "upstreams": [
                               {
-                                "dial": "localhost:8080"
+                                "dial": "localhost:8008"
                               }
                             ]
                           }

--- a/dockerfiles/synapse/caddy.complement.json
+++ b/dockerfiles/synapse/caddy.complement.json
@@ -1,0 +1,76 @@
+{
+    "apps": {
+      "http": {
+        "servers": {
+          "srv0": {
+            "listen": [
+              ":8448"
+            ],
+            "routes": [
+              {
+                "match": [
+                  {
+                    "host": [
+                      "{{ server_name }}"
+                    ]
+                  }
+                ],
+                "handle": [
+                  {
+                    "handler": "subroute",
+                    "routes": [
+                      {
+                        "handle": [
+                          {
+                            "handler": "reverse_proxy",
+                            "upstreams": [
+                              {
+                                "dial": "localhost:8080"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "terminal": true
+              }
+            ]
+          }
+        }
+      },
+      "tls": {
+        "automation": {
+          "policies": [
+            {
+              "subjects": [
+                "{{ server_name }}"
+              ],
+              "issuers": [
+                {
+                  "module": "internal"
+                }
+              ],
+              "on_demand": true
+            }
+          ]
+        }
+      },
+      "pki": {
+        "certificate_authorities": {
+          "local": {
+            "name": "Complement CA",
+            "root": {
+              "certificate": "/ca/ca.crt",
+              "private_key": "/ca/ca.key"
+            },
+            "intermediate": {
+              "certificate": "/ca/ca.crt",
+              "private_key": "/ca/ca.key"
+            }
+          }
+        }
+      }
+    }
+  }

--- a/dockerfiles/synapse/workers-shared.yaml
+++ b/dockerfiles/synapse/workers-shared.yaml
@@ -1,0 +1,59 @@
+## Server ##
+report_stats: False
+trusted_key_servers: []
+enable_registration: true
+
+## Federation ##
+
+# disable verification of federation certificates
+#
+# TODO: Figure out why this is still needed even though we are making use of the custom CA
+federation_verify_certificates: false
+
+# trust certs signed by Complement's CA
+federation_custom_ca_list:
+- /ca/ca.crt
+
+# unblacklist RFC1918 addresses
+federation_ip_range_blacklist: []
+
+# Disable server rate-limiting
+rc_federation:
+  window_size: 1000
+  sleep_limit: 10
+  sleep_delay: 500
+  reject_limit: 99999
+  concurrent: 3
+
+rc_message:
+  per_second: 9999
+  burst_count: 9999
+
+rc_registration:
+  per_second: 9999
+  burst_count: 9999
+
+rc_login:
+  address:
+    per_second: 9999
+    burst_count: 9999
+  account:
+    per_second: 9999
+    burst_count: 9999
+  failed_attempts:
+    per_second: 9999
+    burst_count: 9999
+
+rc_admin_redaction:
+  per_second: 9999
+  burst_count: 9999
+
+rc_joins:
+  local:
+    per_second: 9999
+    burst_count: 9999
+  remote:
+    per_second: 9999
+    burst_count: 9999
+
+federation_rr_transactions_per_room_per_second: 9999


### PR DESCRIPTION
This PR adds a new Dockerfile containing the configuration for a Synapse running in worker mode. Some additional files were required to support the image.

1. A caddy binary needed to be placed in the container for termination TLS requests on the federation port (thanks to Conduit for the idea!). The included file is a Caddy config json file.
2. A shared config file to hand to each Synapse worker was necessary. This file is subtley different from [dockerfiles/synapse/homeserver.yaml](https://github.com/matrix-org/complement/blob/master/dockerfiles/synapse/homeserver.yaml), though it may be nice to have both files be derived from a shared file in the future.

The intention of this is to add testing of Synapse in worker mode to Complement's CI. It is paired with https://github.com/matrix-org/synapse/pull/9162.