### PR TITLE
Fixes to Complement's Federation Certificate

### DIFF
--- a/internal/federation/server.go
+++ b/internal/federation/server.go
@@ -281,7 +281,8 @@ func GetOrCreateCaCert() (*x509.Certificate, *rsa.PrivateKey, error) {
 		}
 	}
 
-	certificateDuration := time.Hour * 5
+	// valid for 10 years
+	certificateDuration := time.Hour * 24 * 365 * 10
 	priv, err := rsa.GenerateKey(rand.Reader, 4096)
 	if err != nil {
 		return nil, nil, err

--- a/internal/federation/server.go
+++ b/internal/federation/server.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/json"
 	"encoding/pem"
 	"errors"
@@ -300,6 +301,14 @@ func GetOrCreateCaCert() (*x509.Certificate, *rsa.PrivateKey, error) {
 		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature | x509.KeyUsageCRLSign,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		BasicConstraintsValid: true,
+		Subject: pkix.Name{
+			Organization:  []string{"matrix.org"},
+			Country:       []string{"GB"},
+			Province:      []string{"London"},
+			Locality:      []string{"London"},
+			StreetAddress: []string{"123 Street"},
+			PostalCode:    []string{"12345"},
+		},
 	}
 
 	derBytes, err := x509.CreateCertificate(rand.Reader, &caCert, &caCert, &priv.PublicKey, priv)
@@ -360,6 +369,14 @@ func federationServer(name string, h http.Handler) (*http.Server, string, string
 		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		BasicConstraintsValid: true,
+		Subject: pkix.Name{
+			Organization:  []string{"matrix.org"},
+			Country:       []string{"GB"},
+			Province:      []string{"London"},
+			Locality:      []string{"London"},
+			StreetAddress: []string{"123 Street"},
+			PostalCode:    []string{"12345"},
+		},
 	}
 	host := docker.HostnameRunningComplement
 	if ip := net.ParseIP(host); ip != nil {


### PR DESCRIPTION
This PR contains two fixes, separated by commit.

1. Add Subject information to Complement's CA and ephemeral certificates. Federation clients will not accept a certificate if they are unable to get the details of the CA that issued them. It looks for this information in the longterm CA cert.
2. The longterm cert would expire after 5 hours. It is not regenerated if it already exists. Federation clients will not accept expired certificates. I've updated the expiration to 10 years.

Because the longterm CA certificate is not regenerated if it already exists, people will need to clear the old certificates (located in `/tests/ca/`) to generate a new certificate.

Note: I think for 1. information is only required for the CA cert, but I've added the same to the ephemeral cert just in case.