### PR TITLE
Enable experimental knocking support in Synapse

### DIFF
--- a/dockerfiles/synapse/homeserver.yaml
+++ b/dockerfiles/synapse/homeserver.yaml
@@ -91,3 +91,9 @@ rc_joins:
     burst_count: 9999
 
 federation_rr_transactions_per_room_per_second: 9999
+
+## Experimental Features ##
+
+experimental:
+  # Enable knocking support
+  msc2403_enabled: true

--- a/dockerfiles/synapse/workers-shared.yaml
+++ b/dockerfiles/synapse/workers-shared.yaml
@@ -57,3 +57,9 @@ rc_joins:
     burst_count: 9999
 
 federation_rr_transactions_per_room_per_second: 9999
+
+## Experimental Features ##
+
+experimental:
+  # Enable knocking support
+  msc2403_enabled: true


### PR DESCRIPTION
This PR enables experimental support for knocking in Synapse. This is to allow Synapse to test itself against the [knocking tests](https://github.com/matrix-org/complement/blob/master/tests/msc2403_test.go).