### PR TITLE
Fix lint script to run on macOS

### DIFF
--- a/build/scripts/find-lint.sh
+++ b/build/scripts/find-lint.sh
@@ -19,7 +19,10 @@ if [ ${1:-""} = "fast" ]
 then args="--fast"
 fi
 
-if [[ -v COMPLEMENT_LINT_CONCURRENCY ]]; then
+if [ -z ${COMPLEMENT_LINT_CONCURRENCY+x} ]; then
+  # COMPLEMENT_LINT_CONCURRENCY was not set
+  :
+else
   args="${args} --concurrency $COMPLEMENT_LINT_CONCURRENCY"
 fi
 


### PR DESCRIPTION
Fix lint script to run on macOS

See

 - `-v` only supported in newer bash 4.2 or above: https://unix.stackexchange.com/a/212192/52320
 - How to test for environement variable existence, https://stackoverflow.com/a/13864829/796832
 - No-op `:`: https://unix.stackexchange.com/a/287867/52320



Before: 
```sh
$ bash --version
GNU bash, version 3.2.57(1)-release (x86_64-apple-darwin20)
Copyright (C) 2007 Free Software Foundation, Inc.

$ ./build/scripts/find-lint.sh
./build/scripts/find-lint.sh: line 22: conditional binary operator expected

$ COMPLEMENT_LINT_CONCURRENCY=1 ./build/scripts/find-lint.sh
./build/scripts/find-lint.sh: line 22: conditional binary operator expected
```

After:
```
$ ./build/scripts/find-lint.sh
No issues found :)

$ COMPLEMENT_LINT_CONCURRENCY=1 ./build/scripts/find-lint.sh
No issues found :)
```



---

Alternative if we want `COMPLEMENT_LINT_CONCURRENCY` to be required:

<details>

<summary>...</summary>

```
if [[ ${COMPLEMENT_LINT_CONCURRENCY} ]]; then
```

After:
```
$ ./build/scripts/find-lint.sh
./build/scripts/find-lint.sh: line 22: conditional binary operator expected

$ COMPLEMENT_LINT_CONCURRENCY=1 ./build/scripts/find-lint.sh
No issues found :)
```

</details>


