### PR TITLE
Add application service support to blueprints

### DIFF
--- a/build/scripts/find-lint.sh
+++ b/build/scripts/find-lint.sh
@@ -19,10 +19,7 @@ if [ ${1:-""} = "fast" ]
 then args="--fast"
 fi
 
-if [ -z ${COMPLEMENT_LINT_CONCURRENCY+x} ]; then
-  # COMPLEMENT_LINT_CONCURRENCY was not set
-  :
-else
+if [[ -v COMPLEMENT_LINT_CONCURRENCY ]]; then
   args="${args} --concurrency $COMPLEMENT_LINT_CONCURRENCY"
 fi
 

--- a/build/scripts/find-lint.sh
+++ b/build/scripts/find-lint.sh
@@ -19,7 +19,10 @@ if [ ${1:-""} = "fast" ]
 then args="--fast"
 fi
 
-if [[ -v COMPLEMENT_LINT_CONCURRENCY ]]; then
+if [ -z ${COMPLEMENT_LINT_CONCURRENCY+x} ]; then
+  # COMPLEMENT_LINT_CONCURRENCY was not set
+  :
+else
   args="${args} --concurrency $COMPLEMENT_LINT_CONCURRENCY"
 fi
 

--- a/dockerfiles/synapse/homeserver.yaml
+++ b/dockerfiles/synapse/homeserver.yaml
@@ -92,6 +92,13 @@ rc_joins:
 
 federation_rr_transactions_per_room_per_second: 9999
 
+## API Configuration ##
+
+# A list of application service config files to use
+#
+app_service_config_files:
+AS_REGISTRATION_FILES  
+
 ## Experimental Features ##
 
 experimental_features:

--- a/dockerfiles/synapse/start.sh
+++ b/dockerfiles/synapse/start.sh
@@ -1,8 +1,21 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
 sed -i "s/SERVER_NAME/${SERVER_NAME}/g" /conf/homeserver.yaml
+
+# Add the application service registration files to the homeserver.yaml config
+for filename in /appservices/*.yaml; do
+  [ -f "$filename" ] || break
+
+  as_id=$(basename "$filename" .yaml)
+
+  # Insert the path to the registration file and the AS_REGISTRATION_FILES marker after 
+  # so we can add the next application service in the next iteration of this for loop
+  sed -i "s/AS_REGISTRATION_FILES/  - \/appservices\/${as_id}.yaml\nAS_REGISTRATION_FILES/g" /conf/homeserver.yaml
+done
+# Remove the AS_REGISTRATION_FILES entry
+sed -i "s/AS_REGISTRATION_FILES//g" /conf/homeserver.yaml
 
 # generate an ssl cert for the server, signed by our dummy CA
 openssl req -new -key /conf/server.tls.key -out /conf/server.tls.csr \

--- a/internal/b/blueprints.go
+++ b/internal/b/blueprints.go
@@ -20,8 +20,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-
-	"github.com/sirupsen/logrus"
 )
 
 // KnownBlueprints lists static blueprints
@@ -132,10 +130,6 @@ func Validate(bp Blueprint) (Blueprint, error) {
 			}
 		}
 	}
-
-	logrus.WithFields(logrus.Fields{
-		"bp": bp.Homeservers[0].ApplicationServices,
-	}).Error("after modfiying bp")
 
 	return bp, nil
 }

--- a/internal/b/blueprints.go
+++ b/internal/b/blueprints.go
@@ -83,12 +83,10 @@ type ApplicationService struct {
 }
 
 type Event struct {
-	Type           string
-	Sender         string
-	OriginServerTS uint64
-	StateKey       *string
-	PrevEvents     []string
-	Content        map[string]interface{}
+	Type     string
+	Sender   string
+	StateKey *string
+	Content  map[string]interface{}
 	// This field is ignored in blueprints as clients are unable to set it. Used with federation.Server
 	Unsigned map[string]interface{}
 }

--- a/internal/b/hs_with_application_service.go
+++ b/internal/b/hs_with_application_service.go
@@ -1,0 +1,25 @@
+package b
+
+// BlueprintHSWithApplicationService who has an application service to interact with
+var BlueprintHSWithApplicationService = MustValidate(Blueprint{
+	Name: "alice",
+	Homeservers: []Homeserver{
+		{
+			Name: "hs1",
+			Users: []User{
+				{
+					Localpart:   "@alice",
+					DisplayName: "Alice",
+				},
+			},
+			ApplicationServices: []ApplicationService{
+				{
+					ID:              "my_as_id",
+					URL:             "http://localhost:9000",
+					SenderLocalpart: "the-bridge-user",
+					RateLimited:     false,
+				},
+			},
+		},
+	},
+})

--- a/internal/docker/builder.go
+++ b/internal/docker/builder.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"path"
 	"runtime"
@@ -39,7 +40,6 @@ import (
 	"github.com/docker/go-connections/nat"
 
 	"github.com/matrix-org/complement/internal/b"
-	internalClient "github.com/matrix-org/complement/internal/client"
 	"github.com/matrix-org/complement/internal/config"
 	"github.com/matrix-org/complement/internal/instruction"
 )
@@ -517,7 +517,7 @@ func deployImage(
 		var buf bytes.Buffer
 		tw := tar.NewWriter(&buf)
 		err = tw.WriteHeader(&tar.Header{
-			Name: fmt.Sprintf("/appservices/%s.yaml", internalClient.GjsonEscape(asID)),
+			Name: fmt.Sprintf("/appservices/%s.yaml", url.PathEscape(asID)),
 			Mode: 0777,
 			Size: int64(len(registration)),
 		})

--- a/internal/docker/builder.go
+++ b/internal/docker/builder.go
@@ -14,6 +14,8 @@
 package docker
 
 import (
+	"archive/tar"
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -31,6 +33,7 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/api/types/volume"
 	client "github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/docker/go-connections/nat"
@@ -276,6 +279,12 @@ func (d *Builder) construct(bprint b.Blueprint) (errs []error) {
 		}
 		labels := labelsForTokens(runner.AccessTokens(res.homeserver.Name))
 
+		// Combine the labels for tokens and application services
+		asLabels := labelsForApplicationServices(res.homeserver)
+		for k, v := range asLabels {
+			labels[k] = v
+		}
+
 		// commit the container
 		commit, err := d.Docker.ContainerCommit(context.Background(), res.containerID, types.ContainerCommitOptions{
 			Author:    "Complement",
@@ -300,7 +309,7 @@ func (d *Builder) construct(bprint b.Blueprint) (errs []error) {
 func (d *Builder) constructHomeserver(blueprintName string, runner *instruction.Runner, hs b.Homeserver, networkID string) result {
 	contextStr := fmt.Sprintf("%s.%s", blueprintName, hs.Name)
 	d.log("%s : constructing homeserver...\n", contextStr)
-	dep, err := d.deployBaseImage(blueprintName, hs.Name, contextStr, networkID)
+	dep, err := d.deployBaseImage(blueprintName, hs, contextStr, networkID)
 	if err != nil {
 		log.Printf("%s : failed to deployBaseImage: %s\n", contextStr, err)
 		containerID := ""
@@ -328,17 +337,19 @@ func (d *Builder) constructHomeserver(blueprintName string, runner *instruction.
 }
 
 // deployBaseImage runs the base image and returns the baseURL, containerID or an error.
-func (d *Builder) deployBaseImage(blueprintName, hsName, contextStr, networkID string) (*HomeserverDeployment, error) {
+func (d *Builder) deployBaseImage(blueprintName string, hs b.Homeserver, contextStr, networkID string) (*HomeserverDeployment, error) {
+	asIDToRegistrationMap := asIDToRegistrationFromLabels(labelsForApplicationServices(hs))
+
 	return deployImage(
-		d.Docker, d.BaseImage, d.CSAPIPort, fmt.Sprintf("complement_%s", contextStr), blueprintName, hsName, contextStr,
+		d.Docker, d.BaseImage, d.CSAPIPort, fmt.Sprintf("complement_%s", contextStr), blueprintName, hs.Name, asIDToRegistrationMap, contextStr,
 		networkID, d.config.VersionCheckIterations,
 	)
 }
 
 // getCaVolume returns the correct mounts and volumes for providing a CA to homeserver containers.
-func getCaVolume(docker *client.Client, ctx context.Context) (map[string]struct{}, []mount.Mount, error) {
-	var caVolume map[string]struct{}
-	var caMount []mount.Mount
+func getCaVolume(docker *client.Client, ctx context.Context) (string, mount.Mount, error) {
+	var caVolume string
+	var caMount mount.Mount
 
 	if os.Getenv("CI") == "true" {
 		// When in CI, Complement itself is a container with the CA volume mounted at /ca.
@@ -349,16 +360,16 @@ func getCaVolume(docker *client.Client, ctx context.Context) (map[string]struct{
 		// /proc/1/cpuset should be /docker/<containerId>
 		cpuset, err := ioutil.ReadFile("/proc/1/cpuset")
 		if err != nil {
-			return nil, nil, err
+			return caVolume, caMount, err
 		}
 		if !strings.Contains(string(cpuset), "docker") {
-			return nil, nil, errors.New("Could not identify container ID using /proc/1/cpuset")
+			return caVolume, caMount, errors.New("Could not identify container ID using /proc/1/cpuset")
 		}
 		cpusetList := strings.Split(strings.TrimSpace(string(cpuset)), "/")
 		containerId := cpusetList[len(cpusetList)-1]
 		container, err := docker.ContainerInspect(ctx, containerId)
 		if err != nil {
-			return nil, nil, err
+			return caVolume, caMount, err
 		}
 		// Get the volume that matches the destination in our complement container
 		var volumeName string
@@ -371,17 +382,13 @@ func getCaVolume(docker *client.Client, ctx context.Context) (map[string]struct{
 			// We did not find a volume. This container might be created without a volume,
 			// or CI=true is passed but we are not running in a container.
 			// todo: log that we do not provide a CA volume mount?
-			return nil, nil, nil
+			return caVolume, caMount, nil
 		} else {
-			caVolume = map[string]struct{}{
-				"/ca": {},
-			}
-			caMount = []mount.Mount{
-				{
-					Type:   mount.TypeVolume,
-					Source: volumeName,
-					Target: "/ca",
-				},
+			caVolume = "/ca"
+			caMount = mount.Mount{
+				Type:   mount.TypeVolume,
+				Source: volumeName,
+				Target: "/ca",
 			}
 		}
 	} else {
@@ -389,33 +396,61 @@ func getCaVolume(docker *client.Client, ctx context.Context) (map[string]struct{
 		// We bind mount this directory to all homeserver containers.
 		cwd, err := os.Getwd()
 		if err != nil {
-			return nil, nil, err
+			return caVolume, caMount, err
 		}
 		caCertificateDirHost := path.Join(cwd, "ca")
 		if _, err := os.Stat(caCertificateDirHost); os.IsNotExist(err) {
 			err = os.Mkdir(caCertificateDirHost, 0770)
 			if err != nil {
-				return nil, nil, err
+				return caVolume, caMount, err
 			}
 		}
-		caMount = []mount.Mount{
-			{
-				Type:   mount.TypeBind,
-				Source: path.Join(cwd, "ca"),
-				Target: "/ca",
-			},
+
+		caMount = mount.Mount{
+			Type:   mount.TypeBind,
+			Source: path.Join(cwd, "ca"),
+			Target: "/ca",
 		}
 	}
 	return caVolume, caMount, nil
 }
 
+func getAppServiceVolume(docker *client.Client, ctx context.Context) (string, mount.Mount, error) {
+	asVolume, err := docker.VolumeCreate(context.Background(), volume.VolumesCreateBody{
+		//Driver:     "overlay2",
+		DriverOpts: map[string]string{},
+		Name:       "appservices",
+	})
+
+	asMount := mount.Mount{
+		Type:   mount.TypeVolume,
+		Source: asVolume.Name,
+		Target: "/appservices",
+	}
+
+	return "/appservices", asMount, err
+}
+
+func generateASRegistrationYaml(as b.ApplicationService) string {
+	return fmt.Sprintf("id: %s\n", as.ID) +
+		fmt.Sprintf("hs_token: %s\n", as.HSToken) +
+		fmt.Sprintf("as_token: %s\n", as.ASToken) +
+		fmt.Sprintf("url: '%s'\n", as.URL) +
+		fmt.Sprintf("sender_localpart: %s\n", as.SenderLocalpart) +
+		fmt.Sprintf("rate_limited: %v\n", as.RateLimited) +
+		"namespaces:\n" +
+		"  users: []\n" +
+		"  rooms: []\n" +
+		"  aliases: []\n"
+}
+
 func deployImage(
-	docker *client.Client, imageID string, csPort int, containerName, blueprintName, hsName, contextStr, networkID string, versionCheckIterations int,
+	docker *client.Client, imageID string, csPort int, containerName, blueprintName, hsName string, asIDToRegistrationMap map[string]string, contextStr, networkID string, versionCheckIterations int,
 ) (*HomeserverDeployment, error) {
 	ctx := context.Background()
 	var extraHosts []string
-	var caVolume map[string]struct{}
-	var caMount []mount.Mount
+	var volumes = make(map[string]struct{})
+	var mounts []mount.Mount
 	var err error
 
 	if runtime.GOOS == "linux" {
@@ -426,26 +461,43 @@ func deployImage(
 	}
 
 	if os.Getenv("COMPLEMENT_CA") == "true" {
+		var caVolume string
+		var caMount mount.Mount
 		caVolume, caMount, err = getCaVolume(docker, ctx)
 		if err != nil {
 			return nil, err
 		}
+
+		volumes[caVolume] = struct{}{}
+		mounts = append(mounts, caMount)
+	}
+
+	asVolume, asMount, err := getAppServiceVolume(docker, ctx)
+	if err != nil {
+		return nil, err
+	}
+	volumes[asVolume] = struct{}{}
+	mounts = append(mounts, asMount)
+
+	env := []string{
+		"SERVER_NAME=" + hsName,
+		"COMPLEMENT_CA=" + os.Getenv("COMPLEMENT_CA"),
 	}
 
 	body, err := docker.ContainerCreate(ctx, &container.Config{
 		Image: imageID,
-		Env:   []string{"SERVER_NAME=" + hsName, "COMPLEMENT_CA=" + os.Getenv("COMPLEMENT_CA")},
+		Env:   env,
 		//Cmd:   d.ImageArgs,
 		Labels: map[string]string{
 			complementLabel:        contextStr,
 			"complement_blueprint": blueprintName,
 			"complement_hs_name":   hsName,
 		},
-		Volumes: caVolume,
+		Volumes: volumes,
 	}, &container.HostConfig{
 		PublishAllPorts: true,
 		ExtraHosts:      extraHosts,
-		Mounts:          caMount,
+		Mounts:          mounts,
 	}, &network.NetworkingConfig{
 		EndpointsConfig: map[string]*network.EndpointSettings{
 			hsName: {
@@ -457,7 +509,32 @@ func deployImage(
 	if err != nil {
 		return nil, err
 	}
+
 	containerID := body.ID
+
+	// Create the application service files
+	for asID, registration := range asIDToRegistrationMap {
+		var buf bytes.Buffer
+		tw := tar.NewWriter(&buf)
+		err = tw.WriteHeader(&tar.Header{
+			Name: fmt.Sprintf("/appservices/%s.yaml", asID),
+			Mode: 0777,
+			Size: int64(len(registration)),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("Failed to copy regstration to container: %v", err)
+		}
+		tw.Write([]byte(registration))
+		tw.Close()
+
+		err = docker.CopyToContainer(context.Background(), containerID, "/", &buf, types.CopyToContainerOptions{
+			AllowOverwriteDirWithFile: false,
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	err = docker.ContainerStart(ctx, containerID, types.ContainerStartOptions{})
 	if err != nil {
 		return nil, err
@@ -488,11 +565,13 @@ func deployImage(
 		lastErr = nil
 		break
 	}
+
 	d := &HomeserverDeployment{
-		BaseURL:      baseURL,
-		FedBaseURL:   fedBaseURL,
-		ContainerID:  containerID,
-		AccessTokens: tokensFromLabels(inspect.Config.Labels),
+		BaseURL:             baseURL,
+		FedBaseURL:          fedBaseURL,
+		ContainerID:         containerID,
+		AccessTokens:        tokensFromLabels(inspect.Config.Labels),
+		ApplicationServices: asIDToRegistrationFromLabels(inspect.Config.Labels),
 	}
 	if lastErr != nil {
 		return d, fmt.Errorf("%s: failed to check server is up. %w", contextStr, lastErr)
@@ -562,6 +641,28 @@ func labelsForTokens(userIDToToken map[string]string) map[string]string {
 	// collect and store access tokens as labels 'access_token_$userid: $token'
 	for k, v := range userIDToToken {
 		labels["access_token_"+k] = v
+	}
+	return labels
+}
+
+func asIDToRegistrationFromLabels(labels map[string]string) map[string]string {
+	asMap := make(map[string]string)
+	for k, v := range labels {
+		if strings.HasPrefix(k, "application_service_") {
+			asMap[strings.TrimPrefix(k, "application_service_")] = v
+		}
+	}
+	return asMap
+}
+
+func labelsForApplicationServices(hs b.Homeserver) map[string]string {
+	labels := make(map[string]string)
+	// collect and store app service registrations as labels 'application_service_$as_id: $registration'
+	// collect and store app service access tokens as labels 'access_token_$sender_localpart: $as_token'
+	for _, as := range hs.ApplicationServices {
+		labels["application_service_"+as.ID] = generateASRegistrationYaml(as)
+
+		labels["access_token_@"+as.SenderLocalpart+":"+hs.Name] = as.ASToken
 	}
 	return labels
 }

--- a/internal/docker/builder.go
+++ b/internal/docker/builder.go
@@ -415,6 +415,8 @@ func getCaVolume(docker *client.Client, ctx context.Context) (string, mount.Moun
 	return caVolume, caMount, nil
 }
 
+// getAppServiceVolume returns the correct mounts and volumes for providing the `/appservice` directory to homeserver containers
+// containing application service registration files to be used by the homeserver
 func getAppServiceVolume(docker *client.Client, ctx context.Context) (string, mount.Mount, error) {
 	asVolume, err := docker.VolumeCreate(context.Background(), volume.VolumesCreateBody{
 		//Driver:     "overlay2",

--- a/internal/docker/deployer.go
+++ b/internal/docker/deployer.go
@@ -81,10 +81,12 @@ func (d *Deployer) Deploy(ctx context.Context, blueprintName string) (*Deploymen
 		d.Counter++
 		contextStr := img.Labels["complement_context"]
 		hsName := img.Labels["complement_hs_name"]
+		asIDToRegistrationMap := asIDToRegistrationFromLabels(img.Labels)
+
 		// TODO: Make CSAPI port configurable
 		deployment, err := deployImage(
 			d.Docker, img.ID, 8008, fmt.Sprintf("complement_%s_%s_%d", d.Namespace, contextStr, d.Counter),
-			blueprintName, hsName, contextStr, networkID, d.config.VersionCheckIterations)
+			blueprintName, hsName, asIDToRegistrationMap, contextStr, networkID, d.config.VersionCheckIterations)
 		if err != nil {
 			if deployment != nil && deployment.ContainerID != "" {
 				// print logs to help debug

--- a/internal/docker/deployment.go
+++ b/internal/docker/deployment.go
@@ -31,12 +31,7 @@ type HomeserverDeployment struct {
 // will print container logs before killing the container.
 func (d *Deployment) Destroy(t *testing.T) {
 	t.Helper()
-	d.Deployer.Destroy(
-		d,
-		// TODO: Revert this back to `t.Failed()`.
-		// I did this so I can always see the homersever logs regardless of outcome
-		true,
-	)
+	d.Deployer.Destroy(d, t.Failed())
 }
 
 // Client returns a CSAPI client targeting the given hsName, using the access token for the given userID.

--- a/internal/docker/deployment.go
+++ b/internal/docker/deployment.go
@@ -20,17 +20,23 @@ type Deployment struct {
 
 // HomeserverDeployment represents a running homeserver in a container.
 type HomeserverDeployment struct {
-	BaseURL      string            // e.g http://localhost:38646
-	FedBaseURL   string            // e.g https://localhost:48373
-	ContainerID  string            // e.g 10de45efba
-	AccessTokens map[string]string // e.g { "@alice:hs1": "myAcc3ssT0ken" }
+	BaseURL             string            // e.g http://localhost:38646
+	FedBaseURL          string            // e.g https://localhost:48373
+	ContainerID         string            // e.g 10de45efba
+	AccessTokens        map[string]string // e.g { "@alice:hs1": "myAcc3ssT0ken" }
+	ApplicationServices map[string]string // e.g { "my-as-id": "id: xxx\nas_token: xxx ..."} }
 }
 
 // Destroy the entire deployment. Destroys all running containers. If `printServerLogs` is true,
 // will print container logs before killing the container.
 func (d *Deployment) Destroy(t *testing.T) {
 	t.Helper()
-	d.Deployer.Destroy(d, t.Failed())
+	d.Deployer.Destroy(
+		d,
+		// TODO: Revert this back to `t.Failed()`.
+		// I did this so I can always see the homersever logs regardless of outcome
+		true,
+	)
 }
 
 // Client returns a CSAPI client targeting the given hsName, using the access token for the given userID.


### PR DESCRIPTION
Add application service support to blueprints

 - Only supports defining a basic app service
 - In tests, you can use the app service `as_token` to interact with the homserver API
 - Does not support defining the `namespaces` part of the app service registration config
 - Does not support a mocked/stubbed actual app service that the homeserver calls back to at the `URL`

Split out from https://github.com/matrix-org/complement/pull/68

---

 - https://matrix.org/docs/guides/application-services
 - https://matrix.org/docs/spec/application_service/r0.1.2