### PR TITLE
Update MSC2403 test to allow knock->knock transitions

### DIFF
--- a/tests/msc2403_test.go
+++ b/tests/msc2403_test.go
@@ -114,8 +114,8 @@ func knockingBetweenTwoUsersTest(t *testing.T, roomID string, inRoomUser, knocki
 		knockOnRoomSynced(t, knockingUser, roomID, testKnockReason, []string{"hs1"})
 	})
 
-	t.Run("A user that has already knocked cannot immediately knock again on the same room", func(t *testing.T) {
-		knockOnRoomWithStatus(t, knockingUser, roomID, "I really like knock knock jokes", []string{"hs1"}, 403)
+	t.Run("A user that has already knocked is allowed to knock again on the same room", func(t *testing.T) {
+		knockOnRoomSynced(t, knockingUser, roomID, "I really like knock knock jokes", []string{"hs1"})
 	})
 
 	t.Run("Users in the room see a user's membership update when they knock", func(t *testing.T) {


### PR DESCRIPTION
We've since allowed knock->knock transitions in [MSC2403](https://github.com/matrix-org/matrix-doc/pull/2403/commits/49a72862a93d814219968cff814ff63926181645).

The mainline implementation has been [updated](https://github.com/matrix-org/synapse/pull/6739/commits/44b502644bc4e0473e3734349459bebd2cff0e17) as well.