### PR TITLE
Add account snapshot binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+sync_snapshot.json
 complement
 .idea

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ You can install `libolm3` on Debian using something like:
 ```
 echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/complement.list && apt-get update && apt-get install -y libolm3 libolm-dev/buster-backports
 ```
+or on Mac:
+```
+brew install libolm
+```
 
 You can either use your own image, or one of the ones supplied in the [dockerfiles](./dockerfiles) directory.
 

--- a/cmd/account-snapshot/README.md
+++ b/cmd/account-snapshot/README.md
@@ -1,0 +1,38 @@
+### Account Snapshot
+
+This is capable of taking an anonymised snapshot of a Matrix account and then create a blueprint for it. It has several stages:
+ - Perform a full `/sync` request. This is cached in `sync_snapshot.json` for subsequent runs in case something fails.
+ - Redact the `/sync` response. This removes all PII including user IDs, messages, room IDs, event IDs, attachments, avatars, display names, etc.
+   An intermediate `Snapshot` struct is the returned.
+   A whitelist approach is used, where only specific event types are persisted. This guarantees that non-spec state events which could be revealing
+   are ignored. However, we apply a blacklist approach for spec-defined event types. This means it is possible that non-spec fields may leak through
+   into the subsequent stages. A reasonably easy way to check to see how well the redaction process worked is to:
+   ```
+   grep -Ei "the|matrix|and|mxc" blueprint.json | sort | uniq
+   ```
+   As this will flag `mxc://` URIs as well as hopefully any textual messages.
+ - Map the `Snapshot` to a `Blueprint` which is capable to be run using `./cmd/homerunner`. The `Blueprint` consists of all the users in the `/sync`
+   response, all joined rooms, and the most recent 50 messages.
+
+
+To try it out:
+```
+./account-snapshot -user @alice:matrix.org -token MDA.... > blueprint.json
+```
+Then run `./homerunner` and do:
+```
+curl -XPOST -d "@blueprint.json" "http://localhost:54321/create"
+```
+
+#### Limitations
+
+Currently, the `/sync` -> snapshot does not:
+ - Handle push rules in account data
+ - Handle invites
+ - Handle third party invites
+
+Currently, the snapshot -> blueprint does not:
+ - Handle `m.reaction` or `m.room.redaction` events - the `/sync` response may not include the events being redacted, so we need to guess/make-up an appropriate
+   event to react to or redact.
+ - Handle `m.room.tombstone` events. This is more a Complement limitation.
+ - Handle `m.room.encrypted` events. Whilst Complement does upload OTKs, it needs to have a field to mark "send this event as E2E" in `b.Event`.

--- a/cmd/account-snapshot/internal/blueprint.go
+++ b/cmd/account-snapshot/internal/blueprint.go
@@ -1,0 +1,177 @@
+package internal
+
+import (
+	"encoding/json"
+	"log"
+
+	"github.com/matrix-org/complement/internal/b"
+	"github.com/tidwall/gjson"
+)
+
+// ConvertToBlueprint converts a /sync snapshot to a Complement blueprint
+func ConvertToBlueprint(s *Snapshot, serverName string) (*b.Blueprint, error) {
+	bp := &b.Blueprint{
+		Name: "snapshot_" + s.UserID,
+	}
+	// TODO: the snapshot has information on servers but we only want 1 server for now
+	hs := b.Homeserver{
+		Name: serverName,
+	}
+	log.Printf("Blueprint: creating users (%d)\n", len(s.Devices))
+	// Create all the users (and devices) in the snapshot
+	for userID, devices := range s.Devices {
+		local, _ := split(userID)
+		for i := range devices {
+			user := b.User{
+				Localpart:   local,
+				DisplayName: local,
+				DeviceID:    &devices[i],
+			}
+			// set up OTKs if this user+device sends E2E messages
+			if devices[i] != NoEncryptedDevice {
+				user.OneTimeKeys = 100
+			}
+			// set DM list if this is the syncing user
+			if userID == s.UserID {
+				user.AccountData = append(user.AccountData, b.AccountData{
+					Type: "m.direct",
+					Value: map[string]interface{}{
+						"content": s.AccountDataDMs,
+					},
+				})
+			}
+			hs.Users = append(hs.Users, user)
+		}
+	}
+	log.Printf("Blueprint: creating rooms (%d)\n", len(s.Rooms))
+	for i := range s.Rooms {
+		room := convertRoom(&s.Rooms[i])
+		if room == nil {
+			log.Printf("  skipping room %v\n", s.Rooms[i].ID)
+			continue
+		}
+		hs.Rooms = append(hs.Rooms, *room)
+	}
+	bp.Homeservers = append(bp.Homeservers, hs)
+
+	return bp, nil
+}
+
+func convertRoom(sr *AnonSnapshotRoom) *b.Room {
+	r := &b.Room{
+		Ref:     sr.ID,
+		Creator: sr.Creator,
+	}
+	// find and set the create content and memberships
+	memberships := map[string][]string{}
+	otherState := []json.RawMessage{}
+	for _, ev := range sr.State {
+		switch gjson.GetBytes(ev, "type").Str {
+		case "m.room.create":
+			var createContent map[string]interface{}
+			if err := json.Unmarshal([]byte(gjson.GetBytes(ev, "content").Raw), &createContent); err != nil {
+				log.Printf("  cannot convert room, cannot unmarshal m.room.create content: %s\n", err)
+				return nil
+			}
+			r.CreateRoom = createContent
+		case "m.room.member":
+			membership := gjson.GetBytes(ev, "content.membership").Str
+			userID := gjson.GetBytes(ev, "state_key").Str
+			memberships[membership] = append(memberships[membership], userID)
+		default:
+			otherState = append(otherState, ev)
+		}
+	}
+	// Make the room publicly joinable then join all the users in the room
+	r.Events = append(r.Events, b.Event{
+		Sender:   sr.Creator,
+		Type:     "m.room.join_rules",
+		StateKey: b.Ptr(""),
+		Content: map[string]interface{}{
+			"join_rule": "public",
+		},
+	})
+	// All joined users should be joined
+	for _, userID := range memberships["join"] {
+		r.Events = append(r.Events, b.Event{
+			Sender:   userID,
+			StateKey: b.Ptr(userID),
+			Type:     "m.room.member",
+			Content: map[string]interface{}{
+				"membership": "join",
+			},
+		})
+	}
+	// All left users should join then immediately leave
+	for _, userID := range memberships["leave"] {
+		r.Events = append(r.Events, b.Event{
+			Sender:   userID,
+			StateKey: b.Ptr(userID),
+			Type:     "m.room.member",
+			Content: map[string]interface{}{
+				"membership": "join",
+			},
+		})
+		r.Events = append(r.Events, b.Event{
+			Sender:   userID,
+			StateKey: b.Ptr(userID),
+			Type:     "m.room.member",
+			Content: map[string]interface{}{
+				"membership": "leave",
+			},
+		})
+	}
+	// All invited users should be invited, we'll just invite them from the first joined user for now
+	for _, userID := range memberships["invite"] {
+		r.Events = append(r.Events, b.Event{
+			Sender:   memberships["join"][0],
+			StateKey: b.Ptr(userID),
+			Type:     "m.room.member",
+			Content: map[string]interface{}{
+				"membership": "invite",
+			},
+		})
+	}
+	// All banned users should be banned, we'll ban them from the first joined user for now
+	for _, userID := range memberships["ban"] {
+		r.Events = append(r.Events, b.Event{
+			Sender:   memberships["join"][0],
+			StateKey: b.Ptr(userID),
+			Type:     "m.room.member",
+			Content: map[string]interface{}{
+				"membership": "ban",
+			},
+		})
+	}
+	// Set all the /sync State (excluding create/member events)
+	for _, ev := range otherState {
+		r.Events = append(r.Events, b.Event{
+			Sender:   gjson.GetBytes(ev, "sender").Str,
+			StateKey: b.Ptr(gjson.GetBytes(ev, "state_key").Str),
+			Type:     gjson.GetBytes(ev, "type").Str,
+			Content:  jsonObject([]byte(gjson.GetBytes(ev, "content").Raw)),
+		})
+	}
+
+	// roll forward Timeline
+	for _, ev := range sr.Timeline {
+		var sk *string
+		skg := gjson.GetBytes(ev, "state_key")
+		if skg.Exists() {
+			sk = &skg.Str
+		}
+		r.Events = append(r.Events, b.Event{
+			Sender:   gjson.GetBytes(ev, "sender").Str,
+			StateKey: sk,
+			Type:     gjson.GetBytes(ev, "type").Str,
+			Content:  jsonObject([]byte(gjson.GetBytes(ev, "content").Raw)),
+		})
+	}
+
+	return r
+}
+
+func jsonObject(in json.RawMessage) (out map[string]interface{}) {
+	_ = json.Unmarshal(in, &out)
+	return
+}

--- a/cmd/account-snapshot/internal/blueprint.go
+++ b/cmd/account-snapshot/internal/blueprint.go
@@ -3,15 +3,25 @@ package internal
 import (
 	"encoding/json"
 	"log"
+	"regexp"
 
 	"github.com/matrix-org/complement/internal/b"
 	"github.com/tidwall/gjson"
 )
 
+var ignoredEventType = map[string]bool{
+	"m.room.tombstone": true, // TODO: need to hit /upgrade API
+	"m.room.encrypted": true, // TODO: need to be able to send E2E messages and then give keys to homerunner clients
+	"m.reaction":       true, // TODO: uhh not in spec, needs event_id mapping
+	"m.room.redaction": true, // TODO: Hit /redact API, needs event_id mapping first
+}
+var regexpAlphanums = regexp.MustCompile("[^a-zA-Z0-9]+")
+
 // ConvertToBlueprint converts a /sync snapshot to a Complement blueprint
 func ConvertToBlueprint(s *Snapshot, serverName string) (*b.Blueprint, error) {
 	bp := &b.Blueprint{
-		Name: "snapshot_" + s.UserID,
+		// format that Docker images are happy with
+		Name: "snapshot_" + regexpAlphanums.ReplaceAllString(s.UserID, ""),
 	}
 	// TODO: the snapshot has information on servers but we only want 1 server for now
 	hs := b.Homeserver{
@@ -58,6 +68,9 @@ func ConvertToBlueprint(s *Snapshot, serverName string) (*b.Blueprint, error) {
 }
 
 func convertRoom(sr *AnonSnapshotRoom) *b.Room {
+	if len(sr.State) == 0 {
+		return convertTimelineOnlyRoom(sr)
+	}
 	r := &b.Room{
 		Ref:     sr.ID,
 		Creator: sr.Creator,
@@ -65,8 +78,14 @@ func convertRoom(sr *AnonSnapshotRoom) *b.Room {
 	// find and set the create content and memberships
 	memberships := map[string][]string{}
 	otherState := []json.RawMessage{}
+	var creatorMembership string
+	var plEvent json.RawMessage
 	for _, ev := range sr.State {
-		switch gjson.GetBytes(ev, "type").Str {
+		evType := gjson.GetBytes(ev, "type").Str
+		if ignoredEventType[evType] {
+			continue
+		}
+		switch evType {
 		case "m.room.create":
 			var createContent map[string]interface{}
 			if err := json.Unmarshal([]byte(gjson.GetBytes(ev, "content").Raw), &createContent); err != nil {
@@ -77,11 +96,19 @@ func convertRoom(sr *AnonSnapshotRoom) *b.Room {
 		case "m.room.member":
 			membership := gjson.GetBytes(ev, "content.membership").Str
 			userID := gjson.GetBytes(ev, "state_key").Str
-			memberships[membership] = append(memberships[membership], userID)
+			if userID == sr.Creator {
+				// we handle the creator separately as they are the magic user who sets room pre-state
+				creatorMembership = membership
+			} else {
+				memberships[membership] = append(memberships[membership], userID)
+			}
+		case "m.room.power_levels":
+			plEvent = ev
 		default:
 			otherState = append(otherState, ev)
 		}
 	}
+
 	// Make the room publicly joinable then join all the users in the room
 	r.Events = append(r.Events, b.Event{
 		Sender:   sr.Creator,
@@ -121,10 +148,10 @@ func convertRoom(sr *AnonSnapshotRoom) *b.Room {
 			},
 		})
 	}
-	// All invited users should be invited, we'll just invite them from the first joined user for now
+	// All invited users should be invited, we'll just invite them from the creator as they will be joined with perms
 	for _, userID := range memberships["invite"] {
 		r.Events = append(r.Events, b.Event{
-			Sender:   memberships["join"][0],
+			Sender:   sr.Creator,
 			StateKey: b.Ptr(userID),
 			Type:     "m.room.member",
 			Content: map[string]interface{}{
@@ -132,10 +159,10 @@ func convertRoom(sr *AnonSnapshotRoom) *b.Room {
 			},
 		})
 	}
-	// All banned users should be banned, we'll ban them from the first joined user for now
+	// All banned users should be banned, we'll ban them from the creator as they will be joined with perms
 	for _, userID := range memberships["ban"] {
 		r.Events = append(r.Events, b.Event{
-			Sender:   memberships["join"][0],
+			Sender:   sr.Creator,
 			StateKey: b.Ptr(userID),
 			Type:     "m.room.member",
 			Content: map[string]interface{}{
@@ -143,18 +170,49 @@ func convertRoom(sr *AnonSnapshotRoom) *b.Room {
 			},
 		})
 	}
-	// Set all the /sync State (excluding create/member events)
+	// Set all the /sync State (excluding create/member events) from the creator as they will be joined with perms
+	// the PL event comes last as it may make the creator unable to do stuff
 	for _, ev := range otherState {
 		r.Events = append(r.Events, b.Event{
-			Sender:   gjson.GetBytes(ev, "sender").Str,
+			Sender:   sr.Creator,
 			StateKey: b.Ptr(gjson.GetBytes(ev, "state_key").Str),
 			Type:     gjson.GetBytes(ev, "type").Str,
 			Content:  jsonObject([]byte(gjson.GetBytes(ev, "content").Raw)),
 		})
 	}
+	if plEvent != nil {
+		r.Events = append(r.Events, b.Event{
+			Sender:   sr.Creator,
+			StateKey: b.Ptr(""),
+			Type:     "m.room.power_levels",
+			Content:  jsonObject([]byte(gjson.GetBytes(plEvent, "content").Raw)),
+		})
+	}
+
+	// NOW handle the creator's membership
+	// We need to inspect the PL event to accurately handle invite/ban
+	switch creatorMembership {
+	case "invite": // TODO: handle this properly
+		fallthrough
+	case "ban": // TODO: handle this properly
+		fallthrough
+	case "leave":
+		r.Events = append(r.Events, b.Event{
+			Sender:   sr.Creator,
+			StateKey: b.Ptr(sr.Creator),
+			Type:     "m.room.member",
+			Content: map[string]interface{}{
+				"membership": "leave",
+			},
+		})
+	}
 
 	// roll forward Timeline
 	for _, ev := range sr.Timeline {
+		evType := gjson.GetBytes(ev, "type").Str
+		if ignoredEventType[evType] {
+			continue
+		}
 		var sk *string
 		skg := gjson.GetBytes(ev, "state_key")
 		if skg.Exists() {
@@ -163,11 +221,46 @@ func convertRoom(sr *AnonSnapshotRoom) *b.Room {
 		r.Events = append(r.Events, b.Event{
 			Sender:   gjson.GetBytes(ev, "sender").Str,
 			StateKey: sk,
-			Type:     gjson.GetBytes(ev, "type").Str,
+			Type:     evType,
 			Content:  jsonObject([]byte(gjson.GetBytes(ev, "content").Raw)),
 		})
 	}
 
+	return r
+}
+
+func convertTimelineOnlyRoom(sr *AnonSnapshotRoom) *b.Room {
+	r := &b.Room{
+		Ref:     sr.ID,
+		Creator: sr.Creator,
+	}
+	for _, ev := range sr.Timeline {
+		evType := gjson.GetBytes(ev, "type").Str
+		if ignoredEventType[evType] {
+			continue
+		}
+		switch evType {
+		case "m.room.create":
+			var createContent map[string]interface{}
+			if err := json.Unmarshal([]byte(gjson.GetBytes(ev, "content").Raw), &createContent); err != nil {
+				log.Printf("  cannot convert room, cannot unmarshal m.room.create content: %s\n", err)
+				return nil
+			}
+			r.CreateRoom = createContent
+		default:
+			var sk *string
+			skg := gjson.GetBytes(ev, "state_key")
+			if skg.Exists() {
+				sk = &skg.Str
+			}
+			r.Events = append(r.Events, b.Event{
+				Sender:   gjson.GetBytes(ev, "sender").Str,
+				StateKey: sk,
+				Type:     evType,
+				Content:  jsonObject([]byte(gjson.GetBytes(ev, "content").Raw)),
+			})
+		}
+	}
 	return r
 }
 

--- a/cmd/account-snapshot/internal/redact.go
+++ b/cmd/account-snapshot/internal/redact.go
@@ -1,0 +1,694 @@
+package internal
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"regexp"
+	"sort"
+	"strings"
+	"unicode"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// NoEncryptedDevice is the device ID used when there are no E2E messages sent by this user
+const NoEncryptedDevice = "device-default"
+
+// Snapshot is the output produced by this script
+type Snapshot struct {
+	Rooms          []AnonSnapshotRoom
+	Servers        []string
+	AccountDataDMs map[string][]string
+	Devices        map[string][]string
+	UserID         string // the anonymous user whose snapshot this is - important for setting account data
+}
+
+// @localpart:domain
+var userIDRegexp = regexp.MustCompile(`@[A-Za-z0-9\-\.=_/]+:[A-Za-z0-9\-\.=_/]+`)
+
+// Redact syncData into an anonymised snapshot
+func Redact(syncData []byte, anonMappings AnonMappings) *Snapshot {
+	sshot := &Snapshot{}
+	joins := gjson.GetBytes(syncData, "rooms.join")
+	// sort the room IDs
+	var joinedRooms []string
+	joins.ForEach(func(k, v gjson.Result) bool {
+		joinedRooms = append(joinedRooms, k.Str)
+		return true
+	})
+	sort.Strings(joinedRooms)
+	for i, roomID := range joinedRooms {
+		log.Printf("Processing room %s %d/%d\n", roomID, i+1, len(joinedRooms))
+		roomData := gjson.GetBytes(syncData, "rooms.join."+gjsonEscape(roomID))
+		room, err := mapAnonRoom(i, roomID, roomData, &anonMappings)
+		if err != nil {
+			log.Printf("WARNING: skipping room - failed to anonymise room: %s\n", err)
+			continue
+		}
+		sshot.Rooms = append(sshot.Rooms, *room)
+		if err != nil {
+			log.Printf("WARNING: skipping room - failed to marshal room as JSON: %s\n", err)
+			continue
+		}
+	}
+	var anonServers []string
+	for _, v := range anonMappings.Servers {
+		anonServers = append(anonServers, v)
+	}
+	var anonUsers []string
+	for _, v := range anonMappings.Users {
+		anonUsers = append(anonUsers, v)
+	}
+	sshot.Servers = anonServers
+	sshot.AccountDataDMs = processAccountDataDMs(syncData, anonMappings)
+	sshot.Devices = anonMappings.deviceMap()
+	for _, userID := range anonUsers {
+		if _, ok := sshot.Devices[userID]; ok {
+			continue
+		}
+		sshot.Devices[userID] = []string{NoEncryptedDevice}
+	}
+	return sshot
+}
+
+// RedactRules are the rules to apply.
+// Only the event types present in this map will be kept, all other ones are dropped, hence some types
+// have empty rules (e.g m.room.history_visibility)
+var RedactRules = map[string][]redaction{
+	"all": {
+		{
+			key: "sender",
+			replaceWith: func(mappings *AnonMappings, event, key gjson.Result, anonRoomID string) interface{} {
+				return mappings.User(key.Str)
+			},
+		},
+		{
+			key: "room_id",
+			replaceWith: func(mappings *AnonMappings, event, key gjson.Result, anonRoomID string) interface{} {
+				return anonRoomID
+			},
+		},
+		{
+			key: "state_key",
+			replaceWith: func(mappings *AnonMappings, event, key gjson.Result, anonRoomID string) interface{} {
+				return mappings.User(key.Str)
+			},
+			onCondition: func(mappings *AnonMappings, event, key gjson.Result, anonRoomID string) bool {
+				return strings.HasPrefix(key.Str, "@")
+			},
+		},
+	},
+	// TODO:
+	// m.room.third_party_invite
+	//
+	"m.room.create": {
+		{
+			key: "content.creator",
+			replaceWith: func(mappings *AnonMappings, event, key gjson.Result, anonRoomID string) interface{} {
+				return mappings.User(key.Str)
+			},
+		},
+		{
+			key: "content.predecessor.room_id",
+			replaceWith: func(mappings *AnonMappings, event, key gjson.Result, anonRoomID string) interface{} {
+				return mappings.Room(key.Str)
+			},
+		},
+		{
+			key: "content.predecessor.event_id",
+			replaceWith: func(mappings *AnonMappings, event, key gjson.Result, anonRoomID string) interface{} {
+				return ""
+			},
+		},
+	},
+	"m.room.name": {
+		{
+			key: "content.name",
+			replaceWith: func(mappings *AnonMappings, event, key gjson.Result, anonRoomID string) interface{} {
+				return strings.Map(redactFunc, key.Str)
+			},
+		},
+	},
+	"m.room.topic": {
+		{
+			key: "content.topic",
+			replaceWith: func(mappings *AnonMappings, event, key gjson.Result, anonRoomID string) interface{} {
+				return strings.Map(redactFunc, key.Str)
+			},
+		},
+	},
+	"m.room.avatar": {
+		{
+			key: "content.url",
+			replaceWith: func(mappings *AnonMappings, event, key gjson.Result, anonRoomID string) interface{} {
+				return "yes"
+			},
+		},
+	},
+	"m.room.canonical_alias": {
+		{
+			key: "content.alias",
+			replaceWith: func(mappings *AnonMappings, event, key gjson.Result, anonRoomID string) interface{} {
+				_, domain := split(key.Str)
+				anonServer := mappings.Server(domain)
+				return "#" + strings.Replace(anonRoomID[1:], ":", "", -1) + ":" + anonServer
+			},
+		},
+		{
+			key: "content.alt_aliases",
+			replaceWith: func(mappings *AnonMappings, event, key gjson.Result, anonRoomID string) interface{} {
+				return nil
+			},
+		},
+	},
+	"m.room.server_acl": {
+		{
+			key: "content.deny",
+			replaceWith: func(mappings *AnonMappings, event, key gjson.Result, anonRoomID string) interface{} {
+				arrint := key.Value()
+				arr, ok := arrint.([]interface{})
+				if !ok {
+					return []string{}
+				}
+				var list []string
+				for _, a := range arr {
+					astr, ok := a.(string)
+					if !ok {
+						continue
+					}
+					list = append(list, strings.Map(redactFunc, astr))
+				}
+				return list
+			},
+		},
+	},
+	"m.reaction": {
+		{
+			key: "content.m\\.relates_to.event_id",
+			replaceWith: func(mappings *AnonMappings, event, key gjson.Result, anonRoomID string) interface{} {
+				// TODO: event_id mapper
+				return ""
+			},
+		},
+	}, // TODO
+	"m.room.encryption":            {}, // TODO
+	"m.room.guest_access":          {},
+	"m.room.history_visibility":    {},
+	"m.room.join_rules":            {},
+	"org.matrix.room.preview_urls": {}, // TODO
+	"m.room.tombstone": {
+		{
+			key: "content.body",
+			replaceWith: func(mappings *AnonMappings, event, key gjson.Result, anonRoomID string) interface{} {
+				return strings.Map(redactFunc, key.Str)
+			},
+		},
+		{
+			key: "content.replacement_room",
+			replaceWith: func(mappings *AnonMappings, event, key gjson.Result, anonRoomID string) interface{} {
+				return mappings.Room(key.Str)
+			},
+		},
+	},
+	"m.room.pinned_events": {
+		{
+			key: "content.pinned",
+			replaceWith: func(mappings *AnonMappings, event, key gjson.Result, anonRoomID string) interface{} {
+				return strings.Map(redactFunc, key.Str)
+			},
+		},
+	},
+	"m.room.member": {
+		{
+			key: "content.avatar_url",
+			replaceWith: func(mappings *AnonMappings, event, key gjson.Result, anonRoomID string) interface{} {
+				return "yes"
+			},
+			onCondition: func(mappings *AnonMappings, event, key gjson.Result, anonRoomID string) bool {
+				return event.Get("type").Str == "m.room.member"
+			},
+		},
+		{
+			key: "content.displayname",
+			replaceWith: func(mappings *AnonMappings, event, key gjson.Result, anonRoomID string) interface{} {
+				target := mappings.User(event.Get("state_key").Str)
+				local, _ := split(target)
+				return local
+			},
+			onCondition: func(mappings *AnonMappings, event, key gjson.Result, anonRoomID string) bool {
+				return event.Get("type").Str == "m.room.member"
+			},
+		},
+		{
+			key: "content.reason",
+			replaceWith: func(mappings *AnonMappings, event, key gjson.Result, anonRoomID string) interface{} {
+				return strings.Map(redactFunc, key.Str)
+			},
+		},
+		{
+			key: "content.third_party_signed",
+			replaceWith: func(mappings *AnonMappings, event, key gjson.Result, anonRoomID string) interface{} {
+				return nil
+			},
+		},
+		{
+			key: "content.third_party_invite",
+			replaceWith: func(mappings *AnonMappings, event, key gjson.Result, anonRoomID string) interface{} {
+				return nil
+			},
+		},
+		{
+			key: "content.inviter",
+			replaceWith: func(mappings *AnonMappings, event, key gjson.Result, anonRoomID string) interface{} {
+				return mappings.User(key.Str)
+			},
+		},
+	},
+	"m.room.power_levels": {
+		{
+			key: "content.users",
+			replaceWith: func(mappings *AnonMappings, event, key gjson.Result, anonRoomID string) interface{} {
+				// user_id => PL
+				result := make(map[string]int)
+				key.ForEach(func(k, v gjson.Result) bool {
+					result[mappings.User(k.Str)] = int(v.Int())
+					return true
+				})
+				return result
+			},
+			onCondition: func(mappings *AnonMappings, event, key gjson.Result, anonRoomID string) bool {
+				return event.Get("type").Str == "m.room.power_levels" && event.Get("state_key").Str == ""
+			},
+		},
+	},
+	"m.room.encrypted": {
+		{
+			key: "content",
+			replaceWith: func(mappings *AnonMappings, event, key gjson.Result, anonRoomID string) interface{} {
+				// map device ID so we know which device sent the encrypted message.
+				deviceID := key.Get("device_id").Str
+				return map[string]interface{}{
+					"device_id":         mappings.Device(event.Get("sender").Str, deviceID),
+					"algorithm":         key.Get("algorithm").Str,
+					"ciphertext_length": len(key.Get("ciphertext").Str),
+				}
+			},
+		},
+	},
+	"m.room.redaction": {
+		{
+			key: "content",
+			replaceWith: func(mappings *AnonMappings, event, key gjson.Result, anonRoomID string) interface{} {
+				if key.Get("ciphertext").Exists() { // E2E redaction
+					// map device ID so we know which device sent the encrypted message.
+					deviceID := key.Get("device_id").Str
+					return map[string]interface{}{
+						"device_id":         mappings.Device(event.Get("sender").Str, deviceID),
+						"algorithm":         key.Get("algorithm").Str,
+						"ciphertext_length": len(key.Get("ciphertext").Str),
+					}
+				}
+				// normal redaction
+				return map[string]interface{}{}
+			},
+		},
+	},
+	"m.room.message": {
+		{
+			key:         "content.body",
+			replaceWith: bodyReplacer,
+		},
+		{
+			key: "content.formatted_body",
+			replaceWith: func(mappings *AnonMappings, event, key gjson.Result, anonRoomID string) interface{} {
+				return nil
+			},
+		},
+		{
+			key: "content.format",
+			replaceWith: func(mappings *AnonMappings, event, key gjson.Result, anonRoomID string) interface{} {
+				return nil
+			},
+		},
+		{
+			key: "content.info.url",
+			replaceWith: func(mappings *AnonMappings, event, key gjson.Result, anonRoomID string) interface{} {
+				return nil
+			},
+		},
+		{
+			key: "content.url",
+			replaceWith: func(mappings *AnonMappings, event, key gjson.Result, anonRoomID string) interface{} {
+				return nil
+			},
+		},
+		{
+			key: "content.file.url",
+			replaceWith: func(mappings *AnonMappings, event, key gjson.Result, anonRoomID string) interface{} {
+				return nil
+			},
+		},
+		{
+			key: "content.info.thumbnail_file.url",
+			replaceWith: func(mappings *AnonMappings, event, key gjson.Result, anonRoomID string) interface{} {
+				return nil
+			},
+		},
+		{
+			key: "content.info.thumbnail_url",
+			replaceWith: func(mappings *AnonMappings, event, key gjson.Result, anonRoomID string) interface{} {
+				return nil
+			},
+		},
+		{
+			key:         "content.m\\.relates_to.m\\.in_reply_to.event_id",
+			replaceWith: bodyReplacer,
+		},
+		{
+			key:         "content.m\\.relates_to.event_id",
+			replaceWith: bodyReplacer,
+		},
+		{
+			key:         "content.m\\.new_content.body",
+			replaceWith: bodyReplacer,
+		},
+		{
+			key: "content.m\\.new_content.formatted_body",
+			replaceWith: func(mappings *AnonMappings, event, key gjson.Result, anonRoomID string) interface{} {
+				return nil
+			},
+		},
+		{
+			key: "content.m\\.new_content.format",
+			replaceWith: func(mappings *AnonMappings, event, key gjson.Result, anonRoomID string) interface{} {
+				return nil
+			},
+		},
+		{
+			key: "content.m\\.new_content.info.url",
+			replaceWith: func(mappings *AnonMappings, event, key gjson.Result, anonRoomID string) interface{} {
+				return nil
+			},
+		},
+		{
+			key: "content.m\\.new_content.url",
+			replaceWith: func(mappings *AnonMappings, event, key gjson.Result, anonRoomID string) interface{} {
+				return nil
+			},
+		},
+	},
+}
+
+func redact(rawJSON, roomID string, mappings *AnonMappings, redactions []redaction) string {
+	val := gjson.Parse(rawJSON)
+	for _, r := range redactions {
+		field := val.Get(r.key)
+		if !field.Exists() {
+			continue
+		}
+		if r.onCondition != nil {
+			if !r.onCondition(mappings, val, field, roomID) {
+				continue
+			}
+		}
+		newVal := r.replaceWith(mappings, val, field, roomID)
+		if newVal != nil {
+			rawJSON, _ = sjson.Set(rawJSON, r.key, newVal)
+		} else {
+			rawJSON, _ = sjson.Delete(rawJSON, r.key)
+		}
+	}
+	return rawJSON
+}
+
+func redactFunc(r rune) rune {
+	if unicode.IsSpace(r) || unicode.IsPunct(r) {
+		return r
+	}
+	return 'x'
+}
+
+func bodyReplacer(mappings *AnonMappings, event, key gjson.Result, anonRoomID string) interface{} {
+	// replace any user ID with an anonymous one
+	var anonUserIDs []string
+	body := userIDRegexp.ReplaceAllStringFunc(key.Str, func(in string) string {
+		anon := mappings.User(in)
+		anonUserIDs = append(anonUserIDs, anon)
+		return anon
+	})
+	// blank out the entire body
+	redactedBody := strings.Map(redactFunc, body)
+	// replace @xxx:xxx.xxx with a user ID from anonUserID
+	for _, au := range anonUserIDs {
+		xu := strings.Map(redactFunc, au)
+		redactedBody = strings.Replace(redactedBody, xu, au, 1)
+	}
+
+	return redactedBody
+}
+
+// AnonMappings contains the mappings to convert live sync data to anonymous sync data. This is done via incremental
+// counts rather than hashing which is potentially vulnerable to reverse lookup attacks.
+type AnonMappings struct {
+	Users             map[string]string          // real user ID -> anonymised
+	UsersCount        int                        // counter for generating anonymous user IDs
+	Devices           map[string]string          // real device ID -> anonymised device ID
+	DevicesCount      int                        // counter for generating anonymous devices
+	Servers           map[string]string          // real server name -> anonymised server name
+	ServersCount      int                        // counter for generating anonymous servers
+	Rooms             map[string]string          // real room ID -> anonymised room ID, counter is from sorted room IDs
+	AnonUserToDevices map[string]map[string]bool // anon user -> anon devices
+	SingleServerName  string                     // if set, all users get to live on this single server
+}
+
+func (a *AnonMappings) Device(userID, deviceID string) string {
+	anonDevice, ok := a.Devices[deviceID]
+	if ok {
+		return anonDevice
+	}
+	// make an anon device
+	anonDevice = fmt.Sprintf("device-%x", a.DevicesCount)
+	a.Devices[deviceID] = anonDevice
+	a.DevicesCount++
+	// store the fact that this user has a device
+	anonUser := a.User(userID)
+	deviceSet, ok := a.AnonUserToDevices[anonUser]
+	if !ok {
+		deviceSet = make(map[string]bool)
+	}
+	deviceSet[anonDevice] = true
+	a.AnonUserToDevices[anonUser] = deviceSet
+
+	return anonDevice
+}
+
+func (a *AnonMappings) User(userID string) string {
+	if len(userID) == 0 || userID[0] != '@' {
+		return ""
+	}
+	anonUser, ok := a.Users[userID]
+	if ok {
+		return anonUser
+	}
+	// make an anon user
+	_, domain := split(userID)
+	if domain == "" {
+		return "" // invalid user ID
+	}
+	anonUser = fmt.Sprintf("@anon-%x:%s", a.UsersCount, a.Server(domain))
+	a.Users[userID] = anonUser
+	a.UsersCount++
+	return anonUser
+}
+
+func (a *AnonMappings) Server(realServer string) string {
+	if a.SingleServerName != "" {
+		return a.SingleServerName
+	}
+	anonServer, ok := a.Servers[realServer]
+	if ok {
+		return anonServer
+	}
+	// make an anon server
+	anonServer = fmt.Sprintf("server-%x", a.ServersCount)
+	a.Servers[realServer] = anonServer
+	a.ServersCount++
+	return anonServer
+}
+
+func (a *AnonMappings) Room(roomID string) string {
+	return a.Rooms[roomID]
+}
+
+func (a *AnonMappings) SetRoom(roomID, anonRoomID string) {
+	a.Rooms[roomID] = anonRoomID
+}
+
+// returns user_id => device_ids
+func (a *AnonMappings) deviceMap() map[string][]string {
+	result := make(map[string][]string)
+	for userID, set := range a.AnonUserToDevices {
+		for deviceID := range set {
+			result[userID] = append(result[userID], deviceID)
+		}
+	}
+	return result
+}
+
+type AnonSnapshotRoom struct {
+	ID       string
+	Creator  string
+	State    []json.RawMessage
+	Timeline []json.RawMessage
+}
+
+// redaction represents a rule to replace parts of a JSON object
+type redaction struct {
+	// The key to inspect
+	key string // e.g content.displayname
+	// Optional function called with the value of the key, return true to replace else false
+	onCondition func(mappings *AnonMappings, event, key gjson.Result, anonRoomID string) bool
+	// The value to replace with
+	replaceWith func(mappings *AnonMappings, event, key gjson.Result, anonRoomID string) interface{}
+}
+
+// loadSyncData loads the entire sync response either from disk or from a remote HTTP call.
+
+func split(matrixID string) (local, domain string) {
+	parts := strings.SplitN(matrixID, ":", 2)
+	if len(parts) != 2 {
+		log.Printf("Invalid matrix identifier: %s\n", matrixID)
+		return
+	}
+	return parts[0][1:], parts[1]
+}
+
+// gjsonEscape escapes . and * from the input so it can be used with gjson.Get
+func gjsonEscape(in string) string {
+	in = strings.ReplaceAll(in, ".", `\.`)
+	in = strings.ReplaceAll(in, "*", `\*`)
+	return in
+}
+
+// Find the event `type` and `state_key` in one or more gjson arrays, returns first match given.
+func findEventInArray(evType, stateKey string, arrs ...gjson.Result) (event *gjson.Result) {
+	for _, arr := range arrs {
+		arr.ForEach(func(_, v gjson.Result) bool {
+			vType := v.Get("type")
+			vSk := v.Get("state_key")
+			isWantedEvent := vType.Str == evType && vSk.Str == stateKey
+			if isWantedEvent {
+				event = &v
+			}
+			return !isWantedEvent
+		})
+		if event != nil {
+			return
+		}
+	}
+	return
+}
+
+func mapAnonRoom(index int, roomID string, roomData gjson.Result, mappings *AnonMappings) (*AnonSnapshotRoom, error) {
+	// pull out the create event
+	createEvent := findEventInArray("m.room.create", "", roomData.Get("state.events"), roomData.Get("timeline.events"))
+	if createEvent == nil {
+		return nil, fmt.Errorf("failed to find m.room.create event")
+	}
+	creator := mappings.User(createEvent.Get("sender").Str)
+	if creator == "" {
+		return nil, fmt.Errorf("failed to find room creator, create event missing sender")
+	}
+	_, domain := split(creator)
+	anonRoomID := fmt.Sprintf("!%d:%s", index, mappings.Server(domain))
+	room := &AnonSnapshotRoom{
+		Creator: creator,
+		ID:      anonRoomID,
+	}
+	mappings.SetRoom(roomID, anonRoomID)
+
+	var dropEventType = func(evType string) bool {
+		_, ok := RedactRules[evType]
+		if ok {
+			return false
+		}
+		log.Println("  dropping event type " + evType)
+		return true
+	}
+
+	// apply redaction rules "all" and $event_type
+	roomData.Get("state.events").ForEach(func(_, v gjson.Result) bool {
+		if dropEventType(v.Get("type").Str) {
+			return true
+		}
+		evJSON := redact(v.Raw, anonRoomID, mappings, RedactRules["all"])
+		evJSON = redact(evJSON, anonRoomID, mappings, RedactRules[v.Get("type").Str])
+		// blueprints only care about a few fields, so just add those fields on a whitelist basis
+		blueprintEvent := map[string]interface{}{}
+		blueprintEvent["sender"] = gjson.Get(evJSON, "sender").Str
+		blueprintEvent["type"] = gjson.Get(evJSON, "type").Str
+		blueprintEvent["state_key"] = gjson.Get(evJSON, "state_key").Str
+		blueprintEvent["content"] = json.RawMessage(gjson.Get(evJSON, "content").Raw)
+		be, err := json.Marshal(blueprintEvent)
+		if err != nil {
+			log.Printf("failed to anonymise event: %s\n", err)
+			return true
+		}
+		room.State = append(room.State, be)
+		return true
+	})
+	roomData.Get("timeline.events").ForEach(func(_, v gjson.Result) bool {
+		if dropEventType(v.Get("type").Str) {
+			return true
+		}
+		evJSON := redact(v.Raw, anonRoomID, mappings, RedactRules["all"])
+		evJSON = redact(evJSON, anonRoomID, mappings, RedactRules[v.Get("type").Str])
+		// blueprints only care about a few fields, so just add those fields on a whitelist basis
+		blueprintEvent := map[string]interface{}{}
+		blueprintEvent["sender"] = gjson.Get(evJSON, "sender").Str
+		blueprintEvent["type"] = gjson.Get(evJSON, "type").Str
+		sk := gjson.Get(evJSON, "state_key")
+		if sk.Exists() {
+			blueprintEvent["state_key"] = sk.Str
+		}
+		blueprintEvent["content"] = json.RawMessage(gjson.Get(evJSON, "content").Raw)
+		be, err := json.Marshal(blueprintEvent)
+		if err != nil {
+			log.Printf("failed to anonymise event: %s\n", err)
+			return true
+		}
+		room.Timeline = append(room.Timeline, be)
+		return true
+	})
+
+	return room, nil
+}
+
+func processAccountDataDMs(syncData []byte, anonMappings AnonMappings) (anonDMMap map[string][]string) {
+	anonDMMap = make(map[string][]string)
+	accData := gjson.GetBytes(syncData, "account_data.events")
+	accData.ForEach(func(k, v gjson.Result) bool {
+		switch v.Get("type").Str {
+		case "m.direct":
+			// content: { $user_id : [ $room_id ]}
+			dmMap := map[string][]string{}
+			err := json.Unmarshal([]byte(v.Get("content").Raw), &dmMap)
+			if err != nil {
+				log.Printf("Failed to load DM map from account data: %s\n", err)
+				return true
+			}
+			for userID, roomIDs := range dmMap {
+				anonRoomIDs := make([]string, len(roomIDs))
+				for i, r := range roomIDs {
+					anonRoomIDs[i] = anonMappings.Room(r)
+				}
+				anonDMMap[anonMappings.User(userID)] = anonRoomIDs
+			}
+		}
+		// TODO: push rules
+		return true
+	})
+	return anonDMMap
+}

--- a/cmd/account-snapshot/internal/redact.go
+++ b/cmd/account-snapshot/internal/redact.go
@@ -39,6 +39,7 @@ func Redact(syncData []byte, anonMappings AnonMappings) *Snapshot {
 		return true
 	})
 	sort.Strings(joinedRooms)
+	joinedRooms = joinedRooms[:10]
 	for i, roomID := range joinedRooms {
 		log.Printf("Processing room %s %d/%d\n", roomID, i+1, len(joinedRooms))
 		roomData := gjson.GetBytes(syncData, "rooms.join."+gjsonEscape(roomID))

--- a/cmd/account-snapshot/internal/redact.go
+++ b/cmd/account-snapshot/internal/redact.go
@@ -39,7 +39,6 @@ func Redact(syncData []byte, anonMappings AnonMappings) *Snapshot {
 		return true
 	})
 	sort.Strings(joinedRooms)
-	joinedRooms = joinedRooms[:10]
 	for i, roomID := range joinedRooms {
 		log.Printf("Processing room %s %d/%d\n", roomID, i+1, len(joinedRooms))
 		roomData := gjson.GetBytes(syncData, "rooms.join."+gjsonEscape(roomID))

--- a/cmd/account-snapshot/internal/sync.go
+++ b/cmd/account-snapshot/internal/sync.go
@@ -1,0 +1,94 @@
+package internal
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// LoadSyncData loads sync data from disk or by doing a /sync request
+func LoadSyncData(hsURL, token, tempFile string) (json.RawMessage, error) {
+	syncData := loadDataFromDisk(tempFile)
+	if syncData != nil {
+		log.Printf("Loaded sync data from %s\n", tempFile)
+		return syncData, nil
+	}
+	// We need to do a remote hit to the homeserver
+	httpCli := &http.Client{}
+
+	filterStr := url.QueryEscape(`{"event_format":"federation", "room":{"timeline":{"limit":50}}}`)
+
+	// Perform the sync
+	log.Println("Performing /sync...")
+	filterReq, err := http.NewRequest("GET", hsURL+"/_matrix/client/r0/sync?filter="+filterStr, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create sync req: %w", err)
+	}
+	body, err := doRequest(httpCli, filterReq, token)
+	if err != nil {
+		return nil, fmt.Errorf("failed to perform sync request: %w", err)
+	}
+
+	// dump it straight to disk first
+	err = ioutil.WriteFile(tempFile, body, 0644)
+	if err != nil {
+		log.Printf("WARNING: failed to write sync data to disk: %s", err)
+	}
+
+	return body, nil
+}
+
+func loadDataFromDisk(tempFile string) json.RawMessage {
+	data, err := ioutil.ReadFile(tempFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		log.Panicf("FATAL: failed to read data from disk: %s", err)
+	}
+	return data
+}
+
+func doRequest(httpCli *http.Client, req *http.Request, token string) ([]byte, error) {
+	req.Header.Set("Authorization", "Bearer "+token)
+	res, err := httpCli.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to perform request: %w", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != 200 {
+		return nil, fmt.Errorf("response returned %s", res.Status)
+	}
+	out := bytes.NewBuffer(nil)
+	// non-fatal if we have no content length
+	cl, _ := strconv.Atoi(res.Header.Get("Content-Length"))
+	counter := &writeCounter{
+		contentLength: cl,
+	}
+	if _, err = io.Copy(out, io.TeeReader(res.Body, counter)); err != nil {
+		return nil, err
+	}
+	return out.Bytes(), nil
+}
+
+type writeCounter struct {
+	contentLength int
+	total         int
+}
+
+func (wc *writeCounter) Write(p []byte) (int, error) {
+	n := len(p)
+	wc.total += n
+	// wipe current line
+	fmt.Fprintf(os.Stderr, "\r%s", strings.Repeat(" ", 80))
+	fmt.Fprintf(os.Stderr, "\rDownloading... %d / %d KB complete", wc.total/1024, wc.contentLength/1024)
+	return n, nil
+}

--- a/cmd/account-snapshot/main.go
+++ b/cmd/account-snapshot/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"github.com/matrix-org/complement/cmd/account-snapshot/internal"
+	"github.com/matrix-org/complement/internal/b"
 )
 
 /*
@@ -20,6 +21,7 @@ var (
 	flagAccessToken = flag.String("token", "", "Account access token")
 	flagHSURL       = flag.String("url", "https://matrix.org", "HS URL")
 	flagUserID      = flag.String("user", "", "Matrix User ID, needed to configure blueprints correctly for account data")
+	imageURI        = "complement-dendrite:latest"
 )
 
 func main() {
@@ -57,7 +59,15 @@ func main() {
 		log.Panicf("FATAL: ConvertToBlueprint %s\n", err)
 	}
 
-	b, err := json.MarshalIndent(bp, "", "  ")
+	homerunnerReq := struct {
+		Blueprint    *b.Blueprint `json:"blueprint"`
+		BaseImageURI string       `json:"base_image_uri"`
+	}{
+		Blueprint:    bp,
+		BaseImageURI: imageURI,
+	}
+
+	b, err := json.MarshalIndent(homerunnerReq, "", "  ")
 	if err != nil {
 		log.Printf("WARNING: failed to marshal anonymous snapshot: %s", err)
 	} else {

--- a/cmd/account-snapshot/main.go
+++ b/cmd/account-snapshot/main.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/matrix-org/complement/cmd/account-snapshot/internal"
+)
+
+/*
+ * Account Snapshot - Take an anonymised snapshot of this account.
+ * Raw /sync results stored in sync_snapshot.json
+ * The anonymised output is written to stdout
+ */
+
+var (
+	flagAccessToken = flag.String("token", "", "Account access token")
+	flagHSURL       = flag.String("url", "https://matrix.org", "HS URL")
+	flagUserID      = flag.String("user", "", "Matrix User ID, needed to configure blueprints correctly for account data")
+)
+
+func main() {
+	flag.Parse()
+	if *flagAccessToken == "" || *flagUserID == "" {
+		var eventsHandled string
+		for evType := range internal.RedactRules {
+			eventsHandled += "  " + evType + "\n"
+		}
+		fmt.Fprintf(os.Stderr,
+			"Capture an anonymous snapshot of this account.\n"+
+				"User name is required to map DM rooms correctly.\n"+
+				"/sync output is stored in 'sync_snapshot.json'\n"+
+				"Anonymised output is written to stdout\n\n"+
+				"Usage: ./account_snapshot -token MDA.... -user @alice:matrix.org > output.json\n\n"+
+				"Currently handles the following events:\n"+eventsHandled+"\n\n")
+		flag.PrintDefaults()
+		os.Exit(1)
+	}
+	syncData, err := internal.LoadSyncData(*flagHSURL, *flagAccessToken, "sync_snapshot.json")
+	if err != nil {
+		log.Panicf("FATAL: LoadSyncData %s\n", err)
+	}
+	var anonMappings internal.AnonMappings
+	anonMappings.Devices = make(map[string]string)
+	anonMappings.Servers = make(map[string]string)
+	anonMappings.Users = make(map[string]string)
+	anonMappings.Rooms = make(map[string]string)
+	anonMappings.AnonUserToDevices = make(map[string]map[string]bool)
+	anonMappings.SingleServerName = "hs1"
+	snapshot := internal.Redact(syncData, anonMappings)
+	snapshot.UserID = anonMappings.User(*flagUserID)
+	bp, err := internal.ConvertToBlueprint(snapshot, "hs1")
+	if err != nil {
+		log.Panicf("FATAL: ConvertToBlueprint %s\n", err)
+	}
+
+	b, err := json.MarshalIndent(bp, "", "  ")
+	if err != nil {
+		log.Printf("WARNING: failed to marshal anonymous snapshot: %s", err)
+	} else {
+		fmt.Printf(string(b) + "\n")
+	}
+}

--- a/internal/b/blueprints.go
+++ b/internal/b/blueprints.go
@@ -58,8 +58,8 @@ type User struct {
 	Localpart   string
 	DisplayName string
 	AvatarURL   string
-	AccountData AccountData
-	DeviceId    *string
+	AccountData []AccountData
+	DeviceID    *string
 	// Enable end-to end encryption for this user and upload the given
 	// amount of one-time keys. This requires the DeviceId to be set as
 	// well.

--- a/internal/b/perf_e2ee_room.go
+++ b/internal/b/perf_e2ee_room.go
@@ -16,12 +16,12 @@ var BlueprintPerfE2EERoom = MustValidate(Blueprint{
 					Localpart:   "@alice",
 					DisplayName: "Alice",
 					OneTimeKeys: 50,
-					DeviceId:    Ptr("ALDJLSKJD"),
+					DeviceID:    Ptr("ALDJLSKJD"),
 				},
 				{
 					Localpart:   "@bob",
 					DisplayName: "Bob",
-					DeviceId:    Ptr("BOBDASLDKJ"),
+					DeviceID:    Ptr("BOBDASLDKJ"),
 				},
 			}, manyUsers(userCount)...),
 			Rooms: []Room{
@@ -90,13 +90,13 @@ func manyUsers(count int) []User {
 	for i := 0; i < count; i++ {
 		localPart := fmt.Sprintf("@alice_%d", i)
 		displayName := fmt.Sprintf("Alice %d", i)
-		deviceId := fmt.Sprintf("ALICEDEVICE%d", i)
+		deviceID := fmt.Sprintf("ALICEDEVICE%d", i)
 
 		users[i] = User{
 			Localpart:   localPart,
 			DisplayName: displayName,
 			OneTimeKeys: 50,
-			DeviceId:    Ptr(deviceId),
+			DeviceID:    Ptr(deviceID),
 		}
 	}
 

--- a/internal/instruction/runner.go
+++ b/internal/instruction/runner.go
@@ -189,8 +189,8 @@ func calculateInstructions(r *Runner, hs b.Homeserver) []instruction {
 			},
 		}
 
-		if user.DeviceId != nil {
-			body["device_id"] = user.DeviceId
+		if user.DeviceID != nil {
+			body["device_id"] = user.DeviceID
 		}
 
 		instrs = append(instrs, instruction{
@@ -208,7 +208,7 @@ func calculateInstructions(r *Runner, hs b.Homeserver) []instruction {
 			ed25519Key, curveKey := account.IdentityKeys()
 
 			userID := fmt.Sprintf("@%s:%s", user.Localpart, hs.Name)
-			deviceID := *user.DeviceId
+			deviceID := *user.DeviceID
 
 			ed25519KeyID := fmt.Sprintf("ed25519:%s", deviceID)
 			curveKeyID := fmt.Sprintf("curve25519:%s", deviceID)


### PR DESCRIPTION
This PR:
 - Adds `./cmd/account-snapshot` - see the README.
 - Fixes some lint naming issues
 - Tweaks the instruction runner to `/login` if the user already exists in the blueprint (e.g logging in on a different device).