### PR TITLE
Update Synapse IP range blacklist option

### DIFF
--- a/dockerfiles/synapse/homeserver.yaml
+++ b/dockerfiles/synapse/homeserver.yaml
@@ -49,7 +49,7 @@ federation_custom_ca_list:
 - /ca/ca.crt
 
 # unblacklist RFC1918 addresses
-federation_ip_range_blacklist: []
+ip_range_blacklist: []
 
 # Disable server rate-limiting
 rc_federation:


### PR DESCRIPTION
This option has been deprecated: https://github.com/matrix-org/synapse/blob/master/UPGRADE.rst#blacklisting-ip-ranges

It is recommended to replace it with the similarly named `ip_range_blacklist`.