### PR TITLE
Homerunner and instruction runner tweaks

### DIFF
--- a/cmd/homerunner/main.go
+++ b/cmd/homerunner/main.go
@@ -45,6 +45,7 @@ func cleanup(c *Config) {
 		DebugLoggingEnabled:    true,
 		VersionCheckIterations: c.VersionCheckIterations,
 		KeepBlueprints:         c.KeepBlueprints,
+		BestEffort:             true,
 	}
 	builder, err := docker.NewBuilder(cfg)
 	if err != nil {

--- a/cmd/homerunner/setup.go
+++ b/cmd/homerunner/setup.go
@@ -40,6 +40,7 @@ func (r *Runtime) CreateDeployment(imageURI string, blueprint *b.Blueprint) (*do
 		BaseImageURI:           imageURI,
 		DebugLoggingEnabled:    true,
 		VersionCheckIterations: r.Config.VersionCheckIterations,
+		BestEffort:             true,
 	}
 	builder, err := docker.NewBuilder(cfg)
 	if err != nil {

--- a/dockerfiles/DendritePostgres.Dockerfile
+++ b/dockerfiles/DendritePostgres.Dockerfile
@@ -18,6 +18,9 @@ RUN ./generate-keys --private-key matrix_key.pem --tls-cert server.crt --tls-key
 RUN sed -i "s%connection_string:.*$%connection_string: postgresql://postgres@localhost/postgres?sslmode=disable%g" dendrite.yaml 
 # No password when connecting over localhost
 RUN sed -i "s%127.0.0.1/32            md5%127.0.0.1/32            trust%g" /etc/postgresql/9.6/main/pg_hba.conf
+# Bump up max conns for moar concurrency
+RUN sed -i 's/max_connections = 100/max_connections = 2000/g' /etc/postgresql/9.6/main/postgresql.conf
+RUN sed -i 's/max_open_conns:.*$/max_open_conns: 100/g' dendrite.yaml
 
 # This entry script starts postgres, waits for it to be up then starts dendrite
 RUN echo '\

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,7 @@ type Complement struct {
 	BaseImageURI           string
 	BaseImageArgs          []string
 	DebugLoggingEnabled    bool
+	BestEffort             bool
 	VersionCheckIterations int
 	KeepBlueprints         []string
 }

--- a/internal/docker/builder.go
+++ b/internal/docker/builder.go
@@ -70,6 +70,7 @@ type Builder struct {
 	FederationPort int
 	Docker         *client.Client
 	debugLogging   bool
+	bestEffort     bool
 	config         *config.Complement
 }
 
@@ -86,6 +87,7 @@ func NewBuilder(cfg *config.Complement) (*Builder, error) {
 		CSAPIPort:      8008,
 		FederationPort: 8448,
 		debugLogging:   cfg.DebugLoggingEnabled,
+		bestEffort:     cfg.BestEffort,
 		config:         cfg,
 	}, nil
 }
@@ -252,7 +254,7 @@ func (d *Builder) construct(bprint b.Blueprint) (errs []error) {
 		return []error{err}
 	}
 
-	runner := instruction.NewRunner(bprint.Name, d.debugLogging)
+	runner := instruction.NewRunner(bprint.Name, d.bestEffort, d.debugLogging)
 	results := make([]result, len(bprint.Homeservers))
 	for i, hs := range bprint.Homeservers {
 		res := d.constructHomeserver(bprint.Name, runner, hs, networkID)


### PR DESCRIPTION
This does a few things.

Instruction runner:
 - Add support for hitting `/leave` and `/invite`
 - Split out concurrency for user creation and room creation (the former is CPU bound, the latter is not)
 - Add an atomic bool for terminating workers on failure.
 - Make failures not fail everything if `bestEffort` is set.

Postgres image:
 - Increase max conns to 2000
 - All components get 100 conns
 
Account snapshot:
 - Change the ordering of events when making blueprints to stop us getting errors.