### PR TITLE
Add Blueprint.KeepAccessTokensForUsers and add --anon-only for account snapshot

### DIFF
--- a/cmd/account-snapshot/internal/blueprint.go
+++ b/cmd/account-snapshot/internal/blueprint.go
@@ -22,6 +22,9 @@ func ConvertToBlueprint(s *Snapshot, serverName string) (*b.Blueprint, error) {
 	bp := &b.Blueprint{
 		// format that Docker images are happy with
 		Name: "snapshot_" + regexpAlphanums.ReplaceAllString(s.UserID, ""),
+		// only keep the access token for the user whose account is being snapshotted else
+		// we could persist 10,000s of tokens as labels and make Docker sad
+		KeepAccessTokensForUsers: []string{s.UserID},
 	}
 	// TODO: the snapshot has information on servers but we only want 1 server for now
 	hs := b.Homeserver{

--- a/cmd/account-snapshot/internal/redact.go
+++ b/cmd/account-snapshot/internal/redact.go
@@ -248,6 +248,12 @@ var RedactRules = map[string][]redaction{
 			},
 		},
 		{
+			key: "content.uk\\.half-shot\\.discord\\.member",
+			replaceWith: func(mappings *AnonMappings, event, key gjson.Result, anonRoomID string) interface{} {
+				return nil
+			},
+		},
+		{
 			key: "content.third_party_signed",
 			replaceWith: func(mappings *AnonMappings, event, key gjson.Result, anonRoomID string) interface{} {
 				return nil

--- a/cmd/account-snapshot/main.go
+++ b/cmd/account-snapshot/main.go
@@ -21,6 +21,7 @@ var (
 	flagAccessToken = flag.String("token", "", "Account access token")
 	flagHSURL       = flag.String("url", "https://matrix.org", "HS URL")
 	flagUserID      = flag.String("user", "", "Matrix User ID, needed to configure blueprints correctly for account data")
+	flagAnonOnly    = flag.Bool("anon-only", false, "If set, outputs an anonymous sync output only, not a blueprint")
 	imageURI        = "complement-dendrite:latest"
 )
 
@@ -54,6 +55,15 @@ func main() {
 	anonMappings.SingleServerName = "hs1"
 	snapshot := internal.Redact(syncData, anonMappings)
 	snapshot.UserID = anonMappings.User(*flagUserID)
+	if *flagAnonOnly {
+		b, err := json.MarshalIndent(snapshot, "", "  ")
+		if err != nil {
+			log.Printf("WARNING: failed to marshal anonymous snapshot: %s", err)
+		} else {
+			fmt.Printf(string(b) + "\n")
+		}
+		os.Exit(0)
+	}
 	bp, err := internal.ConvertToBlueprint(snapshot, "hs1")
 	if err != nil {
 		log.Panicf("FATAL: ConvertToBlueprint %s\n", err)
@@ -69,7 +79,7 @@ func main() {
 
 	b, err := json.MarshalIndent(homerunnerReq, "", "  ")
 	if err != nil {
-		log.Printf("WARNING: failed to marshal anonymous snapshot: %s", err)
+		log.Printf("WARNING: failed to marshal blueprint: %s", err)
 	} else {
 		fmt.Printf(string(b) + "\n")
 	}

--- a/internal/b/blueprints.go
+++ b/internal/b/blueprints.go
@@ -41,6 +41,8 @@ type Blueprint struct {
 	Name string
 	// The list of homeservers to create for this deployment.
 	Homeservers []Homeserver
+	// A set of user IDs to retain access_tokens for. If empty, all tokens are kept.
+	KeepAccessTokensForUsers []string
 }
 
 type Homeserver struct {

--- a/internal/instruction/runner.go
+++ b/internal/instruction/runner.go
@@ -35,6 +35,8 @@ type Runner struct {
 	bestEffort bool
 	// set to true if the runner should stop
 	terminate atomic.Value
+	// Set of user IDs to retain access tokens for, if blank all tokens are grabbed
+	accessTokenSet map[string]bool
 }
 
 func NewRunner(blueprintName string, bestEffort, debugLogging bool) *Runner {
@@ -48,6 +50,7 @@ func NewRunner(blueprintName string, bestEffort, debugLogging bool) *Runner {
 		roomConcurrency: 36,
 		terminate:       v,
 		bestEffort:      bestEffort,
+		accessTokenSet:  make(map[string]bool),
 	}
 }
 

--- a/internal/instruction/runner.go
+++ b/internal/instruction/runner.go
@@ -35,8 +35,6 @@ type Runner struct {
 	bestEffort bool
 	// set to true if the runner should stop
 	terminate atomic.Value
-	// Set of user IDs to retain access tokens for, if blank all tokens are grabbed
-	accessTokenSet map[string]bool
 }
 
 func NewRunner(blueprintName string, bestEffort, debugLogging bool) *Runner {
@@ -50,7 +48,6 @@ func NewRunner(blueprintName string, bestEffort, debugLogging bool) *Runner {
 		roomConcurrency: 36,
 		terminate:       v,
 		bestEffort:      bestEffort,
-		accessTokenSet:  make(map[string]bool),
 	}
 }
 


### PR DESCRIPTION
`Blueprint.KeepAccessTokensForUsers []string` will, if set, add labels for the
given user IDs containing their access tokens. Prior to this, we would do this
for all users, but for blueprints with 100k users this made Docker sad.

`--anon-only`, if set on `./account-snapshot`, will output the intermediate
anonymised state prior to blueprint creation, useful for getting snapshots
from people without losing too much information.