### PR TITLE
Note that homeserver images must assume entrypoints can be run multiple times

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ $ COMPLEMENT_BASE_IMAGE=complement-dendrite:latest go test -timeout 30s -run '^(
 - The homeserver needs to `200 OK` requests to `GET /_matrix/client/versions`.
 - The homeserver needs to manage its own storage within the image.
 - The homeserver needs to accept the server name given by the environment variable `SERVER_NAME` at runtime.
+- The homeserver needs to assume dockerfile `CMD` or `ENTRYPOINT` instructions will be run multiple times.
 - The homeserver can use the CA certificate mounted at /ca to create its own TLS cert (see [Complement PKI](README.md#complement-pki)).
 
 #### Why 'Complement'?


### PR DESCRIPTION
Tests are not the only reason Complement may run a homeserver image. Blueprints, used by tests, are images that are created by spinning up a homeserver image, creating rooms and users, before snapshotting the state of the container. The resulting snapshot image is then used in tests. Blueprints can also use other blueprints as a base.

Thus homeserver images should not be built on the assumption that the command in the `ENTRYPOINT` or `CMD` dockerfile instruction will only be run once.