### PR TITLE
Update README with info on reworked synapse complement.sh script

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,11 @@ To get started developing, see https://github.com/matrix-org/complement/blob/mas
 
 If you're looking to run Complement against a local dev instance of Synapse, see [`matrix-org/synapse` -> `scripts-dev/complement.sh`](https://github.com/matrix-org/synapse/blob/develop/scripts-dev/complement.sh).
 
-If you want to develop Complement tests while working on a local dev instance of Synapse, edit [`scripts-dev/complement.sh`](https://github.com/matrix-org/synapse/blob/develop/scripts-dev/complement.sh) to point to your local Complement checkout (`cd ../complement`) instead of downloading from GitHub.
+If you want to develop Complement tests while working on a local dev instance of Synapse, use the [`scripts-dev/complement.sh`](https://github.com/matrix-org/synapse/blob/develop/scripts-dev/complement.sh) script and set the `COMPLEMENT_DIR` environment variable to the filepath of your local Complement checkout. A regex that matches against test names can also be supplied as an argument to the script, i.e:
+
+```sh
+COMPLEMENT_DIR=/path/to/complement scripts-dev/complement.sh "TestOutboundFederation(Profile|Send)"
+```
 
 
 #### Running


### PR DESCRIPTION
The script has been updated in https://github.com/matrix-org/synapse/pull/9685 to support running from local Complement checkouts.