### PR TITLE
Use GitHub Actions for linting and testing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,19 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
       - run: sudo apt-get -qq install libolm-dev
-      - run: |
-          export PATH="$(go env GOPATH)/bin:$PATH"
-          ./build/scripts/build-and-lint.sh
+      - uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.39
+          args: ./internal/... ./tests/... 
 
   complement:
     needs: lint

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,54 @@
+name: Tests
+
+on:
+  push:
+    branches: [ 'master' ]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - run: sudo apt-get -qq install libolm-dev
+      - run: |
+          export PATH="$(go env GOPATH)/bin:$PATH"
+          ./build/scripts/build-and-lint.sh
+
+  complement:
+    needs: lint
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - homeserver: Synapse
+            tags: synapse_blacklist
+
+          - homeserver: Dendrite
+            tags: msc2836
+
+    container:
+      image: matrixdotorg/complement  # dockerfiles/ComplementCIBuildkite.Dockerfile
+      env:
+        CI: true
+        DOCKER_BUILDKIT: 1
+      ports:
+        - 8448:8448
+      volumes:
+        - /var/run/docker.sock:/var/run/docker.sock
+
+    steps:
+      - uses: actions/checkout@v2
+      - run: docker build -t homeserver -f dockerfiles/${{ matrix.homeserver }}.Dockerfile dockerfiles/
+      - run: go test -v -tags "${{ matrix.tags }}" ./tests
+        env:
+          COMPLEMENT_BASE_IMAGE: homeserver


### PR DESCRIPTION
We don't run the Complement Buildkite pipelines for external pull requests due to security concerns around passing the Docker socket through to the container.

...there's no such concern on GitHub's public build infrastructure :)