### PR TITLE
MSC3083: Add additional tests for joining over federation.

### DIFF
--- a/tests/msc3083_test.go
+++ b/tests/msc3083_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 var (
-	msc1772SpaceChildEventType  = "org.matrix.msc1772.space.child"
+	msc1772SpaceChildEventType = "org.matrix.msc1772.space.child"
 )
 
 func FailJoinRoom(c *client.CSAPI, t *testing.T, roomIDOrAlias string, serverName string, expectedHttpCode int) {

--- a/tests/msc3083_test.go
+++ b/tests/msc3083_test.go
@@ -149,8 +149,7 @@ func TestRestrictedRoomsRemoteJoin(t *testing.T) {
 
 	// Create a second user and attempt to join the room, it should fail.
 	bob := deployment.Client(t, "hs2", "@bob:hs2")
-	// Note that this is a 400 error because it comes back over federation.
-	FailJoinRoom(bob, t, room, "hs1", 400)
+	FailJoinRoom(bob, t, room, "hs1", 403)
 
 	// Join the space, attempt to join the room again, which now should succeed.
 	bob.JoinRoom(t, space, []string{"hs1"})
@@ -159,7 +158,7 @@ func TestRestrictedRoomsRemoteJoin(t *testing.T) {
 	// Leaving the room works and the user is unable to re-join.
 	bob.LeaveRoom(t, room)
 	bob.LeaveRoom(t, space)
-	FailJoinRoom(bob, t, room, "hs1", 400)
+	FailJoinRoom(bob, t, room, "hs1", 403)
 
 	// Invite the user and joining should work.
 	alice.InviteRoom(t, room, "@bob:hs2")
@@ -186,7 +185,7 @@ func TestRestrictedRoomsRemoteJoin(t *testing.T) {
 		},
 	)
 	// Fails since invalid values get filtered out of allow.
-	FailJoinRoom(bob, t, room, "hs1", 400)
+	FailJoinRoom(bob, t, room, "hs1", 403)
 
 	alice.SendEventSynced(
 		t,
@@ -202,5 +201,5 @@ func TestRestrictedRoomsRemoteJoin(t *testing.T) {
 		},
 	)
 	// Fails since a fully invalid allow key requires an invite.
-	FailJoinRoom(bob, t, room, "hs1", 400)
+	FailJoinRoom(bob, t, room, "hs1", 403)
 }

--- a/tests/msc3083_test.go
+++ b/tests/msc3083_test.go
@@ -14,8 +14,7 @@ import (
 )
 
 var (
-	spaceChildEventType  = "org.matrix.msc1772.space.child"
-	spaceParentEventType = "org.matrix.msc1772.space.parent"
+	msc1772SpaceChildEventType  = "org.matrix.msc1772.space.child"
 )
 
 func FailJoinRoom(c *client.CSAPI, t *testing.T, roomIDOrAlias string, serverName string, expectedHttpCode int) {
@@ -66,7 +65,7 @@ func TestRestrictedRoomsLocalJoin(t *testing.T) {
 		},
 	})
 	alice.SendEventSynced(t, space, b.Event{
-		Type:     spaceChildEventType,
+		Type:     msc1772SpaceChildEventType,
 		StateKey: &room,
 		Content: map[string]interface{}{
 			"via": []string{"hs1"},
@@ -163,7 +162,7 @@ func TestRestrictedRoomsRemoteJoin(t *testing.T) {
 		},
 	})
 	alice.SendEventSynced(t, space, b.Event{
-		Type:     spaceChildEventType,
+		Type:     msc1772SpaceChildEventType,
 		StateKey: &room,
 		Content: map[string]interface{}{
 			"via": []string{"hs1"},

--- a/tests/msc3083_test.go
+++ b/tests/msc3083_test.go
@@ -18,7 +18,7 @@ var (
 	spaceParentEventType = "org.matrix.msc1772.space.parent"
 )
 
-func FailJoinRoom(c *client.CSAPI, t *testing.T, roomIDOrAlias string, serverName string) {
+func FailJoinRoom(c *client.CSAPI, t *testing.T, roomIDOrAlias string, serverName string, expectedHttpCode int) {
 	// This is copied from Client.JoinRoom to test a join failure.
 	query := make(url.Values, 1)
 	query.Set("server_name", serverName)
@@ -29,13 +29,13 @@ func FailJoinRoom(c *client.CSAPI, t *testing.T, roomIDOrAlias string, serverNam
 		nil,
 		"application/json",
 		query,
-		403,
+		expectedHttpCode,
 	)
 }
 
 // Test joining a room with join rules restricted to membership in a space.
 func TestRestrictedRoomsLocalJoin(t *testing.T) {
-	deployment := Deploy(t, "msc3083", b.BlueprintOneToOneRoom)
+	deployment := Deploy(t, "msc3083_local", b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	// Create the space and put a room in it.
@@ -75,7 +75,7 @@ func TestRestrictedRoomsLocalJoin(t *testing.T) {
 
 	// Create a second user and attempt to join the room, it should fail.
 	bob := deployment.Client(t, "hs1", "@bob:hs1")
-	FailJoinRoom(bob, t, room, "hs1")
+	FailJoinRoom(bob, t, room, "hs1", 403)
 
 	// Join the space, attempt to join the room again, which now should succeed.
 	bob.JoinRoom(t, space, []string{"hs1"})
@@ -84,7 +84,7 @@ func TestRestrictedRoomsLocalJoin(t *testing.T) {
 	// Leaving the room works and the user is unable to re-join.
 	bob.LeaveRoom(t, room)
 	bob.LeaveRoom(t, space)
-	FailJoinRoom(bob, t, room, "hs1")
+	FailJoinRoom(bob, t, room, "hs1", 403)
 
 	// Invite the user and joining should work.
 	alice.InviteRoom(t, room, "@bob:hs1")
@@ -111,7 +111,7 @@ func TestRestrictedRoomsLocalJoin(t *testing.T) {
 		},
 	)
 	// Fails since invalid values get filtered out of allow.
-	FailJoinRoom(bob, t, room, "hs1")
+	FailJoinRoom(bob, t, room, "hs1", 403)
 
 	alice.SendEventSynced(
 		t,
@@ -127,5 +127,55 @@ func TestRestrictedRoomsLocalJoin(t *testing.T) {
 		},
 	)
 	// Fails since a fully invalid allow key rquires an invite.
-	FailJoinRoom(bob, t, room, "hs1")
+	FailJoinRoom(bob, t, room, "hs1", 403)
+}
+
+// Test joining a room with join rules restricted to membership in a space.
+func TestRestrictedRoomsRemoteJoin(t *testing.T) {
+	deployment := Deploy(t, "msc3083_remote", b.BlueprintFederationOneToOneRoom)
+	defer deployment.Destroy(t)
+
+	// Create the space and put a room in it.
+	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	space := alice.CreateRoom(t, map[string]interface{}{
+		"preset": "public_chat",
+		"name":   "Space",
+	})
+	// The room is an unstable room version which supports the restricted join_rule.
+	room := alice.CreateRoom(t, map[string]interface{}{
+		"preset":       "public_chat",
+		"name":         "Room",
+		"room_version": "org.matrix.msc3083",
+		"initial_state": []map[string]interface{}{
+			{
+				"type":      "m.room.join_rules",
+				"state_key": "",
+				"content": map[string]interface{}{
+					"join_rule": "restricted",
+					"allow": []map[string]interface{}{
+						{
+							"space": &space,
+							"via":   []string{"hs1"},
+						},
+					},
+				},
+			},
+		},
+	})
+	alice.SendEventSynced(t, space, b.Event{
+		Type:     spaceChildEventType,
+		StateKey: &room,
+		Content: map[string]interface{}{
+			"via": []string{"hs1"},
+		},
+	})
+
+	// Create a second user and attempt to join the room, it should fail.
+	bob := deployment.Client(t, "hs2", "@bob:hs2")
+	// Note that this is a 400 error because it comes back over federation.
+	FailJoinRoom(bob, t, room, "hs1", 400)
+
+	// Join the space, attempt to join the room again, which now should succeed.
+	bob.JoinRoom(t, space, []string{"hs1"})
+	bob.JoinRoom(t, room, []string{"hs1"})
 }

--- a/tests/msc3083_test.go
+++ b/tests/msc3083_test.go
@@ -18,7 +18,7 @@ var (
 	msc1772SpaceChildEventType = "org.matrix.msc1772.space.child"
 )
 
-func FailJoinRoom(c *client.CSAPI, t *testing.T, roomIDOrAlias string, serverName string, expectedHttpCode int) {
+func FailJoinRoom(c *client.CSAPI, t *testing.T, roomIDOrAlias string, serverName string) {
 	// This is copied from Client.JoinRoom to test a join failure.
 	query := make(url.Values, 1)
 	query.Set("server_name", serverName)
@@ -29,7 +29,7 @@ func FailJoinRoom(c *client.CSAPI, t *testing.T, roomIDOrAlias string, serverNam
 		nil,
 		"application/json",
 		query,
-		expectedHttpCode,
+		403,
 	)
 }
 
@@ -75,7 +75,7 @@ func SetupRestrictedRoom(t *testing.T, deployment *docker.Deployment) (*client.C
 }
 
 func CheckRestrictedRoom(t *testing.T, alice *client.CSAPI, bob *client.CSAPI, space string, room string) {
-	FailJoinRoom(bob, t, room, "hs1", 403)
+	FailJoinRoom(bob, t, room, "hs1")
 
 	// Join the space, attempt to join the room again, which now should succeed.
 	bob.JoinRoom(t, space, []string{"hs1"})
@@ -84,7 +84,7 @@ func CheckRestrictedRoom(t *testing.T, alice *client.CSAPI, bob *client.CSAPI, s
 	// Leaving the room works and the user is unable to re-join.
 	bob.LeaveRoom(t, room)
 	bob.LeaveRoom(t, space)
-	FailJoinRoom(bob, t, room, "hs1", 403)
+	FailJoinRoom(bob, t, room, "hs1")
 
 	// Invite the user and joining should work.
 	alice.InviteRoom(t, room, bob.UserID)
@@ -111,7 +111,7 @@ func CheckRestrictedRoom(t *testing.T, alice *client.CSAPI, bob *client.CSAPI, s
 		},
 	)
 	// Fails since invalid values get filtered out of allow.
-	FailJoinRoom(bob, t, room, "hs1", 403)
+	FailJoinRoom(bob, t, room, "hs1")
 
 	alice.SendEventSynced(
 		t,
@@ -127,7 +127,7 @@ func CheckRestrictedRoom(t *testing.T, alice *client.CSAPI, bob *client.CSAPI, s
 		},
 	)
 	// Fails since a fully invalid allow key requires an invite.
-	FailJoinRoom(bob, t, room, "hs1", 403)
+	FailJoinRoom(bob, t, room, "hs1")
 }
 
 // Test joining a room with join rules restricted to membership in a space.

--- a/tests/msc3083_test.go
+++ b/tests/msc3083_test.go
@@ -125,7 +125,7 @@ func TestRestrictedRoomsLocalJoin(t *testing.T) {
 			},
 		},
 	)
-	// Fails since a fully invalid allow key rquires an invite.
+	// Fails since a fully invalid allow key requires an invite.
 	FailJoinRoom(bob, t, room, "hs1", 403)
 }
 
@@ -183,7 +183,7 @@ func TestRestrictedRoomsRemoteJoin(t *testing.T) {
 	bob.LeaveRoom(t, space)
 	FailJoinRoom(bob, t, room, "hs1", 400)
 
-	// Invite the user and joining shuold work.
+	// Invite the user and joining should work.
 	alice.InviteRoom(t, room, "@bob:hs2")
 	bob.JoinRoom(t, room, []string{"hs1"})
 
@@ -223,6 +223,6 @@ func TestRestrictedRoomsRemoteJoin(t *testing.T) {
 			},
 		},
 	)
-	// Fails since a fully invalid allow key rquires an invite.
+	// Fails since a fully invalid allow key requires an invite.
 	FailJoinRoom(bob, t, room, "hs1", 400)
 }


### PR DESCRIPTION
This builds on #98 to add tests for matrix-org/synapse#9800.

The tests are pretty much the same, as #98, but the users are no longer on the same server.