### PR TITLE
Update the Spaces Summary tests (MSC2946) to match the current spec

### DIFF
--- a/tests/msc2946_test.go
+++ b/tests/msc2946_test.go
@@ -171,7 +171,7 @@ func TestClientSpacesSummary(t *testing.T) {
 			ss2:  2, // ss1,r4
 			r4:   1, // ss2
 		}
-		res := alice.MustDo(t, "POST", []string{"_matrix", "client", "unstable", "rooms", root, "spaces"}, map[string]interface{}{})
+		res := alice.MustDo(t, "POST", []string{"_matrix", "client", "unstable", "org.matrix.msc2946", "rooms", root, "spaces"}, map[string]interface{}{})
 		must.MatchResponse(t, res, match.HTTPResponse{
 			JSON: []match.JSON{
 				match.JSONCheckOff("rooms", []interface{}{
@@ -218,7 +218,7 @@ func TestClientSpacesSummary(t *testing.T) {
 		// SS2 -> SS1
 		// SS1 -> root
 		// root -> R1,R2 (but only 1 is allowed)
-		res := alice.MustDo(t, "POST", []string{"_matrix", "client", "unstable", "rooms", r4, "spaces"}, map[string]interface{}{
+		res := alice.MustDo(t, "POST", []string{"_matrix", "client", "unstable", "org.matrix.msc2946", "rooms", r4, "spaces"}, map[string]interface{}{
 			"max_rooms_per_space": 1,
 		})
 		wantItems := []interface{}{
@@ -240,7 +240,7 @@ func TestClientSpacesSummary(t *testing.T) {
 	// - Setting limit works correctly
 	t.Run("limit", func(t *testing.T) {
 		// should omit R4 due to limit
-		res := alice.MustDo(t, "POST", []string{"_matrix", "client", "unstable", "rooms", root, "spaces"}, map[string]interface{}{
+		res := alice.MustDo(t, "POST", []string{"_matrix", "client", "unstable", "org.matrix.msc2946", "rooms", root, "spaces"}, map[string]interface{}{
 			"limit": 6,
 		})
 		must.MatchResponse(t, res, match.HTTPResponse{
@@ -267,7 +267,7 @@ func TestClientSpacesSummary(t *testing.T) {
 			StateKey: &ss1,
 			Content:  map[string]interface{}{},
 		})
-		res := alice.MustDo(t, "POST", []string{"_matrix", "client", "unstable", "rooms", root, "spaces"}, map[string]interface{}{})
+		res := alice.MustDo(t, "POST", []string{"_matrix", "client", "unstable", "org.matrix.msc2946", "rooms", root, "spaces"}, map[string]interface{}{})
 		must.MatchResponse(t, res, match.HTTPResponse{
 			JSON: []match.JSON{
 				match.JSONCheckOff("rooms", []interface{}{
@@ -383,7 +383,7 @@ func TestFederatedClientSpaces(t *testing.T) {
 	}
 	t.Logf("rooms: %v", allEvents)
 
-	res := alice.MustDo(t, "POST", []string{"_matrix", "client", "unstable", "rooms", root, "spaces"}, map[string]interface{}{})
+	res := alice.MustDo(t, "POST", []string{"_matrix", "client", "unstable", "org.matrix.msc2946", "rooms", root, "spaces"}, map[string]interface{}{})
 	must.MatchResponse(t, res, match.HTTPResponse{
 		JSON: []match.JSON{
 			match.JSONCheckOff("rooms", []interface{}{

--- a/tests/msc2946_test.go
+++ b/tests/msc2946_test.go
@@ -78,17 +78,24 @@ func TestClientSpacesSummary(t *testing.T) {
 	roomNames[ss1] = "Sub-Space 1"
 	r2 := alice.CreateRoom(t, map[string]interface{}{
 		"preset": "public_chat",
+		"name": "R2",
 	})
+	roomNames[r2] = "R2"
 	ss2 := alice.CreateRoom(t, map[string]interface{}{
 		"preset": "public_chat",
+		"name": "SS2",
 	})
+	roomNames[ss2] = "SS2"
 	r3 := alice.CreateRoom(t, map[string]interface{}{
 		"preset": "public_chat",
+		"name": "R3",
 	})
+	roomNames[r3] = "R3"
 	// alice is not joined to R4
 	bob := deployment.Client(t, "hs1", "@bob:hs1")
 	r4 := bob.CreateRoom(t, map[string]interface{}{
 		"preset": "public_chat",
+		"name": "R4",
 		"initial_state": []map[string]interface{}{
 			{
 				"type":      "m.room.history_visibility",
@@ -99,6 +106,7 @@ func TestClientSpacesSummary(t *testing.T) {
 			},
 		},
 	})
+	roomNames[r4] = "R4"
 
 	// create the links
 	rootToR1 := eventKey(root, r1, spaceChildEventType)

--- a/tests/msc3083_test.go
+++ b/tests/msc3083_test.go
@@ -14,8 +14,7 @@ import (
 )
 
 var (
-	spaceChildEventType  = "org.matrix.msc1772.space.child"
-	spaceParentEventType = "org.matrix.msc1772.space.parent"
+	msc1772SpaceChildEventType = "org.matrix.msc1772.space.child"
 )
 
 func FailJoinRoom(c *client.CSAPI, t *testing.T, roomIDOrAlias string, serverName string) {
@@ -66,7 +65,7 @@ func TestRestrictedRoomsLocalJoin(t *testing.T) {
 		},
 	})
 	alice.SendEventSynced(t, space, b.Event{
-		Type:     spaceChildEventType,
+		Type:     msc1772SpaceChildEventType,
 		StateKey: &room,
 		Content: map[string]interface{}{
 			"via": []string{"hs1"},


### PR DESCRIPTION
This fixes matrix-org/synapse#9756 by updating the Complement tests to match the current specification. The main differences are:

* There's no longer a `limit` flag.
* The summary only travels "down" to children rooms from the given root.
* The path specifies the unstable identifier in it.

Note that this won't break Dendrite because Dendrite was not passing the tag to run these tests.