### PR TITLE
Update the Synapse Worker configuration with new base image name and worker configuration

### DIFF
--- a/dockerfiles/SynapseWorkers.Dockerfile
+++ b/dockerfiles/SynapseWorkers.Dockerfile
@@ -47,7 +47,7 @@ ENTRYPOINT \
   # Set postgres authentication details which will be placed in the homeserver config file
   POSTGRES_PASSWORD=somesecret POSTGRES_USER=postgres POSTGRES_HOST=localhost \
   # Specify the workers to test with
-  SYNAPSE_WORKERS=\
+  SYNAPSE_WORKER_TYPES=\
     event_persister, \
     event_persister, \
     background_worker, \

--- a/dockerfiles/SynapseWorkers.Dockerfile
+++ b/dockerfiles/SynapseWorkers.Dockerfile
@@ -1,6 +1,6 @@
 # This dockerfile builds on top of Dockerfile-worker and includes a built-in postgres instance
 # as well as sets up the homeserver so that it is ready for testing via Complement
-FROM matrixdotorg/synapse:workers
+FROM matrixdotorg/synapse-workers
 
 # Download a caddy server to stand in front of nginx and terminate TLS using Complement's
 # custom CA.

--- a/dockerfiles/SynapseWorkers.Dockerfile
+++ b/dockerfiles/SynapseWorkers.Dockerfile
@@ -55,7 +55,8 @@ ENTRYPOINT \
     event_creator, \
     user_dir, \
     client_reader, \
-    media_repo, \
+    media_repository, \
+    federation_inbound, \
     federation_reader, \
     federation_sender, \
     synchrotron, \

--- a/dockerfiles/SynapseWorkers.Dockerfile
+++ b/dockerfiles/SynapseWorkers.Dockerfile
@@ -47,7 +47,7 @@ ENTRYPOINT \
   # Set postgres authentication details which will be placed in the homeserver config file
   POSTGRES_PASSWORD=somesecret POSTGRES_USER=postgres POSTGRES_HOST=localhost \
   # Specify the workers to test with
-  SYNAPSE_WORKER_TYPES=\
+  SYNAPSE_WORKER_TYPES="\
     event_persister, \
     event_persister, \
     background_worker, \
@@ -61,7 +61,7 @@ ENTRYPOINT \
     federation_sender, \
     synchrotron, \
     appservice, \
-    pusher \
+    pusher" \
   # Run the script that writes the necessary config files and starts supervisord, which in turn
   # starts everything else
   /configure_workers_and_start.py

--- a/dockerfiles/SynapseWorkers.Dockerfile
+++ b/dockerfiles/SynapseWorkers.Dockerfile
@@ -54,7 +54,6 @@ ENTRYPOINT \
     frontend_proxy, \
     event_creator, \
     user_dir, \
-    client_reader, \
     media_repository, \
     federation_inbound, \
     federation_reader, \

--- a/dockerfiles/SynapseWorkers.Dockerfile
+++ b/dockerfiles/SynapseWorkers.Dockerfile
@@ -46,8 +46,21 @@ ENTRYPOINT \
   SYNAPSE_REPORT_STATS=no \
   # Set postgres authentication details which will be placed in the homeserver config file
   POSTGRES_PASSWORD=somesecret POSTGRES_USER=postgres POSTGRES_HOST=localhost \
-  # Use all available worker types
-  SYNAPSE_WORKERS=* \
+  # Specify the workers to test with
+  SYNAPSE_WORKERS=\
+    event_persister, \
+    event_persister, \
+    background_worker, \
+    frontend_proxy, \
+    event_creator, \
+    user_dir, \
+    client_reader, \
+    media_repo, \
+    federation_reader, \
+    federation_sender, \
+    synchrotron, \
+    appservice, \
+    pusher \
   # Run the script that writes the necessary config files and starts supervisord, which in turn
   # starts everything else
   /configure_workers_and_start.py


### PR DESCRIPTION
This PR updates Complement's Synapse worker-flavoured docker image in a few ways:

* Updates the base image name from `synapse:workers` to `synapse-workers`, as it's built from a separate Dockerfile from the base `matrixdotorg/synapse` image.
* Update the `SYNAPSE_WORKERS` env var name to `SYNAPSE_WORKER_TYPES`
* Switches to an explicit list of worker names. We dropped the `*` functionality after adding sharding capabilities. The worker configuration mirrors [that of sytest](https://github.com/matrix-org/sytest/blob/7d297956d6c5a177d2ea492ce6561b2e2500b291/lib/SyTest/Homeserver/Synapse.pm#L657-L1051).

These changes grew out of [this PR on Synapse](https://github.com/matrix-org/synapse/pull/9162/) which changed the base image.

I'd ideally like feedback from the Synapse team on the chosen worker configuration.