### PR TITLE
Add a test for restricted rooms appearing in the spaces summary (MSC3083).

### DIFF
--- a/tests/msc3083_test.go
+++ b/tests/msc3083_test.go
@@ -165,7 +165,6 @@ func TestRestrictedRoomsRemoteJoin(t *testing.T) {
 
 // Request the room summary and ensure the expected rooms are in the response.
 func RequestAndAssertSummary(t *testing.T, user *client.CSAPI, space string, expected_rooms []interface{}) {
-	// The room appears for no one at first since hs2 doesn't know about who is in ss1.
 	res := user.MustDo(t, "POST", []string{"_matrix", "client", "unstable", "org.matrix.msc2946", "rooms", space, "spaces"}, map[string]interface{}{})
 	must.MatchResponse(t, res, match.HTTPResponse{
 		JSON: []match.JSON{

--- a/tests/msc3083_test.go
+++ b/tests/msc3083_test.go
@@ -252,7 +252,9 @@ func TestRestrictedRoomsSpacesSummary(t *testing.T) {
 // Tests that MSC2946 works over federation for a restricted room.
 //
 // Create a space with a room in it that has join rules restricted to membership
-// in that space. The space and room are on different homeservers.
+// in that space. The space and room are on different homeservers. While generating
+// the summary of space hs1 needs to ask hs2 to generate the summary for room since
+// it is not participating in the room.
 //
 // The user should be unable to see the room in the spaces summary unless they
 // are a member of the space.

--- a/tests/msc3083_test.go
+++ b/tests/msc3083_test.go
@@ -258,7 +258,7 @@ func TestRestrictedRoomsSpacesSummary(t *testing.T) {
 // are a member of the space.
 //
 // This tests the interactions over federation where the space and room are on
-// difference homeservers, which might not have the proper information needed to
+// different homeservers, and one might not have the proper information needed to
 // decide if a user is in a room.
 func TestRestrictedRoomsSpacesSummaryFederation(t *testing.T) {
 	deployment := Deploy(t, b.BlueprintFederationTwoLocalOneRemote)
@@ -321,7 +321,7 @@ func TestRestrictedRoomsSpacesSummaryFederation(t *testing.T) {
 	requestAndAssertSummary(t, bob, space, []interface{}{space})
 
 	// charlie joins the space and now hs2 knows that alice is in the space (and
-	// can join room).
+	// can join the room).
 	charlie.JoinRoom(t, space, []string{"hs1"})
 
 	// The restricted room should appear for alice (who is in the space).

--- a/tests/msc3083_test.go
+++ b/tests/msc3083_test.go
@@ -184,7 +184,7 @@ func RequestAndAssertSummary(t *testing.T, user *client.CSAPI, space string, exp
 // The user should be unable to see the room in the spaces summary unless they
 // are a member of the space.
 func TestRestrictedRoomsSpacesSummary(t *testing.T) {
-	deployment := Deploy(t, "msc2946", b.BlueprintOneToOneRoom)
+	deployment := Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	// Create the rooms
@@ -254,7 +254,7 @@ func TestRestrictedRoomsSpacesSummary(t *testing.T) {
 // The user should be unable to see the room in the spaces summary unless they
 // are a member of the space.
 func TestRestrictedRoomsSpacesSummaryFederation(t *testing.T) {
-	deployment := Deploy(t, "msc2946", b.BlueprintFederationTwoLocalOneRemote)
+	deployment := Deploy(t, b.BlueprintFederationTwoLocalOneRemote)
 	defer deployment.Destroy(t)
 
 	// Create the rooms


### PR DESCRIPTION
This adds some additional tests for [MSC3083](matrix-org/matrix-doc#3083) for ensuring that the space summary works for restricted rooms.

See matrix-org/synapse#9922 for the Synapse implementation.