### PR TITLE
Speed up Complement runs

### DIFF
--- a/internal/docker/builder.go
+++ b/internal/docker/builder.go
@@ -617,12 +617,14 @@ func deployImage(
 // CreateNetworkIfNotExists creates a docker network and returns its id.
 // ID is guaranteed not to be empty when err == nil
 func CreateNetworkIfNotExists(docker *client.Client, blueprintName string) (networkID string, err error) {
+	// check if a network already exists for this blueprint
 	nws, err := docker.NetworkList(context.Background(), types.NetworkListOptions{
 		Filters: label("complement_blueprint=" + blueprintName),
 	})
 	if err != nil {
 		return "", fmt.Errorf("%s: failed to list networks. %w", blueprintName, err)
 	}
+	// return the existing network
 	if len(nws) > 0 {
 		return nws[0].ID, nil
 	}

--- a/internal/docker/builder.go
+++ b/internal/docker/builder.go
@@ -128,7 +128,6 @@ func (d *Builder) removeNetworks() error {
 			return err
 		}
 	}
-
 	return nil
 }
 
@@ -211,6 +210,9 @@ func (d *Builder) ConstructBlueprintsIfNotExist(bs []b.Blueprint) error {
 			blueprintsToBuild = append(blueprintsToBuild, bprint)
 		}
 	}
+	if len(blueprintsToBuild) == 0 {
+		return nil
+	}
 	return d.ConstructBlueprints(blueprintsToBuild)
 }
 
@@ -263,7 +265,7 @@ func (d *Builder) ConstructBlueprints(bs []b.Blueprint) error {
 
 // construct all Homeservers sequentially then commits them
 func (d *Builder) construct(bprint b.Blueprint) (errs []error) {
-	networkID, err := CreateNetwork(d.Docker, bprint.Name)
+	networkID, err := CreateNetworkIfNotExists(d.Docker, bprint.Name)
 	if err != nil {
 		return []error{err}
 	}
@@ -612,9 +614,18 @@ func deployImage(
 	return d, nil
 }
 
-// CreateNetwork creates a docker network and returns its id.
+// CreateNetworkIfNotExists creates a docker network and returns its id.
 // ID is guaranteed not to be empty when err == nil
-func CreateNetwork(docker *client.Client, blueprintName string) (networkID string, err error) {
+func CreateNetworkIfNotExists(docker *client.Client, blueprintName string) (networkID string, err error) {
+	nws, err := docker.NetworkList(context.Background(), types.NetworkListOptions{
+		Filters: label("complement_blueprint=" + blueprintName),
+	})
+	if err != nil {
+		return "", fmt.Errorf("%s: failed to list networks. %w", blueprintName, err)
+	}
+	if len(nws) > 0 {
+		return nws[0].ID, nil
+	}
 	// make a user-defined network so we get DNS based on the container name
 	nw, err := docker.NetworkCreate(context.Background(), "complement_"+blueprintName, types.NetworkCreate{
 		Labels: map[string]string{

--- a/internal/docker/deployer.go
+++ b/internal/docker/deployer.go
@@ -72,7 +72,7 @@ func (d *Deployer) Deploy(ctx context.Context, blueprintName string) (*Deploymen
 	if len(images) == 0 {
 		return nil, fmt.Errorf("Deploy: No images have been built for blueprint %s", blueprintName)
 	}
-	networkID, err := CreateNetwork(d.Docker, blueprintName)
+	networkID, err := CreateNetworkIfNotExists(d.Docker, blueprintName)
 	if err != nil {
 		return nil, fmt.Errorf("Deploy: %w", err)
 	}
@@ -115,12 +115,6 @@ func (d *Deployer) Destroy(dep *Deployment, printServerLogs bool) {
 		})
 		if err != nil {
 			log.Printf("Destroy: Failed to remove container %s : %s\n", hsDep.ContainerID, err)
-		}
-	}
-	if d.networkID != "" {
-		err := d.Docker.NetworkRemove(context.Background(), d.networkID)
-		if err != nil {
-			log.Printf("Destroy: Failed to destroy network %s : %s\n", d.networkID, err)
 		}
 	}
 }

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -56,6 +56,7 @@ func TestMain(m *testing.M) {
 // which tests can interact with.
 func Deploy(t *testing.T, namespace string, blueprint b.Blueprint) *docker.Deployment {
 	t.Helper()
+	timeStartBlueprint := time.Now()
 	cfg := config.NewConfigFromEnvVars()
 	builder, err := docker.NewBuilder(cfg)
 	if err != nil {
@@ -68,10 +69,12 @@ func Deploy(t *testing.T, namespace string, blueprint b.Blueprint) *docker.Deplo
 	if err != nil {
 		t.Fatalf("Deploy: NewDeployer returned error %s", err)
 	}
+	timeStartDeploy := time.Now()
 	dep, err := d.Deploy(context.Background(), blueprint.Name)
 	if err != nil {
 		t.Fatalf("Deploy: Deploy returned error %s", err)
 	}
+	t.Logf("Deploy times: %v blueprints, %v containers", timeStartDeploy.Sub(timeStartBlueprint), time.Now().Sub(timeStartDeploy))
 	return dep
 }
 

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -74,7 +74,7 @@ func Deploy(t *testing.T, namespace string, blueprint b.Blueprint) *docker.Deplo
 	if err != nil {
 		t.Fatalf("Deploy: Deploy returned error %s", err)
 	}
-	t.Logf("Deploy times: %v blueprints, %v containers", timeStartDeploy.Sub(timeStartBlueprint), time.Now().Sub(timeStartDeploy))
+	t.Logf("Deploy times: %v blueprints, %v containers", timeStartDeploy.Sub(timeStartBlueprint), time.Since(timeStartDeploy))
 	return dep
 }
 


### PR DESCRIPTION
Every `Deploy()` call used to create a network and the deploy the containers.
It took 4s per network and 4s for containers, so 8s for single HSes, 12s for
federated deployments. Both the networks and containers got torn down at the
end of the test via `Destroy()`.

We don't need to re-create networks all the time. It is sufficient to just
make the network once (similar to how we execute blueprints once per run)
and then clean everything up at the *end of all the tests*. This PR does
just that.

Back of the envelope calculations:
```
Number of Deploy() calls: 23
Number of unique blueprints (hence networks): 4
Number of repeat Deploy() calls: 23-4 = 19

Savings per full Complement run: 19*4 = 76s
```

Also added in logs for `Deploy()` calls to keep an eye on any regressions.