### PR TITLE
Use atomic ints for namespaces

### DIFF
--- a/tests/apidoc_login_test.go
+++ b/tests/apidoc_login_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestLogin(t *testing.T) {
-	deployment := Deploy(t, "login", b.BlueprintAlice)
+	deployment := Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 	unauthedClient := deployment.Client(t, "hs1", "")
 	t.Run("parallel", func(t *testing.T) {

--- a/tests/apidoc_presence_test.go
+++ b/tests/apidoc_presence_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestPresence(t *testing.T) {
-	deployment := Deploy(t, "presence", b.BlueprintAlice)
+	deployment := Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	authedClient := deployment.Client(t, "hs1", "@alice:hs1")

--- a/tests/apidoc_register_test.go
+++ b/tests/apidoc_register_test.go
@@ -28,7 +28,7 @@ import (
 // Can register using an email address
 
 func TestRegistration(t *testing.T) {
-	deployment := Deploy(t, "registration", b.BlueprintAlice)
+	deployment := Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 	unauthedClient := deployment.Client(t, "hs1", "")
 	t.Run("parallel", func(t *testing.T) {

--- a/tests/apidoc_request_encoding_test.go
+++ b/tests/apidoc_request_encoding_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestRequestEncodingFails(t *testing.T) {
-	deployment := Deploy(t, "request_encoding", b.BlueprintAlice)
+	deployment := Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 	unauthedClient := deployment.Client(t, "hs1", "")
 	testString := `{ "test":"a` + "\x81" + `" }`

--- a/tests/apidoc_version_test.go
+++ b/tests/apidoc_version_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestVersionStructure(t *testing.T) {
-	deployment := Deploy(t, "test_version", b.BlueprintAlice)
+	deployment := Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 	unauthedClient := deployment.Client(t, "hs1", "")
 	// sytest: Version responds 200 OK with valid structure

--- a/tests/federation_keys_test.go
+++ b/tests/federation_keys_test.go
@@ -27,7 +27,7 @@ import (
 // https://matrix.org/docs/spec/server_server/latest#get-matrix-key-v2-server-keyid
 // sytest: Federation key API allows unsigned requests for keys
 func TestInboundFederationKeys(t *testing.T) {
-	deployment := Deploy(t, "federation_keys", b.BlueprintAlice)
+	deployment := Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 	fedClient := &http.Client{
 		Timeout:   10 * time.Second,

--- a/tests/federation_query_profile_test.go
+++ b/tests/federation_query_profile_test.go
@@ -18,7 +18,7 @@ import (
 // Test that the server can make outbound federation profile requests
 // https://matrix.org/docs/spec/server_server/latest#get-matrix-federation-v1-query-profile
 func TestOutboundFederationProfile(t *testing.T) {
-	deployment := Deploy(t, "federation_profile", b.BlueprintAlice)
+	deployment := Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	srv := federation.NewServer(t, deployment,

--- a/tests/federation_room_get_missing_events_test.go
+++ b/tests/federation_room_get_missing_events_test.go
@@ -30,7 +30,7 @@ import (
 // * Ensure that fetching the event results in an error.
 // sytest: Outbound federation will ignore a missing event with bad JSON for room version 6
 func TestOutboundFederationIgnoresMissingEventWithBadJSONForRoomVersion6(t *testing.T) {
-	deployment := Deploy(t, "federation_get_missing_events", b.BlueprintAlice)
+	deployment := Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 	srv := federation.NewServer(t, deployment,
 		federation.HandleKeyRequests(),

--- a/tests/federation_room_join_test.go
+++ b/tests/federation_room_join_test.go
@@ -27,7 +27,7 @@ import (
 // m.room.create event would pick that up. We also can't tear down the Complement
 // server because otherwise signing key lookups will fail.
 func TestJoinViaRoomIDAndServerName(t *testing.T) {
-	deployment := Deploy(t, "federation_room_join", b.BlueprintFederationOneToOneRoom)
+	deployment := Deploy(t, b.BlueprintFederationOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	acceptMakeSendJoinRequests := true
@@ -92,7 +92,7 @@ func TestJoinViaRoomIDAndServerName(t *testing.T) {
 // the properties listed above, then asking HS1 to join them and make sure that
 // they 200 OK.
 func TestJoinFederatedRoomWithUnverifiableEvents(t *testing.T) {
-	deployment := Deploy(t, "federation_room_join_unverifiable", b.BlueprintAlice)
+	deployment := Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	srv := federation.NewServer(t, deployment,

--- a/tests/federation_room_send_test.go
+++ b/tests/federation_room_send_test.go
@@ -19,7 +19,7 @@ import (
 
 // Tests that the server is capable of making outbound /send requests
 func TestOutboundFederationSend(t *testing.T) {
-	deployment := Deploy(t, "federation_send", b.BlueprintAlice)
+	deployment := Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	waiter := NewWaiter()

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -16,6 +17,8 @@ import (
 	"github.com/matrix-org/complement/internal/docker"
 	"github.com/matrix-org/complement/internal/federation"
 )
+
+var namespaceCounter uint64
 
 // TestMain is the main entry point for Complement.
 //
@@ -50,11 +53,11 @@ func TestMain(m *testing.M) {
 	os.Exit(exitCode)
 }
 
-// Deploy will deploy the given blueprint in the given namespace or terminate the test.
+// Deploy will deploy the given blueprint or terminate the test.
 // It will construct the blueprint if it doesn't already exist in the docker image cache.
 // This function is the main setup function for all tests as it provides a deployment with
 // which tests can interact with.
-func Deploy(t *testing.T, namespace string, blueprint b.Blueprint) *docker.Deployment {
+func Deploy(t *testing.T, blueprint b.Blueprint) *docker.Deployment {
 	t.Helper()
 	timeStartBlueprint := time.Now()
 	cfg := config.NewConfigFromEnvVars()
@@ -65,6 +68,7 @@ func Deploy(t *testing.T, namespace string, blueprint b.Blueprint) *docker.Deplo
 	if err = builder.ConstructBlueprintsIfNotExist([]b.Blueprint{blueprint}); err != nil {
 		t.Fatalf("Deploy: Failed to construct blueprint: %s", err)
 	}
+	namespace := fmt.Sprintf("%d", atomic.AddUint64(&namespaceCounter, 1))
 	d, err := docker.NewDeployer(namespace, cfg)
 	if err != nil {
 		t.Fatalf("Deploy: NewDeployer returned error %s", err)

--- a/tests/media_nofilename_test.go
+++ b/tests/media_nofilename_test.go
@@ -13,7 +13,7 @@ import (
 
 // Can handle uploads and remote/local downloads without a file name
 func TestMediaWithoutFileName(t *testing.T) {
-	deployment := Deploy(t, "media_repo", b.BlueprintAlice)
+	deployment := Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	remoteMediaId := "PlainTextFile"

--- a/tests/msc2403_test.go
+++ b/tests/msc2403_test.go
@@ -36,7 +36,7 @@ const knockUnstableIdentifier string = "xyz.amorgan.knock"
 // Knocking is currently an experimental feature and not in the matrix spec.
 // This function tests knocking on local and remote room.
 func TestKnocking(t *testing.T) {
-	deployment := Deploy(t, "test_knocking", b.BlueprintFederationTwoLocalOneRemote)
+	deployment := Deploy(t, b.BlueprintFederationTwoLocalOneRemote)
 	defer deployment.Destroy(t)
 
 	// Create a client for one local user
@@ -350,7 +350,7 @@ func doInitialSync(t *testing.T, c *client.CSAPI) string {
 // representing a knock room. For sanity-checking, this test will also create a public room and ensure it has a
 // 'join_rule' representing a publicly-joinable room.
 func TestKnockRoomsInPublicRoomsDirectory(t *testing.T) {
-	deployment := Deploy(t, "test_knock_rooms_in_public_rooms_directory", b.BlueprintAlice)
+	deployment := Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	// Create a client for a local user

--- a/tests/msc2836_test.go
+++ b/tests/msc2836_test.go
@@ -36,7 +36,7 @@ import (
 // an event which the server does have, event B, to ensure that this request also works and also does
 // federated hits to return missing events (A,C).
 func TestEventRelationships(t *testing.T) {
-	deployment := Deploy(t, "msc2836", b.BlueprintFederationOneToOneRoom)
+	deployment := Deploy(t, b.BlueprintFederationOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	// Create the room and send events A,B,C,D
@@ -185,7 +185,7 @@ func TestEventRelationships(t *testing.T) {
 // We then check that B, which wasn't on the return path on the previous request, was persisted by calling
 // /event_relationships again with event ID 'A' and direction 'down'.
 func TestFederatedEventRelationships(t *testing.T) {
-	deployment := Deploy(t, "msc2836_fed", b.BlueprintAlice)
+	deployment := Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 	srv := federation.NewServer(t, deployment,
 		federation.HandleKeyRequests(),

--- a/tests/msc2946_test.go
+++ b/tests/msc2946_test.go
@@ -50,7 +50,7 @@ func eventKey(srcRoomID, dstRoomID, evType string) string {
 // - Events are returned correctly.
 // - Redacting links works correctly.
 func TestClientSpacesSummary(t *testing.T) {
-	deployment := Deploy(t, "msc2946", b.BlueprintOneToOneRoom)
+	deployment := Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	roomNames := make(map[string]string)
@@ -275,7 +275,7 @@ func TestClientSpacesSummary(t *testing.T) {
 // Tests that:
 // - Querying from root returns the entire graph
 func TestFederatedClientSpaces(t *testing.T) {
-	deployment := Deploy(t, "msc2946", b.BlueprintFederationOneToOneRoom)
+	deployment := Deploy(t, b.BlueprintFederationOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	worldReadable := map[string]interface{}{

--- a/tests/msc3083_test.go
+++ b/tests/msc3083_test.go
@@ -132,7 +132,7 @@ func CheckRestrictedRoom(t *testing.T, alice *client.CSAPI, bob *client.CSAPI, s
 
 // Test joining a room with join rules restricted to membership in a space.
 func TestRestrictedRoomsLocalJoin(t *testing.T) {
-	deployment := Deploy(t, "msc3083_local", b.BlueprintOneToOneRoom)
+	deployment := Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	// Setup the user, space, and restricted room.
@@ -147,7 +147,7 @@ func TestRestrictedRoomsLocalJoin(t *testing.T) {
 
 // Test joining a room with join rules restricted to membership in a space.
 func TestRestrictedRoomsRemoteJoin(t *testing.T) {
-	deployment := Deploy(t, "msc3083_remote", b.BlueprintFederationOneToOneRoom)
+	deployment := Deploy(t, b.BlueprintFederationOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	// Setup the user, space, and restricted room.

--- a/tests/rooms_state_test.go
+++ b/tests/rooms_state_test.go
@@ -20,7 +20,7 @@ import (
 
 // Test that the m.room.create and m.room.member events for a room we created comes down /sync
 func TestRoomCreationReportsEventsToMyself(t *testing.T) {
-	deployment := Deploy(t, "rooms_state", b.BlueprintAlice)
+	deployment := Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	userID := "@alice:hs1"

--- a/tests/user_query_keys_test.go
+++ b/tests/user_query_keys_test.go
@@ -18,7 +18,7 @@ import (
 // like an array in Python and hence go un-noticed. In Go however it will result in a 400. The correct behaviour is
 // to return a 400. Element iOS uses this erroneous format.
 func TestKeysQueryWithDeviceIDAsObjectFails(t *testing.T) {
-	deployment := Deploy(t, "user_query_keys", b.BlueprintAlice)
+	deployment := Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	userID := "@alice:hs1"


### PR DESCRIPTION
It's always been a weird quirk that you need to specify a unique namespace string when
deploying containers. This is for parallel tests such that if 2 tests deploy
BlueprintAlice they get unique container names.

This PR changes the API so that we just increment an atomic
counter and use that as the namespace.