### PR TITLE
BREAKING: Use functional options for Client

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -223,7 +223,7 @@ func WithQueries(q url.Values) RequestOpt {
 	}
 }
 
-// MustDoFunc is the same as DoFunc but fails the test if it is not 2xx.
+// MustDoFunc is the same as DoFunc but fails the test if the returned HTTP response code is not 2xx.
 func (c *CSAPI) MustDoFunc(t *testing.T, method string, paths []string, opts ...RequestOpt) *http.Response {
 	t.Helper()
 	res := c.DoFunc(t, method, paths, opts...)

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -179,32 +179,6 @@ func (c *CSAPI) SyncUntil(t *testing.T, since, key string, check func(gjson.Resu
 	}
 }
 
-// MustDoWithStatus is the same as MustDo but fails the test if the response code does not match that provided
-func (c *CSAPI) MustDoWithStatus(t *testing.T, method string, paths []string, jsonBody interface{}, status int) *http.Response {
-	t.Helper()
-	res, err := c.DoWithAuth(t, method, paths, jsonBody)
-	if err != nil {
-		t.Fatalf("CSAPI.MustDoWithStatus %s %s error: %s", method, strings.Join(paths, "/"), err)
-	}
-	if res.StatusCode != status {
-		t.Fatalf("CSAPI.MustDoWithStatus %s %s returned HTTP %d, expected %d", method, res.Request.URL.String(), res.StatusCode, status)
-	}
-	return res
-}
-
-// MustDoWithStatusRaw is the same as MustDoRaw but fails the test if the response code does not match that provided
-func (c *CSAPI) MustDoWithStatusRaw(t *testing.T, method string, paths []string, body []byte, contentType string, query url.Values, status int) *http.Response {
-	t.Helper()
-	res, err := c.DoWithAuthRaw(t, method, paths, body, contentType, query)
-	if err != nil {
-		t.Fatalf("CSAPI.MustDoWithStatusRaw %s %s error: %s", method, strings.Join(paths, "/"), err)
-	}
-	if res.StatusCode != status {
-		t.Fatalf("CSAPI.MustDoWithStatusRaw %s %s returned HTTP %d, expected %d", method, res.Request.URL.String(), res.StatusCode, status)
-	}
-	return res
-}
-
 // MustDo is the same as Do but fails the test if the response is not 2xx
 func (c *CSAPI) MustDo(t *testing.T, method string, paths []string, jsonBody interface{}) *http.Response {
 	t.Helper()
@@ -304,7 +278,9 @@ func (c *CSAPI) DoFunc(t *testing.T, method string, paths []string, opts ...Requ
 		t.Fatalf("CSAPI.DoFunc failed to create http.NewRequest: %s", err)
 	}
 	// set defaults before RequestOpts
-	req.Header.Set("Authorization", "Bearer "+c.AccessToken)
+	if c.AccessToken != "" {
+		req.Header.Set("Authorization", "Bearer "+c.AccessToken)
+	}
 
 	// set functional options
 	for _, o := range opts {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -215,8 +215,9 @@ func WithJSONBody(t *testing.T, obj interface{}) RequestOpt {
 	}
 }
 
-// WithQueries sets the query parameters on the request. Does not modify access token as it
-// is set as an Authorization header.
+// WithQueries sets the query parameters on the request.
+// This function should not be used to set an "access_token" parameter for Matrix authentication.
+// Instead, set CSAPI.AccessToken.
 func WithQueries(q url.Values) RequestOpt {
 	return func(req *http.Request) {
 		req.URL.RawQuery = q.Encode()

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -153,13 +153,7 @@ func (c *CSAPI) SyncUntil(t *testing.T, since, key string, check func(gjson.Resu
 		if since != "" {
 			query["since"] = []string{since}
 		}
-		res, err := c.Do(t, "GET", []string{"_matrix", "client", "r0", "sync"}, nil, query)
-		if err != nil {
-			t.Fatalf("CSAPI.syncUntil since=%s error: %s", since, err)
-		}
-		if res.StatusCode < 200 || res.StatusCode >= 300 {
-			t.Fatalf("CSAPI.syncUntil since=%s returned HTTP %d", since, res.StatusCode)
-		}
+		res := c.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "sync"}, WithQueries(query))
 		body := ParseJSON(t, res)
 		since = GetJSONFieldStr(t, body, "next_batch")
 		keyRes := gjson.GetBytes(body, key)
@@ -296,19 +290,6 @@ func (c *CSAPI) DoFunc(t *testing.T, method string, paths []string, opts ...Requ
 		t.Logf("%s", string(dump))
 	}
 	return res
-}
-
-// Do a JSON request.
-func (c *CSAPI) Do(t *testing.T, method string, paths []string, jsonBody interface{}, query url.Values) (*http.Response, error) {
-	body := make([]byte, 0)
-	if jsonBody != nil {
-		b, err := json.Marshal(jsonBody)
-		if err != nil {
-			t.Fatalf("CSAPI.Do failed to marshal JSON body: %s", err)
-		}
-		body = b
-	}
-	return c.DoRaw(t, method, paths, body, "application/json", query)
 }
 
 func (c *CSAPI) DoRaw(t *testing.T, method string, paths []string, body []byte, contentType string, query url.Values) (*http.Response, error) {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -190,6 +190,10 @@ func (c *CSAPI) MustDo(t *testing.T, method string, paths []string, jsonBody int
 func WithRawBody(body []byte) RequestOpt {
 	return func(req *http.Request) {
 		req.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+		// we need to manually set this because we don't set the body
+		// in http.NewRequest due to using functional options, and only in NewRequest
+		// does the stdlib set this for us.
+		req.ContentLength = int64(len(body))
 	}
 }
 

--- a/tests/apidoc_login_test.go
+++ b/tests/apidoc_login_test.go
@@ -21,7 +21,7 @@ func TestLogin(t *testing.T) {
 		// sytest: GET /login yields a set of flows
 		t.Run("GET /login yields a set of flows", func(t *testing.T) {
 			t.Parallel()
-			res := unauthedClient.MustDo(t, "GET", []string{"_matrix", "client", "r0", "login"}, json.RawMessage(`{}`))
+			res := unauthedClient.DoFunc(t, "GET", []string{"_matrix", "client", "r0", "login"}, client.WithRawBody(json.RawMessage(`{}`)))
 			must.MatchResponse(t, res, match.HTTPResponse{
 				Headers: map[string]string{
 					"Content-Type": "application/json",

--- a/tests/apidoc_login_test.go
+++ b/tests/apidoc_login_test.go
@@ -106,18 +106,14 @@ func TestLogin(t *testing.T) {
 		// sytest: POST /login as non-existing user is rejected
 		t.Run("POST /login as non-existing user is rejected", func(t *testing.T) {
 			t.Parallel()
-			res, err := unauthedClient.Do(t, "POST", []string{"_matrix", "client", "r0", "login"}, json.RawMessage(`{
+			res := unauthedClient.DoFunc(t, "POST", []string{"_matrix", "client", "r0", "login"}, client.WithRawBody(json.RawMessage(`{
 				"type": "m.login.password",
 				"identifier": {
 					"type": "m.id.user",
 					"user": "i-dont-exist"
 				},
 				"password": "superuser"
-			}`), nil)
-			if err != nil {
-				t.Fatalf("unable to make request to /login: %v", err)
-			}
-
+			}`)))
 			must.MatchResponse(t, res, match.HTTPResponse{
 				StatusCode: 403,
 			})
@@ -126,19 +122,14 @@ func TestLogin(t *testing.T) {
 		t.Run("POST /login wrong password is rejected", func(t *testing.T) {
 			t.Parallel()
 			createDummyUser(t, unauthedClient, "login_wrong_password")
-			res, err := unauthedClient.Do(t, "POST", []string{"_matrix", "client", "r0", "login"}, json.RawMessage(`{
+			res := unauthedClient.DoFunc(t, "POST", []string{"_matrix", "client", "r0", "login"}, client.WithRawBody(json.RawMessage(`{
 				"type": "m.login.password",
 				"identifier": {
 					"type": "m.id.user",
 					"user": "login_wrong_password"
 				},
 				"password": "wrong_password"
-			}`), nil)
-
-			if err != nil {
-				t.Fatalf("unable to make request to /login: %v", err)
-			}
-
+			}`)))
 			must.MatchResponse(t, res, match.HTTPResponse{
 				StatusCode: 403,
 				JSON: []match.JSON{
@@ -160,10 +151,7 @@ func createDummyUser(t *testing.T, unauthedClient *client.CSAPI, userID string) 
 	if err != nil {
 		t.Fatalf("unable to marshal json: %v", err)
 	}
-	res, err := unauthedClient.Do(t, "POST", []string{"_matrix", "client", "r0", "register"}, json.RawMessage(reqBody), nil)
-	if err != nil {
-		t.Fatalf("unable to make register user: %v", err)
-	}
+	res := unauthedClient.DoFunc(t, "POST", []string{"_matrix", "client", "r0", "register"}, client.WithRawBody(json.RawMessage(reqBody)))
 	must.MatchResponse(t, res, match.HTTPResponse{
 		JSON: []match.JSON{
 			match.JSONKeyTypeEqual("access_token", gjson.String),

--- a/tests/apidoc_presence_test.go
+++ b/tests/apidoc_presence_test.go
@@ -19,8 +19,7 @@ func TestPresence(t *testing.T) {
 	authedClient := deployment.Client(t, "hs1", "@alice:hs1")
 	// sytest: GET /presence/:user_id/status fetches initial status
 	t.Run("GET /presence/:user_id/status fetches initial status", func(t *testing.T) {
-		res := authedClient.MustDo(t, "GET", []string{"_matrix", "client", "r0", "presence", "@alice:hs1", "status"}, nil)
-
+		res := authedClient.DoFunc(t, "GET", []string{"_matrix", "client", "r0", "presence", "@alice:hs1", "status"})
 		must.MatchResponse(t, res, match.HTTPResponse{
 			JSON: []match.JSON{
 				match.JSONKeyPresent("presence"),

--- a/tests/apidoc_register_test.go
+++ b/tests/apidoc_register_test.go
@@ -157,13 +157,16 @@ func TestRegistration(t *testing.T) {
 					match.JSONKeyTypeEqual("user_id", gjson.String),
 				},
 			})
-			unauthedClient.MustDoWithStatus(t, "POST", []string{"_matrix", "client", "r0", "register"}, json.RawMessage(`{
+			res = unauthedClient.DoFunc(t, "POST", []string{"_matrix", "client", "r0", "register"}, client.WithRawBody(json.RawMessage(`{
 				"auth": {
 					"type": "m.login.dummy"
 				},
 				"username": "post-can-create-a-user-once",
 				"password": "anotherSuperSecret"
-			}`), 400)
+			}`)))
+			must.MatchResponse(t, res, match.HTTPResponse{
+				StatusCode: 400,
+			})
 		})
 	})
 }

--- a/tests/apidoc_request_encoding_test.go
+++ b/tests/apidoc_request_encoding_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 
 	"github.com/matrix-org/complement/internal/b"
+	"github.com/matrix-org/complement/internal/client"
 	"github.com/matrix-org/complement/internal/match"
 	"github.com/matrix-org/complement/internal/must"
 )
@@ -17,10 +18,7 @@ func TestRequestEncodingFails(t *testing.T) {
 	testString := `{ "test":"a` + "\x81" + `" }`
 	// sytest: POST rejects invalid utf-8 in JSON
 	t.Run("POST rejects invalid utf-8 in JSON", func(t *testing.T) {
-		res, err := unauthedClient.Do(t, "POST", []string{"_matrix", "client", "r0", "register"}, json.RawMessage(testString), nil)
-		if err != nil {
-			t.Fatalf("failed to make request to register %v", err)
-		}
+		res := unauthedClient.DoFunc(t, "POST", []string{"_matrix", "client", "r0", "register"}, client.WithRawBody(json.RawMessage(testString)))
 		must.MatchResponse(t, res, match.HTTPResponse{
 			StatusCode: 400,
 			JSON: []match.JSON{

--- a/tests/federation_room_join_test.go
+++ b/tests/federation_room_join_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/tidwall/sjson"
 
 	"github.com/matrix-org/complement/internal/b"
+	"github.com/matrix-org/complement/internal/client"
 	"github.com/matrix-org/complement/internal/docker"
 	"github.com/matrix-org/complement/internal/federation"
 	"github.com/matrix-org/complement/internal/match"
@@ -70,8 +71,7 @@ func TestJoinViaRoomIDAndServerName(t *testing.T) {
 
 	queryParams := url.Values{}
 	queryParams.Set("server_name", "hs1")
-	res, err := bob.DoWithAuthRaw(t, "POST", []string{"_matrix", "client", "r0", "join", serverRoom.RoomID}, nil, "application/json", queryParams)
-	must.NotError(t, "failed to join room", err)
+	res := bob.DoFunc(t, "POST", []string{"_matrix", "client", "r0", "join", serverRoom.RoomID}, client.WithQueries(queryParams))
 	must.MatchResponse(t, res, match.HTTPResponse{
 		StatusCode: 200,
 		JSON: []match.JSON{

--- a/tests/msc2403_test.go
+++ b/tests/msc2403_test.go
@@ -324,7 +324,6 @@ func knockOnRoomWithStatus(t *testing.T, c *client.CSAPI, roomID, reason string,
 		t,
 		"POST",
 		[]string{"_matrix", "client", "unstable", knockUnstableIdentifier, roomID},
-		b,
 		client.WithQueries(query),
 		client.WithRawBody(b),
 	)
@@ -336,12 +335,9 @@ func knockOnRoomWithStatus(t *testing.T, c *client.CSAPI, roomID, reason string,
 // doInitialSync will carry out an initial sync and return the next_batch token
 func doInitialSync(t *testing.T, c *client.CSAPI) string {
 	query := url.Values{
-		"access_token": []string{c.AccessToken},
-		"timeout":      []string{"1000"},
+		"timeout": []string{"1000"},
 	}
-	res, err := c.Do(t, "GET", []string{"_matrix", "client", "r0", "sync"}, nil, query)
-	must.NotError(t, "doInitialSync failed to marshal JSON body", err)
-
+	res := c.DoFunc(t, "GET", []string{"_matrix", "client", "r0", "sync"}, client.WithQueries(query))
 	body := client.ParseJSON(t, res)
 	since := client.GetJSONFieldStr(t, body, "next_batch")
 	return since

--- a/tests/msc2403_test.go
+++ b/tests/msc2403_test.go
@@ -99,15 +99,16 @@ func knockingBetweenTwoUsersTest(t *testing.T, roomID string, inRoomUser, knocki
 			"server_name": []string{"hs1"},
 		}
 
-		knockingUser.MustDoWithStatusRaw(
+		res := knockingUser.DoFunc(
 			t,
 			"POST",
 			[]string{"_matrix", "client", "r0", "join", roomID},
-			[]byte("{}"),
-			"application/json",
-			query,
-			403,
+			client.WithQueries(query),
+			client.WithRawBody([]byte(`{}`)),
 		)
+		must.MatchResponse(t, res, match.HTTPResponse{
+			StatusCode: 403,
+		})
 	})
 
 	t.Run("Knocking on a room with join rule '"+knockUnstableIdentifier+"' should succeed", func(t *testing.T) {
@@ -319,16 +320,17 @@ func knockOnRoomWithStatus(t *testing.T, c *client.CSAPI, roomID, reason string,
 	}
 
 	// Knock on the room
-	c.MustDoWithStatusRaw(
+	res := c.DoFunc(
 		t,
 		"POST",
 		[]string{"_matrix", "client", "unstable", knockUnstableIdentifier, roomID},
 		b,
-		"application/json",
-		query,
-		expectedStatus,
+		client.WithQueries(query),
+		client.WithRawBody(b),
 	)
-
+	must.MatchResponse(t, res, match.HTTPResponse{
+		StatusCode: expectedStatus,
+	})
 }
 
 // doInitialSync will carry out an initial sync and return the next_batch token

--- a/tests/msc2946_test.go
+++ b/tests/msc2946_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/matrix-org/complement/internal/b"
+	"github.com/matrix-org/complement/internal/client"
 	"github.com/matrix-org/complement/internal/match"
 	"github.com/matrix-org/complement/internal/must"
 	"github.com/tidwall/gjson"
@@ -210,13 +211,11 @@ func TestClientSpacesSummary(t *testing.T) {
 		// SS2 -> R3,R4 (but only 1 is allowed)
 		query := make(url.Values, 1)
 		query.Set("max_rooms_per_space", "1")
-		res := alice.MustDoRaw(
+		res := alice.MustDoFunc(
 			t,
 			"GET",
 			[]string{"_matrix", "client", "unstable", "org.matrix.msc2946", "rooms", ss1, "spaces"},
-			nil,
-			"application/json",
-			query,
+			client.WithQueries(query),
 		)
 		wantItems := []interface{}{
 			ss1ToSS2,

--- a/tests/msc3083_test.go
+++ b/tests/msc3083_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/matrix-org/complement/internal/b"
 	"github.com/matrix-org/complement/internal/client"
 	"github.com/matrix-org/complement/internal/docker"
+	"github.com/matrix-org/complement/internal/match"
+	"github.com/matrix-org/complement/internal/must"
 )
 
 var (
@@ -22,15 +24,15 @@ func FailJoinRoom(c *client.CSAPI, t *testing.T, roomIDOrAlias string, serverNam
 	// This is copied from Client.JoinRoom to test a join failure.
 	query := make(url.Values, 1)
 	query.Set("server_name", serverName)
-	c.MustDoWithStatusRaw(
+	res := c.DoFunc(
 		t,
 		"POST",
 		[]string{"_matrix", "client", "r0", "join", roomIDOrAlias},
-		nil,
-		"application/json",
-		query,
-		403,
+		client.WithQueries(query),
 	)
+	must.MatchResponse(t, res, match.HTTPResponse{
+		StatusCode: 403,
+	})
 }
 
 // Create a space and put a room in it which is set to:

--- a/tests/user_query_keys_test.go
+++ b/tests/user_query_keys_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/matrix-org/complement/internal/b"
+	"github.com/matrix-org/complement/internal/client"
 	"github.com/matrix-org/complement/internal/match"
 	"github.com/matrix-org/complement/internal/must"
 )
@@ -23,15 +24,16 @@ func TestKeysQueryWithDeviceIDAsObjectFails(t *testing.T) {
 
 	userID := "@alice:hs1"
 	alice := deployment.Client(t, "hs1", userID)
-	res, err := alice.DoWithAuth(t, "POST", []string{"_matrix", "client", "r0", "keys", "query"}, map[string]interface{}{
-		"device_keys": map[string]interface{}{
-			"@bob:hs1": map[string]bool{
-				"device_id1": true,
-				"device_id2": true,
+	res := alice.DoFunc(t, "POST", []string{"_matrix", "client", "r0", "keys", "query"},
+		client.WithJSONBody(t, map[string]interface{}{
+			"device_keys": map[string]interface{}{
+				"@bob:hs1": map[string]bool{
+					"device_id1": true,
+					"device_id2": true,
+				},
 			},
-		},
-	})
-	must.NotError(t, "Failed to perform POST", err)
+		}),
+	)
 	must.MatchResponse(t, res, match.HTTPResponse{
 		StatusCode: 400,
 		JSON: []match.JSON{


### PR DESCRIPTION
This PR changes the `Client` API to reduce the number of functions in it. This has grown organically as the need for query params, raw bodies and custom content types has arisen in tests. Tests can now add as much or as little as they want via the use of functional options which we already use in places like the `match` package.

This removes a number of public `Client` functions:
 - `MustDoWithStatus`
 - `MustDoWithStatusRaw`
 - `MustDoRaw`
 - `DoWithAuth`
 - `DoWithAuthRaw`
 - `Do`
 - `DoRaw`

This adds the following public `Client` functions:
- `MustDoFunc`
- `DoFunc`

This adds the following functional options:
- `WithQueries`
- `WithJSONBody`
- `WithContentType`
- `WithRawBody`

Tests which use `MustDo` need no changes as that function has not been altered.
By default, we now use Authorization headers for access tokens and not query params
to avoid pollution when tests need to set query params.

Example usage:
```go
// Knock on the room
res := c.DoFunc(
	t,
	"POST",
	[]string{"_matrix", "client", "unstable", knockUnstableIdentifier, roomID},
	client.WithQueries(query),
	client.WithRawBody(b),
)
must.MatchResponse(t, res, match.HTTPResponse{
	StatusCode: expectedStatus,
})
```

The godoc for the `Client` now looks like:
```
    type CSAPI
        func (c *CSAPI) CreateRoom(t *testing.T, creationContent interface{}) string
        func (c *CSAPI) DoFunc(t *testing.T, method string, paths []string, opts ...RequestOpt) *http.Response
        func (c *CSAPI) DownloadContent(t *testing.T, mxcUri string) ([]byte, string)
        func (c *CSAPI) InviteRoom(t *testing.T, roomID string, userID string)
        func (c *CSAPI) JoinRoom(t *testing.T, roomIDOrAlias string, serverNames []string) string
        func (c *CSAPI) LeaveRoom(t *testing.T, roomID string)
        func (c *CSAPI) MustDo(t *testing.T, method string, paths []string, jsonBody interface{}) *http.Response
        func (c *CSAPI) MustDoFunc(t *testing.T, method string, paths []string, opts ...RequestOpt) *http.Response
        func (c *CSAPI) SendEventSynced(t *testing.T, roomID string, e b.Event) string
        func (c *CSAPI) SyncUntil(t *testing.T, since, key string, check func(gjson.Result) bool)
        func (c *CSAPI) SyncUntilTimelineHas(t *testing.T, roomID string, check func(gjson.Result) bool)
        func (c *CSAPI) UploadContent(t *testing.T, fileBody []byte, fileName string, contentType string) string
    type RequestOpt
        func WithContentType(cType string) RequestOpt
        func WithJSONBody(t *testing.T, obj interface{}) RequestOpt
        func WithQueries(q url.Values) RequestOpt
        func WithRawBody(body []byte) RequestOpt
```