### PR TITLE
Update helper functions to follow best-practices

### DIFF
--- a/tests/msc3083_test.go
+++ b/tests/msc3083_test.go
@@ -18,7 +18,7 @@ var (
 	msc1772SpaceChildEventType = "org.matrix.msc1772.space.child"
 )
 
-func FailJoinRoom(c *client.CSAPI, t *testing.T, roomIDOrAlias string, serverName string) {
+func failJoinRoom(c *client.CSAPI, t *testing.T, roomIDOrAlias string, serverName string) {
 	// This is copied from Client.JoinRoom to test a join failure.
 	query := make(url.Values, 1)
 	query.Set("server_name", serverName)
@@ -36,7 +36,7 @@ func FailJoinRoom(c *client.CSAPI, t *testing.T, roomIDOrAlias string, serverNam
 // Create a space and put a room in it which is set to:
 // * The experimental room version.
 // * restricted join rules with allow set to the space.
-func SetupRestrictedRoom(t *testing.T, deployment *docker.Deployment) (*client.CSAPI, string, string) {
+func setupRestrictedRoom(t *testing.T, deployment *docker.Deployment) (*client.CSAPI, string, string) {
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
 	space := alice.CreateRoom(t, map[string]interface{}{
 		"preset": "public_chat",
@@ -74,8 +74,8 @@ func SetupRestrictedRoom(t *testing.T, deployment *docker.Deployment) (*client.C
 	return alice, space, room
 }
 
-func CheckRestrictedRoom(t *testing.T, alice *client.CSAPI, bob *client.CSAPI, space string, room string) {
-	FailJoinRoom(bob, t, room, "hs1")
+func checkRestrictedRoom(t *testing.T, alice *client.CSAPI, bob *client.CSAPI, space string, room string) {
+	failJoinRoom(bob, t, room, "hs1")
 
 	// Join the space, attempt to join the room again, which now should succeed.
 	bob.JoinRoom(t, space, []string{"hs1"})
@@ -84,7 +84,7 @@ func CheckRestrictedRoom(t *testing.T, alice *client.CSAPI, bob *client.CSAPI, s
 	// Leaving the room works and the user is unable to re-join.
 	bob.LeaveRoom(t, room)
 	bob.LeaveRoom(t, space)
-	FailJoinRoom(bob, t, room, "hs1")
+	failJoinRoom(bob, t, room, "hs1")
 
 	// Invite the user and joining should work.
 	alice.InviteRoom(t, room, bob.UserID)
@@ -111,7 +111,7 @@ func CheckRestrictedRoom(t *testing.T, alice *client.CSAPI, bob *client.CSAPI, s
 		},
 	)
 	// Fails since invalid values get filtered out of allow.
-	FailJoinRoom(bob, t, room, "hs1")
+	failJoinRoom(bob, t, room, "hs1")
 
 	alice.SendEventSynced(
 		t,
@@ -127,7 +127,7 @@ func CheckRestrictedRoom(t *testing.T, alice *client.CSAPI, bob *client.CSAPI, s
 		},
 	)
 	// Fails since a fully invalid allow key requires an invite.
-	FailJoinRoom(bob, t, room, "hs1")
+	failJoinRoom(bob, t, room, "hs1")
 }
 
 // Test joining a room with join rules restricted to membership in a space.
@@ -136,13 +136,13 @@ func TestRestrictedRoomsLocalJoin(t *testing.T) {
 	defer deployment.Destroy(t)
 
 	// Setup the user, space, and restricted room.
-	alice, space, room := SetupRestrictedRoom(t, deployment)
+	alice, space, room := setupRestrictedRoom(t, deployment)
 
 	// Create a second user on the same homeserver.
 	bob := deployment.Client(t, "hs1", "@bob:hs1")
 
 	// Execute the checks.
-	CheckRestrictedRoom(t, alice, bob, space, room)
+	checkRestrictedRoom(t, alice, bob, space, room)
 }
 
 // Test joining a room with join rules restricted to membership in a space.
@@ -151,11 +151,11 @@ func TestRestrictedRoomsRemoteJoin(t *testing.T) {
 	defer deployment.Destroy(t)
 
 	// Setup the user, space, and restricted room.
-	alice, space, room := SetupRestrictedRoom(t, deployment)
+	alice, space, room := setupRestrictedRoom(t, deployment)
 
 	// Create a second user on a different homeserver.
 	bob := deployment.Client(t, "hs2", "@bob:hs2")
 
 	// Execute the checks.
-	CheckRestrictedRoom(t, alice, bob, space, room)
+	checkRestrictedRoom(t, alice, bob, space, room)
 }

--- a/tests/msc3083_test.go
+++ b/tests/msc3083_test.go
@@ -18,7 +18,9 @@ var (
 	msc1772SpaceChildEventType = "org.matrix.msc1772.space.child"
 )
 
-func failJoinRoom(c *client.CSAPI, t *testing.T, roomIDOrAlias string, serverName string) {
+func failJoinRoom(t *testing.T, c *client.CSAPI, roomIDOrAlias string, serverName string) {
+	t.Helper()
+
 	// This is copied from Client.JoinRoom to test a join failure.
 	query := make(url.Values, 1)
 	query.Set("server_name", serverName)
@@ -37,6 +39,8 @@ func failJoinRoom(c *client.CSAPI, t *testing.T, roomIDOrAlias string, serverNam
 // * The experimental room version.
 // * restricted join rules with allow set to the space.
 func setupRestrictedRoom(t *testing.T, deployment *docker.Deployment) (*client.CSAPI, string, string) {
+	t.Helper()
+
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
 	space := alice.CreateRoom(t, map[string]interface{}{
 		"preset": "public_chat",
@@ -75,7 +79,9 @@ func setupRestrictedRoom(t *testing.T, deployment *docker.Deployment) (*client.C
 }
 
 func checkRestrictedRoom(t *testing.T, alice *client.CSAPI, bob *client.CSAPI, space string, room string) {
-	failJoinRoom(bob, t, room, "hs1")
+	t.Helper()
+
+	failJoinRoom(t, bob, room, "hs1")
 
 	// Join the space, attempt to join the room again, which now should succeed.
 	bob.JoinRoom(t, space, []string{"hs1"})
@@ -84,7 +90,7 @@ func checkRestrictedRoom(t *testing.T, alice *client.CSAPI, bob *client.CSAPI, s
 	// Leaving the room works and the user is unable to re-join.
 	bob.LeaveRoom(t, room)
 	bob.LeaveRoom(t, space)
-	failJoinRoom(bob, t, room, "hs1")
+	failJoinRoom(t, bob, room, "hs1")
 
 	// Invite the user and joining should work.
 	alice.InviteRoom(t, room, bob.UserID)
@@ -111,7 +117,7 @@ func checkRestrictedRoom(t *testing.T, alice *client.CSAPI, bob *client.CSAPI, s
 		},
 	)
 	// Fails since invalid values get filtered out of allow.
-	failJoinRoom(bob, t, room, "hs1")
+	failJoinRoom(t, bob, room, "hs1")
 
 	alice.SendEventSynced(
 		t,
@@ -127,7 +133,7 @@ func checkRestrictedRoom(t *testing.T, alice *client.CSAPI, bob *client.CSAPI, s
 		},
 	)
 	// Fails since a fully invalid allow key requires an invite.
-	failJoinRoom(bob, t, room, "hs1")
+	failJoinRoom(t, bob, room, "hs1")
 }
 
 // Test joining a room with join rules restricted to membership in a space.


### PR DESCRIPTION
Fixes #112 by calling `t.Helper()` and not exporting functions.

Some of these fixes might also apply in `msc2403_test.go` (I see some of those functions don't call `t.Helper()`, but I'm unsure if they should).