### PR TITLE
Remove an errant unstable MSC1772 prefix from tests.

### DIFF
--- a/tests/msc3083_test.go
+++ b/tests/msc3083_test.go
@@ -228,7 +228,7 @@ func TestRestrictedRoomsSpacesSummary(t *testing.T) {
 		},
 	})
 	alice.SendEventSynced(t, space, b.Event{
-		Type:     "org.matrix.msc1772.space.child",
+		Type:     "m.space.child",
 		StateKey: &room,
 		Content: map[string]interface{}{
 			"via": []string{"hs1"},


### PR DESCRIPTION
#107 did this already, but I think I had competing PRs or something. Not sure how this got in there!