### PR TITLE
Remove redundant `hsName` param from `FederationClient`

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -78,7 +78,7 @@ Get a Federation client:
 // automatically maps localhost:12345 to the right container
 // automatically signs requests
 // srv == federation.Server
-fedClient := srv.FederationClient(deployment, "hs1")
+fedClient := srv.FederationClient(deployment)
 ```
 
 ## FAQ

--- a/internal/federation/server.go
+++ b/internal/federation/server.go
@@ -148,8 +148,10 @@ func (s *Server) MustMakeRoom(t *testing.T, roomVer gomatrixserverlib.RoomVersio
 	return room
 }
 
-// FederationClient returns a client which will sign requests using this server and accept certs from hsName.
-func (s *Server) FederationClient(deployment *docker.Deployment, hsName string) *gomatrixserverlib.FederationClient {
+// FederationClient returns a client which will sign requests using this server's key.
+//
+// The requests will be routed according to the deployment map in `deployment`.
+func (s *Server) FederationClient(deployment *docker.Deployment) *gomatrixserverlib.FederationClient {
 	f := gomatrixserverlib.NewFederationClient(
 		gomatrixserverlib.ServerName(s.ServerName), s.KeyID, s.Priv,
 		gomatrixserverlib.WithTransport(&docker.RoundTripper{Deployment: deployment}),

--- a/tests/federation_room_get_missing_events_test.go
+++ b/tests/federation_room_get_missing_events_test.go
@@ -116,7 +116,7 @@ func TestOutboundFederationIgnoresMissingEventWithBadJSONForRoomVersion6(t *test
 		w.Write(responseBytes)
 	}).Methods("POST")
 
-	fedClient := srv.FederationClient(deployment, "hs1")
+	fedClient := srv.FederationClient(deployment)
 	resp, err := fedClient.SendTransaction(context.Background(), gomatrixserverlib.Transaction{
 		TransactionID: "wut",
 		Destination:   gomatrixserverlib.ServerName("hs1"),

--- a/tests/msc2836_test.go
+++ b/tests/msc2836_test.go
@@ -310,7 +310,7 @@ func TestFederatedEventRelationships(t *testing.T) {
 		},
 	})
 	room.AddEvent(eventE)
-	fedClient := srv.FederationClient(deployment, "hs1")
+	fedClient := srv.FederationClient(deployment)
 	_, err := fedClient.SendTransaction(context.Background(), gomatrixserverlib.Transaction{
 		TransactionID:  "complement",
 		Origin:         gomatrixserverlib.ServerName(srv.ServerName),


### PR DESCRIPTION
This was unused; let's remove it for clarity.