### PR TITLE
Test validation on `send_{join,knock,leave}`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/docker/go-connections v0.4.0
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/gorilla/mux v1.8.0
+	github.com/matrix-org/gomatrix v0.0.0-20190528120928-7df988a63f26
 	github.com/matrix-org/gomatrixserverlib v0.0.0-20210624115417-42ac4e797a58
 	github.com/matrix-org/util v0.0.0-20190711121626-527ce5ddefc7
 	github.com/opencontainers/go-digest v1.0.0 // indirect

--- a/tests/federation_room_join_test.go
+++ b/tests/federation_room_join_test.go
@@ -219,7 +219,7 @@ func TestCannotSendNonLeaveViaSendLeaveV2(t *testing.T) {
 // and checks that they are all rejected.
 func testValidationForSendMembershipEndpoint(t *testing.T, baseApiPath, expectedMembership string, createRoomOpts map[string]interface{}) {
 	if createRoomOpts == nil {
-		createRoomOpts = map[string]interface{}{}
+		createRoomOpts = make(map[string]interface{})
 	}
 
 	deployment := Deploy(t, b.BlueprintAlice)

--- a/tests/federation_room_join_test.go
+++ b/tests/federation_room_join_test.go
@@ -241,18 +241,20 @@ func testValidationForSendMembershipEndpoint(t *testing.T, baseApiPath, expected
 	// a helper function which makes a send_* request to the given path and checks
 	// that it fails with a 400 error
 	assertRequestFails := func(t *testing.T, event *gomatrixserverlib.Event) {
-		req := gomatrixserverlib.NewFederationRequest("PUT", "hs1",
-			fmt.Sprintf("%s/%s/%s",
-				baseApiPath,
-				url.PathEscape(event.RoomID()),
-				url.PathEscape(event.EventID()),
-			))
+		path := fmt.Sprintf("%s/%s/%s",
+			baseApiPath,
+			url.PathEscape(event.RoomID()),
+			url.PathEscape(event.EventID()),
+		)
+		t.Logf("PUT %s", path)
+		req := gomatrixserverlib.NewFederationRequest("PUT", "hs1", path)
 		if err := req.SetContent(event); err != nil {
 			t.Errorf("req.SetContent: %v", err)
 			return
 		}
 
-		err := srv.SendFederationRequest(deployment, req, map[string]interface{}{})
+		var res map[string]interface{}
+		err := srv.SendFederationRequest(deployment, req, &res)
 		if err == nil {
 			t.Errorf("send request returned 200")
 			return
@@ -280,7 +282,7 @@ func testValidationForSendMembershipEndpoint(t *testing.T, baseApiPath, expected
 	})
 	t.Run("non-state membership event", func(t *testing.T) {
 		event := srv.MustCreateEvent(t, room, b.Event{
-			Type:    "m.room.message",
+			Type:    "m.room.member",
 			Sender:  charlie,
 			Content: map[string]interface{}{"body": "bzz"},
 		})

--- a/tests/msc2403_test.go
+++ b/tests/msc2403_test.go
@@ -469,7 +469,7 @@ func publishAndCheckRoomJoinRule(t *testing.T, c *client.CSAPI, roomID, expected
 
 // TestCannotSendNonKnockViaSendKnock checks that we cannot submit anything via /send_knock except a knock
 func TestCannotSendNonKnockViaSendKnock(t *testing.T) {
-	testValidationForSendMembershipEndpoint(t, "knock", "/_matrix/federation/v2/send_leave",
+	testValidationForSendMembershipEndpoint(t, "/_matrix/federation/v1/send_knock", "knock",
 		map[string]interface{}{
 			"room_version": "7",
 		},

--- a/tests/msc2403_test.go
+++ b/tests/msc2403_test.go
@@ -465,5 +465,13 @@ func publishAndCheckRoomJoinRule(t *testing.T, c *client.CSAPI, roomID, expected
 	if !roomFound {
 		t.Fatalf("Room was not present in public room directory response")
 	}
+}
 
+// TestCannotSendNonKnockViaSendKnock checks that we cannot submit anything via /send_knock except a knock
+func TestCannotSendNonKnockViaSendKnock(t *testing.T) {
+	testValidationForSendMembershipEndpoint(t, "knock", "/_matrix/federation/v2/send_leave",
+		map[string]interface{}{
+			"room_version": "7",
+		},
+	)
 }


### PR DESCRIPTION
Add some tests that try sending things other than proper events via `send_{join,knock,leave}`