### PR TITLE
Allow running against older Synapse releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ If you want to develop Complement tests while working on a local dev instance of
 COMPLEMENT_DIR=/path/to/complement scripts-dev/complement.sh "TestOutboundFederation(Profile|Send)"
 ```
 
+To run Complement against a specific release of Synapse, set the
+`SYNAPSE_VERSION` build argument. For example:
+
+```sh
+docker build -t complement-synapse:v1.36.0 -f dockerfiles/Synapse.Dockerfile --build-arg=SYNAPSE_VERSION=v1.36.0 dockerfiles
+COMPLEMENT_BASE_IMAGE=complement-synapse:v1.36.0 go test ./tests
+```
+
 ### Image requirements
 
 If you're looking to run against a custom Dockerfile, it must meet the following requirements:

--- a/dockerfiles/Synapse.Dockerfile
+++ b/dockerfiles/Synapse.Dockerfile
@@ -11,7 +11,9 @@
 # (cd dockerfiles && docker build -t complement-synapse -f Synapse.Dockerfile .)
 # COMPLEMENT_BASE_IMAGE=complement-synapse go test -v ./tests
 
-FROM matrixdotorg/synapse:latest
+ARG SYNAPSE_VERSION=latest
+
+FROM matrixdotorg/synapse:${SYNAPSE_VERSION}
 
 ENV SERVER_NAME=localhost
 

--- a/dockerfiles/synapse/start.sh
+++ b/dockerfiles/synapse/start.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 


### PR DESCRIPTION
This is super useful if you're trying to bisect for where a bug got introduced (or fixed, in my case...)