### PR TITLE
Do not recurse into non-spaces in the spaces summary.

### DIFF
--- a/tests/msc3083_test.go
+++ b/tests/msc3083_test.go
@@ -44,6 +44,9 @@ func setupRestrictedRoom(t *testing.T, deployment *docker.Deployment) (*client.C
 	space := alice.CreateRoom(t, map[string]interface{}{
 		"preset": "public_chat",
 		"name":   "Space",
+		"creation_content": map[string]interface{}{
+			"type": "m.space",
+		},
 	})
 	// The room is an unstable room version which supports the restricted join_rule.
 	room := alice.CreateRoom(t, map[string]interface{}{
@@ -196,6 +199,9 @@ func TestRestrictedRoomsSpacesSummary(t *testing.T) {
 	space := alice.CreateRoom(t, map[string]interface{}{
 		"preset": "public_chat",
 		"name":   "Space",
+		"creation_content": map[string]interface{}{
+			"type": "m.space",
+		},
 		// World readable to allow peeking without joining.
 		"initial_state": []map[string]interface{}{
 			{
@@ -274,6 +280,9 @@ func TestRestrictedRoomsSpacesSummaryFederation(t *testing.T) {
 	space := alice.CreateRoom(t, map[string]interface{}{
 		"preset": "public_chat",
 		"name":   "Space",
+		"creation_content": map[string]interface{}{
+			"type": "m.space",
+		},
 		"initial_state": []map[string]interface{}{
 			{
 				"type":      "m.room.history_visibility",


### PR DESCRIPTION
This is a subset of #123 and corresponds to matrix-org/synapse#10256, which is the straightforward change to only recurse into spaces, not the bit about trimming unnecessary events.