### PR TITLE
Added Apple Silicon instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ or on Mac:
 ```
 brew install libolm
 ```
-If you are on an Apple Silicon Mac then you'll need to set these environment variables too:
+If you are on an Apple Silicon Mac then you'll need to set these environment variables too so Go can find `libolm`:
 ```
 export LIBRARY_PATH=/opt/homebrew/lib
 export CPATH=/opt/homebrew/include

--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ or on Mac:
 ```
 brew install libolm
 ```
+If you are on an Apple Silicon Mac then you'll need to set these environment variables too:
+```
+export LIBRARY_PATH=/opt/homebrew/lib
+export CPATH=/opt/homebrew/include
+export PATH=/opt/homebrew/bin:$PATH
+```
 
 You can either use your own image, or one of the ones supplied in the [dockerfiles](./dockerfiles) directory.
 


### PR DESCRIPTION
I ran into some trouble getting Complement to run on an M1 Mac. It wasn't able to find libolm - which was installed using brew. Thanks to @tulir, this fixed it!