### PR TITLE
Blacklist a test to match sytest.

### DIFF
--- a/tests/federation_room_get_missing_events_test.go
+++ b/tests/federation_room_get_missing_events_test.go
@@ -1,3 +1,5 @@
+// +build !synapse_blacklist
+
 package tests
 
 import (


### PR DESCRIPTION
See matrix-org/synapse#10275, current Synapse develop fails unless this is disabled.