### PR TITLE
Add homeserver name to client request logging to differentiate which homeserver is being talked to

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -324,7 +324,7 @@ func (c *CSAPI) DoFunc(t *testing.T, method string, paths []string, opts ...Requ
 }
 
 // NewLoggedClient returns an http.Client which logs requests/responses
-func NewLoggedClient(t *testing.T, cli *http.Client) *http.Client {
+func NewLoggedClient(t *testing.T, hsName string, cli *http.Client) *http.Client {
 	t.Helper()
 	if cli == nil {
 		cli = &http.Client{
@@ -335,22 +335,23 @@ func NewLoggedClient(t *testing.T, cli *http.Client) *http.Client {
 	if transport == nil {
 		transport = http.DefaultTransport
 	}
-	cli.Transport = &loggedRoundTripper{t, transport}
+	cli.Transport = &loggedRoundTripper{t, hsName, transport}
 	return cli
 }
 
 type loggedRoundTripper struct {
-	t    *testing.T
-	wrap http.RoundTripper
+	t      *testing.T
+	hsName string
+	wrap   http.RoundTripper
 }
 
 func (t *loggedRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	start := time.Now()
 	res, err := t.wrap.RoundTrip(req)
 	if err != nil {
-		t.t.Logf("%s %s => error: %s (%s)", req.Method, req.URL.Path, err, time.Since(start))
+		t.t.Logf("%s %s%s => error: %s (%s)", req.Method, t.hsName, req.URL.Path, err, time.Since(start))
 	} else {
-		t.t.Logf("%s %s => %s (%s)", req.Method, req.URL.Path, res.Status, time.Since(start))
+		t.t.Logf("%s %s%s => %s (%s)", req.Method, t.hsName, req.URL.Path, res.Status, time.Since(start))
 	}
 	return res, err
 }

--- a/internal/docker/deployment.go
+++ b/internal/docker/deployment.go
@@ -53,7 +53,7 @@ func (d *Deployment) Client(t *testing.T, hsName, userID string) *client.CSAPI {
 		UserID:           userID,
 		AccessToken:      token,
 		BaseURL:          dep.BaseURL,
-		Client:           client.NewLoggedClient(t, nil),
+		Client:           client.NewLoggedClient(t, hsName, nil),
 		SyncUntilTimeout: 5 * time.Second,
 		Debug:            d.Deployer.debugLogging,
 	}
@@ -69,7 +69,7 @@ func (d *Deployment) RegisterUser(t *testing.T, hsName, localpart, password stri
 	}
 	client := &client.CSAPI{
 		BaseURL:          dep.BaseURL,
-		Client:           client.NewLoggedClient(t, nil),
+		Client:           client.NewLoggedClient(t, hsName, nil),
 		SyncUntilTimeout: 5 * time.Second,
 		Debug:            d.Deployer.debugLogging,
 	}


### PR DESCRIPTION
Add homeserver name to client request logging to differentiate which homeserver is being talked to

Before:
```
=== CONT  TestBackfillingHistory
    client.go:356: GET /_matrix/client/r0/sync => 200 OK (31.496008ms)
    client.go:356: POST /_matrix/client/unstable/org.matrix.msc2716/rooms/!GkmAGvcDmllsuqLgZA:hs1/batch_send => 200 OK (96.308307ms)
    client.go:356: POST /_matrix/client/r0/join/!GkmAGvcDmllsuqLgZA:hs1 => 200 OK (808.747133ms)
    client.go:356: GET /_matrix/client/r0/rooms/!GkmAGvcDmllsuqLgZA:hs1/messages => 200 OK (83.415512ms)
```

After:
```
=== CONT  TestBackfillingHistory
    client.go:357: GET hs1/_matrix/client/r0/sync => 200 OK (29.885812ms)
    client.go:357: POST hs1/_matrix/client/unstable/org.matrix.msc2716/rooms/!jbwgZJKNOedwNWRdop:hs1/batch_send => 200 OK (96.173807ms)
    client.go:357: POST hs2/_matrix/client/r0/join/!jbwgZJKNOedwNWRdop:hs1 => 200 OK (808.849665ms)
    client.go:357: GET hs2/_matrix/client/r0/rooms/!jbwgZJKNOedwNWRdop:hs1/messages => 200 OK (73.667196ms)
```