### PR TITLE
Add option to always print server logs

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -163,6 +163,12 @@ There is no syntactically pleasing way to do this. Create a separate function wh
 
 This is done using standard Go testing mechanisms, use `t.Logf(...)` which will be logged only if the test fails or if `-v` is set. Note that you will not need to log HTTP requests performed using one of the built in deployment clients as they are already wrapped in loggers. For full HTTP logs, use `COMPLEMENT_DEBUG=1`.
 
+
+### How do I show the server logs even when the tests pass?
+
+Normally, server logs are only printed when one of the tests fail. To override that behavior to always show server logs, you can use `COMPLEMENT_ALWAYS_PRINT_SERVER_LOGS=1`.
+
+
 ### How do I skip a test?
 
 Use one of `t.Skipf(...)` or `t.SkipNow()`.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,7 @@ type Complement struct {
 	BaseImageURI           string
 	BaseImageArgs          []string
 	DebugLoggingEnabled    bool
+	AlwaysPrintServerLogs  bool
 	BestEffort             bool
 	VersionCheckIterations int
 	KeepBlueprints         []string
@@ -20,6 +21,7 @@ func NewConfigFromEnvVars() *Complement {
 	cfg.BaseImageURI = os.Getenv("COMPLEMENT_BASE_IMAGE")
 	cfg.BaseImageArgs = strings.Split(os.Getenv("COMPLEMENT_BASE_IMAGE_ARGS"), " ")
 	cfg.DebugLoggingEnabled = os.Getenv("COMPLEMENT_DEBUG") == "1"
+	cfg.AlwaysPrintServerLogs = os.Getenv("COMPLEMENT_ALWAYS_PRINT_SERVER_LOGS") == "1"
 	cfg.VersionCheckIterations = parseEnvWithDefault("COMPLEMENT_VERSION_CHECK_ITERATIONS", 100)
 	cfg.KeepBlueprints = strings.Split(os.Getenv("COMPLEMENT_KEEP_BLUEPRINTS"), " ")
 	if cfg.BaseImageURI == "" {

--- a/internal/docker/deployment.go
+++ b/internal/docker/deployment.go
@@ -31,7 +31,7 @@ type HomeserverDeployment struct {
 // will print container logs before killing the container.
 func (d *Deployment) Destroy(t *testing.T) {
 	t.Helper()
-	d.Deployer.Destroy(d, t.Failed())
+	d.Deployer.Destroy(d, d.Deployer.config.AlwaysPrintServerLogs || t.Failed())
 }
 
 // Client returns a CSAPI client targeting the given hsName, using the access token for the given userID.


### PR DESCRIPTION
Add option to always print server logs.

When working on https://github.com/matrix-org/complement/pull/68, I would just put a `true` in their manually but seems useful to have an actual option to use.