### PR TITLE
Document how to hook up Element to the resultant homeservers from Complement

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -188,6 +188,36 @@ For Goland:
  * Under "Run"->"Edit Configurations..."->"Templates"->"Go Test", add `COMPLEMENT_BASE_IMAGE=complement-dendrite:latest`
  * Then you can right-click on any test file or test case and "Run <test name>".
 
+
+### How do I hook up a Matrix client like Element to the homeservers spun up by Complement after a test runs?
+
+It can be useful to view the output of a test in Element to better debug something going wrong or just make sure your test is doing what you expect before you try to assert everything.
+
+ 1. In your test comment out `defer deployment.Destroy(t)` and replace with `defer time.Sleep(2 * time.Hour)` to keep the homeserver running after the tests complete
+ 1. Start the Complement tests
+ 1. Save the Element config as `~/Downloads/riot-complement-config.json` and replace the port according to the output from `docker ps` (`docker ps -f name=complement_` to just filter to the Complement containers)
+    ```json
+    {
+      "default_server_config": {
+        "m.homeserver": {
+          "base_url": "http://localhost:55449",
+          "server_name": "my.complement.host"
+        }
+      },
+      "brand": "Element"
+    }
+    ```
+ 1. Start up Element (your matrix client)
+    ```
+    docker run -it --rm \
+        --publish 7080:80 \
+        --volume ~/Downloads/riot-complement-config.json:/app/config.json \
+        --name riot-complement \
+        vectorim/riot-web:v1.7.8
+    ```
+ 1. Now you can visit http://localhost:7080/ and register a new user and explore the rooms from the test output
+
+
 ### What do I need to know if I'm coming from sytest?
 
 Sytest has a concept of a `fixture` to configure the homeserver or test in a particular way, these are replaced with a `Blueprint` in Complement.


### PR DESCRIPTION
Document how to hook up Element to the resultant homeservers from running Complement tests.

Spawned from https://github.com/matrix-org/complement/pull/68