### PR TITLE
Always specify a preset

### DIFF
--- a/tests/federation_room_join_test.go
+++ b/tests/federation_room_join_test.go
@@ -326,7 +326,7 @@ func testValidationForSendMembershipEndpoint(t *testing.T, baseApiPath, expected
 			return
 		}
 
-		var res map[string]interface{}
+		var res interface{}
 		err := srv.SendFederationRequest(deployment, req, &res)
 		if err == nil {
 			t.Errorf("send request returned 200")

--- a/tests/federation_room_join_test.go
+++ b/tests/federation_room_join_test.go
@@ -290,7 +290,9 @@ func TestCannotSendNonLeaveViaSendLeaveV2(t *testing.T) {
 // and checks that they are all rejected.
 func testValidationForSendMembershipEndpoint(t *testing.T, baseApiPath, expectedMembership string, createRoomOpts map[string]interface{}) {
 	if createRoomOpts == nil {
-		createRoomOpts = make(map[string]interface{})
+		createRoomOpts = map[string]interface{}{
+			"preset": "public_chat",
+		}
 	}
 
 	deployment := Deploy(t, b.BlueprintAlice)

--- a/tests/msc2403_test.go
+++ b/tests/msc2403_test.go
@@ -473,6 +473,7 @@ func publishAndCheckRoomJoinRule(t *testing.T, c *client.CSAPI, roomID, expected
 func TestCannotSendNonKnockViaSendKnock(t *testing.T) {
 	testValidationForSendMembershipEndpoint(t, "/_matrix/federation/v1/send_knock", "knock",
 		map[string]interface{}{
+			"preset":       "public_chat",
 			"room_version": "7",
 		},
 	)


### PR DESCRIPTION
Synapse and Dendrite disagree what the join rules are if this is omitted.
Dendrite follows the spec, Synapse doesn't. Nontheless, we should be
specific in tests.

Also, actually fix the /v1 tests to unmarshal into the right data structure.
You can't use `map[string]interface{}` for v1 due to it sending back an
array of `[200, {}]` instead.