### PR TITLE
Test failover logic for MSC3083

### DIFF
--- a/tests/msc3083_test.go
+++ b/tests/msc3083_test.go
@@ -393,7 +393,7 @@ func TestRestrictedRoomsRemoteJoinFailOver(t *testing.T) {
 				return false
 			}
 			must.EqualStr(t, ev.Get("content").Get("membership").Str, "join", "Charlie failed to join the room")
-			must.EqualStr(t, ev.Get("content").Get("membership").Str, "join_authorised_via_users_server", alice.UserID)
+			must.EqualStr(t, ev.Get("content").Get("join_authorised_via_users_server").Str, alice.UserID, "Join authorised via incorrect server")
 
 			return true
 		},
@@ -448,7 +448,7 @@ func TestRestrictedRoomsRemoteJoinFailOver(t *testing.T) {
 				return false
 			}
 			must.EqualStr(t, ev.Get("content").Get("membership").Str, "join", "Charlie failed to join the room")
-			must.EqualStr(t, ev.Get("content").Get("membership").Str, "join_authorised_via_users_server", alice.UserID)
+			must.EqualStr(t, ev.Get("content").Get("join_authorised_via_users_server").Str, alice.UserID, "Join authorised via incorrect server")
 
 			return true
 		},

--- a/tests/msc3083_test.go
+++ b/tests/msc3083_test.go
@@ -315,7 +315,7 @@ func TestRestrictedRoomsRemoteJoinLocalUser(t *testing.T) {
 // Setup 3 homeservers:
 // * hs1 creates the space/room.
 // * hs2 joins the room
-// * hs3 attempts to join via hs2 (should fail) and hs3 (should work)
+// * hs3 attempts to join via hs2 (should fail) and hs1 (should work)
 func TestRestrictedRoomsRemoteJoinFailOver(t *testing.T) {
 	deployment := Deploy(t, b.Blueprint{
 		Name: "federation_three_homeservers",

--- a/tests/msc3083_test.go
+++ b/tests/msc3083_test.go
@@ -423,9 +423,7 @@ func TestRestrictedRoomsRemoteJoinFailOver(t *testing.T) {
 			if ev.Get("type").Str != "m.room.member" || ev.Get("state_key").Str != charlie.UserID {
 				return false
 			}
-			must.EqualStr(t, ev.Get("content").Get("membership").Str, "leave", "Charlie failed to leave the room")
-
-			return true
+			return ev.Get("content").Get("membership").Str == "leave"
 		},
 	)
 


### PR DESCRIPTION
This tests what happens if a server is unable to authorize a room join (due to not being able to invite users or not being able to check the proper allowed rooms).

Corresponds to matrix-org/synapse#10447

~~Based on #145~~