### PR TITLE
Sync build tags with buildkite.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         include:
           - homeserver: Synapse
-            tags: synapse_blacklist
+            tags: synapse_blacklist,msc2403,msc2946,msc3083
 
           - homeserver: Dendrite
             tags: msc2836 dendrite_blacklist


### PR DESCRIPTION
I was wondering why #172 was only failing on buildkite and not on GHA. Turns out we run with different build tags. 🤦 