### PR TITLE
Attempt to pull the corresponding Synapse branch when running tests.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,10 +55,8 @@ jobs:
           #
           # 1. First check if there's a similarly named branch (GITHUB_HEAD_REF
           #    for pull requests, otherwise GITHUB_REF).
-          # 2. Attempt to use the base branch, e.g. when merging into release-vX.Y
-          #    (GITHUB_BASE_REF for pull requests).
           # 3. Use the default homeserver branch.
-          for BRANCH_NAME in "$GITHUB_HEAD_REF" "$GITHUB_BASE_REF" "${GITHUB_REF#refs/heads/}" "${{ matrix.default_branch }}"; do
+          for BRANCH_NAME in "$GITHUB_HEAD_REF" "${GITHUB_REF#refs/heads/}" "${{ matrix.default_branch }}"; do
             # Skip empty branch names and merge commits.
             if [[ -z "$BRANCH_NAME" || $BRANCH_NAME =~ ^refs/pull/.* ]]; then
               continue

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,8 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: "Checkout corresponding ${{ matrix.homeserver }} branch"
+        # This is only done for Synapse since Dendrite's docker file pulls in
+        # the Dendrite sources directly.
         if: ${{ matrix.homeserver == 'Synapse' }}
         shell: bash
         run: |
@@ -67,6 +69,9 @@ jobs:
 
       # Build initial homeserver image
       - run: docker build -t matrixdotorg/synapse:latest -f docker/Dockerfile .
+        # We only do this for Synapse since Dendrite's docker file pulls in
+        # the Dendrite sources directly (instead of being based on a previously
+        # built docker image).
         if: ${{ matrix.homeserver == 'Synapse' }}
         working-directory: homeserver
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,7 +49,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p homeserver
-          # Attempt to use the version of of the homeserver which best matches the
+          # Attempt to use the version of the homeserver which best matches the
           # current build. Depending on whether this is a PR or release, etc. we
           # need to use different fallbacks.
           #

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,7 +55,7 @@ jobs:
           #
           # 1. First check if there's a similarly named branch (GITHUB_HEAD_REF
           #    for pull requests, otherwise GITHUB_REF).
-          # 3. Use the default homeserver branch.
+          # 2. Use the default homeserver branch.
           for BRANCH_NAME in "$GITHUB_HEAD_REF" "${GITHUB_REF#refs/heads/}" "${{ matrix.default_branch }}"; do
             # Skip empty branch names and merge commits.
             if [[ -z "$BRANCH_NAME" || $BRANCH_NAME =~ ^refs/pull/.* ]]; then

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,9 +25,11 @@ jobs:
         include:
           - homeserver: Synapse
             tags: synapse_blacklist,msc2403,msc2946,msc3083
+            default_branch: develop
 
           - homeserver: Dendrite
             tags: msc2836 dendrite_blacklist
+            default_branch: master
 
     container:
       image: matrixdotorg/complement  # dockerfiles/ComplementCIBuildkite.Dockerfile
@@ -41,6 +43,35 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
+      - name: "Checkout corresponding ${{ matrix.homeserver }} branch"
+        if: ${{ matrix.homeserver == 'Synapse' }}
+        shell: bash
+        run: |
+          mkdir -p homeserver
+          # Attempt to use the version of of the homeserver which best matches the
+          # current build. Depending on whether this is a PR or release, etc. we
+          # need to use different fallbacks.
+          #
+          # 1. First check if there's a similarly named branch (GITHUB_HEAD_REF
+          #    for pull requests, otherwise GITHUB_REF).
+          # 2. Attempt to use the base branch, e.g. when merging into release-vX.Y
+          #    (GITHUB_BASE_REF for pull requests).
+          # 3. Use the default homeserver branch.
+          for BRANCH_NAME in "$GITHUB_HEAD_REF" "$GITHUB_BASE_REF" "${GITHUB_REF#refs/heads/}" "${{ matrix.default_branch }}"; do
+            # Skip empty branch names and merge commits.
+            if [[ -z "$BRANCH_NAME" || $BRANCH_NAME =~ ^refs/pull/.* ]]; then
+              continue
+            fi
+
+            (wget -O - "https://github.com/matrix-org/${{ matrix.homeserver }}/archive/$BRANCH_NAME.tar.gz" | tar -xz --strip-components=1 -C homeserver) && break
+          done
+
+      # Build initial homeserver image
+      - run: docker build -t matrixdotorg/synapse:latest -f docker/Dockerfile .
+        if: ${{ matrix.homeserver == 'Synapse' }}
+        working-directory: homeserver
+
       - run: docker build -t homeserver -f dockerfiles/${{ matrix.homeserver }}.Dockerfile dockerfiles/
       - run: go test -p 2 -v -tags "${{ matrix.tags }}" ./tests/...
         env:


### PR DESCRIPTION
This matches matrix-org/pipelines#158, but for GHA.

The code is cribbed from matrix-org/synapse#10160, and made somewhat homeserver-agnostic, but it seems that Dendrite actually pulls the code it needs as part of building the Docker image, so it is quite different.

This fixes the tests in #145