### PR TITLE
Use stable room version 8 for MSC3083 tests.

### DIFF
--- a/tests/msc3083_test.go
+++ b/tests/msc3083_test.go
@@ -53,7 +53,7 @@ func setupRestrictedRoom(t *testing.T, deployment *docker.Deployment) (*client.C
 	room := alice.CreateRoom(t, map[string]interface{}{
 		"preset":       "public_chat",
 		"name":         "Room",
-		"room_version": "org.matrix.msc3083.v2",
+		"room_version": "8",
 		"initial_state": []map[string]interface{}{
 			{
 				"type":      "m.room.join_rules",
@@ -204,7 +204,7 @@ func TestRestrictedRoomsRemoteJoinLocalUser(t *testing.T) {
 	room := charlie.CreateRoom(t, map[string]interface{}{
 		"preset":       "public_chat",
 		"name":         "Room",
-		"room_version": "org.matrix.msc3083.v2",
+		"room_version": "8",
 		"initial_state": []map[string]interface{}{
 			{
 				"type":      "m.room.join_rules",
@@ -358,7 +358,7 @@ func TestRestrictedRoomsSpacesSummary(t *testing.T) {
 	room := alice.CreateRoom(t, map[string]interface{}{
 		"preset":       "public_chat",
 		"name":         "Room",
-		"room_version": "org.matrix.msc3083.v2",
+		"room_version": "8",
 		"initial_state": []map[string]interface{}{
 			{
 				"type":      "m.room.join_rules",
@@ -441,7 +441,7 @@ func TestRestrictedRoomsSpacesSummaryFederation(t *testing.T) {
 	room := charlie.CreateRoom(t, map[string]interface{}{
 		"preset":       "public_chat",
 		"name":         "Room",
-		"room_version": "org.matrix.msc3083.v2",
+		"room_version": "8",
 		"initial_state": []map[string]interface{}{
 			{
 				"type":      "m.room.join_rules",


### PR DESCRIPTION
To correspond with matrix-org/synapse#10449.

This should not be merged until [MSC3289](https://github.com/matrix-org/matrix-doc/pull/3289) is merged.