### PR TITLE
Fix the build for the master branch for synapse.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,10 +55,14 @@ jobs:
           # current build. Depending on whether this is a PR or release, etc. we
           # need to use different fallbacks.
           #
-          # 1. First check if there's a similarly named branch (GITHUB_HEAD_REF
-          #    for pull requests, otherwise GITHUB_REF).
-          # 2. Use the default homeserver branch.
-          for BRANCH_NAME in "$GITHUB_HEAD_REF" "${GITHUB_REF#refs/heads/}" "${{ matrix.default_branch }}"; do
+          # Check if there's a similarly named branch (GITHUB_HEAD_REF for pull
+          # requests, otherwise GITHUB_REF), but if this is the default complement
+          # branch, use the default homeserver branch.
+          if [[ "$GITHUB_HEAD_REF" == "master" ]]
+            GITHUB_HEAD_REF="${{ matrix.default_branch }}"
+          fi
+
+          for BRANCH_NAME in "$GITHUB_HEAD_REF" "${GITHUB_REF#refs/heads/}"; do
             # Skip empty branch names and merge commits.
             if [[ -z "$BRANCH_NAME" || $BRANCH_NAME =~ ^refs/pull/.* ]]; then
               continue

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,14 +55,15 @@ jobs:
           # current build. Depending on whether this is a PR or release, etc. we
           # need to use different fallbacks.
           #
-          # Check if there's a similarly named branch (GITHUB_HEAD_REF for pull
-          # requests, otherwise GITHUB_REF), but if this is the default complement
-          # branch, use the default homeserver branch.
+          # 1. Check if there's a similarly named branch (GITHUB_HEAD_REF for pull
+          #    requests, otherwise GITHUB_REF), but if this is the default complement
+          #    branch, use the default homeserver branch.
+          # 2. Use the default homeserver branch.
           if [[ "$GITHUB_HEAD_REF" == "master" ]]
             GITHUB_HEAD_REF="${{ matrix.default_branch }}"
           fi
 
-          for BRANCH_NAME in "$GITHUB_HEAD_REF" "${GITHUB_REF#refs/heads/}"; do
+          for BRANCH_NAME in "$GITHUB_HEAD_REF" "${GITHUB_REF#refs/heads/}" "${{ matrix.default_branch }}"; do
             # Skip empty branch names and merge commits.
             if [[ -z "$BRANCH_NAME" || $BRANCH_NAME =~ ^refs/pull/.* ]]; then
               continue

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,7 +59,7 @@ jobs:
           #    requests, otherwise GITHUB_REF), but if this is the default complement
           #    branch, use the default homeserver branch.
           # 2. Use the default homeserver branch.
-          if [[ "$GITHUB_HEAD_REF" == "master" ]]
+          if [[ "$GITHUB_HEAD_REF" == "master" ]]; then
             GITHUB_HEAD_REF="${{ matrix.default_branch }}"
           fi
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,14 +59,15 @@ jobs:
           #    requests, otherwise GITHUB_REF), but if this is the default complement
           #    branch, use the default homeserver branch.
           # 2. Use the default homeserver branch.
-          if [[ "$GITHUB_HEAD_REF" == "master" ]]; then
-            GITHUB_HEAD_REF="${{ matrix.default_branch }}"
-          fi
-
           for BRANCH_NAME in "$GITHUB_HEAD_REF" "${GITHUB_REF#refs/heads/}" "${{ matrix.default_branch }}"; do
             # Skip empty branch names and merge commits.
             if [[ -z "$BRANCH_NAME" || $BRANCH_NAME =~ ^refs/pull/.* ]]; then
               continue
+            fi
+
+            # If this is complement's default branch, use the homeserver's default branch.
+            if [[ "$BRANCH_NAME" == "master" ]]; then
+              BRANCH_NAME="${{ matrix.default_branch }}"
             fi
 
             (wget -O - "https://github.com/matrix-org/${{ matrix.homeserver }}/archive/$BRANCH_NAME.tar.gz" | tar -xz --strip-components=1 -C homeserver) && break


### PR DESCRIPTION
When the `master` branch of complement is built we want to run against the *default homeserver branch*, not the `master` branch (which will most likely always exist).

Fixes #184