### PR TITLE
Ensure many batches are able to be imported (MSC2716)

### DIFF
--- a/tests/msc2716_test.go
+++ b/tests/msc2716_test.go
@@ -226,6 +226,9 @@ func TestBackfillingHistory(t *testing.T) {
 			// eventIDsAfter
 			createMessagesInRoom(t, alice, roomID, 2)
 
+			// Import a long chain of batches connected to each other.
+			// We want to make sure Synapse doesn't blow up after we import
+			// many messages.
 			nextBatchID := ""
 			for i := 0; i < numBatches; i++ {
 				insertTime := timeAfterEventBefore.Add(timeBetweenMessages * time.Duration(numBatches-numHistoricalMessagesPerBatch*i))


### PR DESCRIPTION
Ensure many batches are able to be imported and `/messages` still gives us a 200 OK.

Used to reproduce https://gitlab.com/gitterHQ/webapp/-/merge_requests/2229#note_665906390 which led to the fix in Synapse, https://github.com/matrix-org/synapse/pull/11027.

Part of MSC2716: https://github.com/matrix-org/matrix-doc/pull/2716