### PR TITLE
Fix Go lints and errors from month old test in #207 (MSC2716)

### DIFF
--- a/tests/msc2716_test.go
+++ b/tests/msc2716_test.go
@@ -399,15 +399,15 @@ func TestImportHistoricalMessages(t *testing.T) {
 			})
 
 			txnId := getTxnID("duplicateinsertion-txn")
-			res := alice.DoFunc(t, "PUT", []string{"_matrix", "client", "r0", "rooms", roomID, "send", insertionEventType, txnId}, map[string]interface{}{
+			res := alice.DoFunc(t, "PUT", []string{"_matrix", "client", "r0", "rooms", roomID, "send", insertionEventType, txnId}, client.WithJSONBody(t, map[string]interface{}{
 				nextBatchIDContentField: "same",
 				historicalContentField:  true,
-			})
+			}))
 
 			// We expect the send request for the duplicate insertion event to fail
 			expectedStatus := 400
 			if res.StatusCode != expectedStatus {
-				t.Fatalf("Expected HTTP Status to be %s but received %s", expectedStatus, res.StatusCode)
+				t.Fatalf("Expected HTTP Status to be %d but received %d", expectedStatus, res.StatusCode)
 			}
 		})
 


### PR DESCRIPTION
Fix Go lints and errors from month old test in https://github.com/matrix-org/complement/pull/207

Looks like some forgotten stuff around the functional client and not sure how the string interpolation worked before.