### PR TITLE
Use sub-tests for restricted join tests

### DIFF
--- a/internal/must/must.go
+++ b/internal/must/must.go
@@ -66,6 +66,20 @@ func MatchRequest(t *testing.T, req *http.Request, m match.HTTPRequest) []byte {
 	return body
 }
 
+// MatchSuccess consumes the HTTP response and fails if the response is non-2xx.
+func MatchSuccess(t *testing.T, res *http.Response) {
+	if res.StatusCode < 200 || res.StatusCode > 299 {
+		t.Fatalf("MatchSuccess got status %d instead of a success code", res.StatusCode)
+	}
+}
+
+// MatchFailure consumes the HTTP response and fails if the response is 2xx.
+func MatchFailure(t *testing.T, res *http.Response) {
+	if res.StatusCode >= 200 && res.StatusCode <= 299 {
+		t.Fatalf("MatchFailure got status %d instead of a failure code", res.StatusCode)
+	}
+}
+
 // MatchResponse consumes the HTTP response and performs HTTP-level assertions on it. Returns the raw response body.
 func MatchResponse(t *testing.T, res *http.Response, m match.HTTPResponse) []byte {
 	t.Helper()

--- a/tests/restricted_rooms_test.go
+++ b/tests/restricted_rooms_test.go
@@ -71,11 +71,11 @@ func setupRestrictedRoom(t *testing.T, deployment *docker.Deployment) (*client.C
 func checkRestrictedRoom(t *testing.T, alice *client.CSAPI, bob *client.CSAPI, allowed_room string, room string) {
 	t.Helper()
 
-	t.Run("JoinShouldFailInitially", func(t *testing.T) {
+	t.Run("Join should fail initially", func(t *testing.T) {
 		failJoinRoom(t, bob, room, "hs1")
 	})
 
-	t.Run("JoinShouldSucceedWhenJoinedToAllowedRoom", func(t *testing.T) {
+	t.Run("Join should succeed when joined to allowed room", func(t *testing.T) {
 		// Join the allowed room, attempt to join the room again, which now should succeed.
 		bob.JoinRoom(t, allowed_room, []string{"hs1"})
 		bob.JoinRoom(t, room, []string{"hs1"})
@@ -98,7 +98,7 @@ func checkRestrictedRoom(t *testing.T, alice *client.CSAPI, bob *client.CSAPI, a
 		)
 	})
 
-	t.Run("JoinShouldFailWhenLeftAllowedRoom", func(t *testing.T) {
+	t.Run("Join should fail when left allowed room", func(t *testing.T) {
 		// Leaving the room works and the user is unable to re-join.
 		bob.LeaveRoom(t, room)
 		bob.LeaveRoom(t, allowed_room)
@@ -117,7 +117,7 @@ func checkRestrictedRoom(t *testing.T, alice *client.CSAPI, bob *client.CSAPI, a
 		failJoinRoom(t, bob, room, "hs1")
 	})
 
-	t.Run("JoinShouldSucceedWhenInvited", func(t *testing.T) {
+	t.Run("Join should succeed when invited", func(t *testing.T) {
 		// Invite the user and joining should work.
 		alice.InviteRoom(t, room, bob.UserID)
 		bob.JoinRoom(t, room, []string{"hs1"})
@@ -127,7 +127,7 @@ func checkRestrictedRoom(t *testing.T, alice *client.CSAPI, bob *client.CSAPI, a
 		bob.JoinRoom(t, allowed_room, []string{"hs1"})
 	})
 
-	t.Run("JoinShouldFailWithMangledJoinRules", func(t *testing.T) {
+	t.Run("Join should fail with mangled join rules", func(t *testing.T) {
 		// Update the room to have bad values in the "allow" field, which should stop
 		// joining from working properly.
 		emptyStateKey := ""

--- a/tests/restricted_rooms_test.go
+++ b/tests/restricted_rooms_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/matrix-org/complement/internal/must"
 )
 
-func failJoinRoom(t *testing.T, c *client.CSAPI, roomIDOrAlias string, serverName string, _ int) {
+func failJoinRoom(t *testing.T, c *client.CSAPI, roomIDOrAlias string, serverName string) {
 	t.Helper()
 
 	// This is copied from Client.JoinRoom to test a join failure.
@@ -72,7 +72,7 @@ func checkRestrictedRoom(t *testing.T, alice *client.CSAPI, bob *client.CSAPI, a
 	t.Helper()
 
 	t.Run("JoinShouldFailInitially", func(t *testing.T) {
-		failJoinRoom(t, bob, room, "hs1", 403)
+		failJoinRoom(t, bob, room, "hs1")
 	})
 
 	t.Run("JoinShouldSucceedWhenJoinedToAllowedRoom", func(t *testing.T) {
@@ -114,7 +114,7 @@ func checkRestrictedRoom(t *testing.T, alice *client.CSAPI, bob *client.CSAPI, a
 			return ev.Get("content").Get("membership").Str == "leave"
 		})
 
-		failJoinRoom(t, bob, room, "hs1", 403)
+		failJoinRoom(t, bob, room, "hs1")
 	})
 
 	t.Run("JoinShouldSucceedWhenInvited", func(t *testing.T) {
@@ -145,7 +145,7 @@ func checkRestrictedRoom(t *testing.T, alice *client.CSAPI, bob *client.CSAPI, a
 			},
 		)
 		// Fails since invalid values get filtered out of allow.
-		failJoinRoom(t, bob, room, "hs1", 403)
+		failJoinRoom(t, bob, room, "hs1")
 
 		alice.SendEventSynced(
 			t,
@@ -161,7 +161,7 @@ func checkRestrictedRoom(t *testing.T, alice *client.CSAPI, bob *client.CSAPI, a
 			},
 		)
 		// Fails since a fully invalid allow key requires an invite.
-		failJoinRoom(t, bob, room, "hs1", 403)
+		failJoinRoom(t, bob, room, "hs1")
 	})
 }
 
@@ -254,7 +254,7 @@ func TestRestrictedRoomsRemoteJoinLocalUser(t *testing.T) {
 	})
 
 	// Bob cannot join the room.
-	failJoinRoom(t, bob, room, "hs1", 403)
+	failJoinRoom(t, bob, room, "hs1")
 
 	// Join the allowed room via hs2.
 	bob.JoinRoom(t, allowed_room, []string{"hs2"})
@@ -383,7 +383,7 @@ func TestRestrictedRoomsRemoteJoinFailOver(t *testing.T) {
 	charlie.JoinRoom(t, allowed_room, []string{"hs1"})
 
 	// hs2 doesn't have anyone to invite from, so the join fails.
-	failJoinRoom(t, charlie, room, "hs2", 502)
+	failJoinRoom(t, charlie, room, "hs2")
 
 	// Including hs1 (and failing over to it) allows the join to succeed.
 	charlie.JoinRoom(t, room, []string{"hs2", "hs1"})
@@ -437,7 +437,7 @@ func TestRestrictedRoomsRemoteJoinFailOver(t *testing.T) {
 
 	// hs2 cannot complete the join since they do not know if Charlie meets the
 	// requirements (since it is no longer in the allowed room).
-	failJoinRoom(t, charlie, room, "hs2", 502)
+	failJoinRoom(t, charlie, room, "hs2")
 
 	// Including hs1 (and failing over to it) allows the join to succeed.
 	charlie.JoinRoom(t, room, []string{"hs2", "hs1"})

--- a/tests/restricted_rooms_test.go
+++ b/tests/restricted_rooms_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/matrix-org/complement/internal/must"
 )
 
-func failJoinRoom(t *testing.T, c *client.CSAPI, roomIDOrAlias string, serverName string, expectedErrorCode int) {
+func failJoinRoom(t *testing.T, c *client.CSAPI, roomIDOrAlias string, serverName string, _ int) {
 	t.Helper()
 
 	// This is copied from Client.JoinRoom to test a join failure.
@@ -27,9 +27,7 @@ func failJoinRoom(t *testing.T, c *client.CSAPI, roomIDOrAlias string, serverNam
 		[]string{"_matrix", "client", "r0", "join", roomIDOrAlias},
 		client.WithQueries(query),
 	)
-	must.MatchResponse(t, res, match.HTTPResponse{
-		StatusCode: expectedErrorCode,
-	})
+	must.MatchFailure(t, res)
 }
 
 // Creates two rooms on room version 8 and sets the second room to have
@@ -73,88 +71,98 @@ func setupRestrictedRoom(t *testing.T, deployment *docker.Deployment) (*client.C
 func checkRestrictedRoom(t *testing.T, alice *client.CSAPI, bob *client.CSAPI, allowed_room string, room string) {
 	t.Helper()
 
-	failJoinRoom(t, bob, room, "hs1", 403)
-
-	// Join the allowed room, attempt to join the room again, which now should succeed.
-	bob.JoinRoom(t, allowed_room, []string{"hs1"})
-	bob.JoinRoom(t, room, []string{"hs1"})
-
-	// Joining the same room again should work fine (e.g. to change your display name).
-	bob.SendEventSynced(
-		t,
-		room,
-		b.Event{
-			Type:     "m.room.member",
-			Sender:   bob.UserID,
-			StateKey: &bob.UserID,
-			Content: map[string]interface{}{
-				"membership":  "join",
-				"displayname": "Bobby",
-				// This should be ignored since this is a join -> join transition.
-				"join_authorised_via_users_server": "unused",
-			},
-		},
-	)
-
-	// Leaving the room works and the user is unable to re-join.
-	bob.LeaveRoom(t, room)
-	bob.LeaveRoom(t, allowed_room)
-
-	// Wait until Alice sees Bob leave the allowed room. This ensures that Alice's HS
-	// has processed the leave before Bob tries rejoining, so that it rejects his
-	// attempt to join the room.
-	alice.SyncUntilTimelineHas(t, allowed_room, func(ev gjson.Result) bool {
-		if ev.Get("type").Str != "m.room.member" || ev.Get("sender").Str != bob.UserID {
-			return false
-		}
-
-		return ev.Get("content").Get("membership").Str == "leave"
+	t.Run("JoinShouldFailInitially", func(t *testing.T) {
+		failJoinRoom(t, bob, room, "hs1", 403)
 	})
 
-	failJoinRoom(t, bob, room, "hs1", 403)
+	t.Run("JoinShouldSucceedWhenJoinedToAllowedRoom", func(t *testing.T) {
+		// Join the allowed room, attempt to join the room again, which now should succeed.
+		bob.JoinRoom(t, allowed_room, []string{"hs1"})
+		bob.JoinRoom(t, room, []string{"hs1"})
 
-	// Invite the user and joining should work.
-	alice.InviteRoom(t, room, bob.UserID)
-	bob.JoinRoom(t, room, []string{"hs1"})
-
-	// Leave the room again, and join the allowed room.
-	bob.LeaveRoom(t, room)
-	bob.JoinRoom(t, allowed_room, []string{"hs1"})
-
-	// Update the room to have bad values in the "allow" field, which should stop
-	// joining from working properly.
-	emptyStateKey := ""
-	alice.SendEventSynced(
-		t,
-		room,
-		b.Event{
-			Type:     "m.room.join_rules",
-			Sender:   alice.UserID,
-			StateKey: &emptyStateKey,
-			Content: map[string]interface{}{
-				"join_rule": "restricted",
-				"allow":     []string{"invalid"},
+		// Joining the same room again should work fine (e.g. to change your display name).
+		bob.SendEventSynced(
+			t,
+			room,
+			b.Event{
+				Type:     "m.room.member",
+				Sender:   bob.UserID,
+				StateKey: &bob.UserID,
+				Content: map[string]interface{}{
+					"membership":  "join",
+					"displayname": "Bobby",
+					// This should be ignored since this is a join -> join transition.
+					"join_authorised_via_users_server": "unused",
+				},
 			},
-		},
-	)
-	// Fails since invalid values get filtered out of allow.
-	failJoinRoom(t, bob, room, "hs1", 403)
+		)
+	})
 
-	alice.SendEventSynced(
-		t,
-		room,
-		b.Event{
-			Type:     "m.room.join_rules",
-			Sender:   alice.UserID,
-			StateKey: &emptyStateKey,
-			Content: map[string]interface{}{
-				"join_rule": "restricted",
-				"allow":     "invalid",
+	t.Run("JoinShouldFailWhenLeftAllowedRoom", func(t *testing.T) {
+		// Leaving the room works and the user is unable to re-join.
+		bob.LeaveRoom(t, room)
+		bob.LeaveRoom(t, allowed_room)
+
+		// Wait until Alice sees Bob leave the allowed room. This ensures that Alice's HS
+		// has processed the leave before Bob tries rejoining, so that it rejects his
+		// attempt to join the room.
+		alice.SyncUntilTimelineHas(t, allowed_room, func(ev gjson.Result) bool {
+			if ev.Get("type").Str != "m.room.member" || ev.Get("sender").Str != bob.UserID {
+				return false
+			}
+
+			return ev.Get("content").Get("membership").Str == "leave"
+		})
+
+		failJoinRoom(t, bob, room, "hs1", 403)
+	})
+
+	t.Run("JoinShouldSucceedWhenInvited", func(t *testing.T) {
+		// Invite the user and joining should work.
+		alice.InviteRoom(t, room, bob.UserID)
+		bob.JoinRoom(t, room, []string{"hs1"})
+
+		// Leave the room again, and join the allowed room.
+		bob.LeaveRoom(t, room)
+		bob.JoinRoom(t, allowed_room, []string{"hs1"})
+	})
+
+	t.Run("JoinShouldFailWithMangledJoinRules", func(t *testing.T) {
+		// Update the room to have bad values in the "allow" field, which should stop
+		// joining from working properly.
+		emptyStateKey := ""
+		alice.SendEventSynced(
+			t,
+			room,
+			b.Event{
+				Type:     "m.room.join_rules",
+				Sender:   alice.UserID,
+				StateKey: &emptyStateKey,
+				Content: map[string]interface{}{
+					"join_rule": "restricted",
+					"allow":     []string{"invalid"},
+				},
 			},
-		},
-	)
-	// Fails since a fully invalid allow key requires an invite.
-	failJoinRoom(t, bob, room, "hs1", 403)
+		)
+		// Fails since invalid values get filtered out of allow.
+		failJoinRoom(t, bob, room, "hs1", 403)
+
+		alice.SendEventSynced(
+			t,
+			room,
+			b.Event{
+				Type:     "m.room.join_rules",
+				Sender:   alice.UserID,
+				StateKey: &emptyStateKey,
+				Content: map[string]interface{}{
+					"join_rule": "restricted",
+					"allow":     "invalid",
+				},
+			},
+		)
+		// Fails since a fully invalid allow key requires an invite.
+		failJoinRoom(t, bob, room, "hs1", 403)
+	})
 }
 
 // Test joining a room with join rules restricted to membership in another room.


### PR DESCRIPTION
The sub-tests make it clearer which parts of the test are failing and which are succeeding.

This also adds `MatchSuccess` and `MatchFailure` for wider checks of whether something had failed or not (it's either in the HTTP 200 range or it isn't), rather than checking specific error codes.