### PR TITLE
Improve federation_keys_test.go

### DIFF
--- a/tests/federation_keys_test.go
+++ b/tests/federation_keys_test.go
@@ -29,60 +29,215 @@ import (
 func TestInboundFederationKeys(t *testing.T) {
 	deployment := Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
+
 	fedClient := &http.Client{
 		Timeout:   10 * time.Second,
 		Transport: &docker.RoundTripper{Deployment: deployment},
 	}
+
 	res, err := fedClient.Get("https://hs1/_matrix/key/v2/server")
 	must.NotError(t, "failed to GET /keys", err)
-	var key ed25519.PublicKey
-	var keyID string
+
+	var keys map[string]ed25519.PublicKey
+	var oldKeys map[string]ed25519.PublicKey
+
 	body := must.MatchResponse(t, res, match.HTTPResponse{
 		StatusCode: 200,
 		JSON: []match.JSON{
-			match.JSONKeyPresent("old_verify_keys"),
+			match.JSONKeyTypeEqual("valid_until_ts", gjson.Number),
 			match.JSONKeyEqual("server_name", "hs1"),
+
+			// Check validity of verify_keys+old_verify_keys and store values
 			match.JSONMapEach("verify_keys", func(k, v gjson.Result) error {
 				// Currently we always expect ed25519 keys
 				if !strings.HasPrefix(k.Str, "ed25519:") {
-					return fmt.Errorf("complement: unknown key ID type, only ed25519 is supported, got '%s'", k.Str)
+					return fmt.Errorf("complement: Key '%s' has no 'ed25519:' prefix", k.Str)
 				}
+
+				key := v.Get("key")
+
+				// Test key existence and string type
+				if !key.Exists() {
+					return fmt.Errorf("verify_keys: Key '%s' has no expired_ts in value", k.Str)
+				}
+				if key.Type != gjson.String {
+					return fmt.Errorf("verify_keys: Key '%s' has expired_ts with unexpected type, expected String, got '%s'", k.Str, key.Type.String())
+				}
+
 				var keyBytes []byte
-				keyBytes, err = base64.RawStdEncoding.DecodeString(v.Get("key").Str)
+				keyBytes, err = base64.RawStdEncoding.DecodeString(key.Str)
 				if err != nil {
-					return fmt.Errorf("Failed to decode ed25519 key as base64: %s", err)
+					return fmt.Errorf("verify_keys: Key '%s' failed to decode as ed25519 base64: %s", k.Str, err)
 				}
-				// slightly evil to side-effect like this, but it's the easiest way
-				keyID = k.Str
-				key = keyBytes
+
+				keys[k.Str] = keyBytes
+				return nil
+			}),
+			match.JSONMapEach("old_verify_keys", func(k, v gjson.Result) error {
+				// Check for ed25519 prefix
+				if !strings.HasPrefix(k.Str, "ed25519:") {
+					return fmt.Errorf("old_verify_keys: Key '%s' has no 'ed25519:' prefix", k.Str)
+				}
+
+				expiredTs := v.Get("expired_ts")
+
+				// Test expired_ts existence and number type
+				if !expiredTs.Exists() {
+					return fmt.Errorf("old_verify_keys: Key '%s' has no expired_ts in value", k.Str)
+				}
+				if expiredTs.Type != gjson.Number {
+					return fmt.Errorf("old_verify_keys: Key '%s' has expired_ts with unexpected type, expected Number, got '%s'", k.Str, expiredTs.Type.String())
+				}
+
+				key := v.Get("key")
+
+				// Test key existence and string type
+				if !key.Exists() {
+					return fmt.Errorf("old_verify_keys: Key '%s' has no expired_ts in value", k.Str)
+				}
+				if key.Type != gjson.String {
+					return fmt.Errorf("old_verify_keys: Key '%s' has expired_ts with unexpected type, expected String, got '%s'", k.Str, key.Type.String())
+				}
+
+				var keyBytes []byte
+				keyBytes, err = base64.RawStdEncoding.DecodeString(key.Str)
+				if err != nil {
+					return fmt.Errorf("old_verify_keys: Key '%s' failed to decode as ed25519 base64: %s", k.Str, err)
+				}
+
+				oldKeys[k.Str] = keyBytes
+
+				return nil
+			}),
+
+			// Check signatures
+			match.JSONMapEach("signatures", func(k, v gjson.Result) error {
+				if !v.IsObject() {
+					return fmt.Errorf("signatures: Value for server '%s' is not an object", k.Str)
+				}
+
+				for key, v := range v.Map() {
+					// Check for ed25519 prefix
+					if !strings.HasPrefix(key, "ed25519:") {
+						return fmt.Errorf("signatures: Key '%s' for server '%s' has no 'ed25519:' prefix", key, k)
+					}
+
+					if v.Type != gjson.String {
+						return fmt.Errorf("signatures: Key '%s' for server '%s' has unexpected type, expected String, got '%s'", k.Str, v.Type.String())
+					}
+
+					_, err = base64.RawStdEncoding.DecodeString(v.Str)
+					if err != nil {
+						return fmt.Errorf("old_verify_keys: Key '%s' failed to decode as ed25519 base64: %s", k.Str, err)
+					}
+				}
+
 				return nil
 			}),
 		},
 	})
+
 	jsonObj := gjson.ParseBytes(body)
 	gotTime := time.Unix(0, jsonObj.Get("valid_until_ts").Int()*1000*1000) // ms -> ns
 	wantTime := time.Now()
 	if gotTime.Before(wantTime) {
-		t.Errorf("valid_until_ts : timestamp is in the past: %s < %s", gotTime, wantTime)
+		t.Errorf("valid_until_ts: timestamp is in the past: %s < %s", gotTime, wantTime)
 	}
 
-	if keyID == "" {
-		t.Fatalf("missing ed25519: key")
+	if len(keys) == 0 {
+		t.Fatalf("verify_keys: missing any ed25519: key")
 	}
-	sigBase64 := jsonObj.Get(fmt.Sprintf("signatures.hs1.%s", keyID))
-	if !sigBase64.Exists() {
-		t.Fatalf("missing signature for hs1.%s", keyID)
+
+	if len(oldKeys) > 0 {
+		// Check if any old key exists in the new keys
+		for k := range oldKeys {
+			if _, ok := keys[k]; ok {
+				t.Fatalf("old_verify_keys: Key '%s' exists in both old_verify_keys and verify_keys", k)
+			}
+		}
 	}
-	sigBytes, err := base64.RawStdEncoding.DecodeString(sigBase64.Str)
-	if err != nil {
-		t.Fatalf("unable to decode base64 signature: %s", err.Error())
+
+	sigObj := jsonObj.Get("signatures").Map()
+
+	// Test signatures object sanity
+	if _, ok := sigObj["hs1"]; !ok {
+		t.Fatalf("signatures: Did not contain server key for 'hs1'")
+	}
+
+	if len(sigObj) > 1 {
+		var extraKeys []string
+		for k := range sigObj {
+			if k == "hs1" {
+				continue
+			}
+			extraKeys = append(extraKeys, k)
+		}
+		t.Fatalf("signatures: Contained more than one server keys, extra keys: %s", strings.Join(extraKeys, ", "))
+	}
+
+	sigServerObj := sigObj["hs1"].Map()
+
+	type sigWithKey struct {
+		signature []byte
+		key       ed25519.PublicKey
+		old       bool
+	}
+
+	var signatures map[string]sigWithKey
+
+	// Test signatures for all verify_keys, these *have* to exist.
+	for keyName, keyBytes := range keys {
+		sigBase64 := jsonObj.Get(fmt.Sprintf("signatures.hs1.%s", keyName))
+		if !sigBase64.Exists() {
+			t.Fatalf("signatures: missing signature for Key '%s'", keyName)
+		}
+
+		if sigBase64.Type != gjson.String {
+			t.Fatalf("signatures: Signature for Key '%s' has unexpected type, expected String, got '%s'", keyName, sigBase64.Type.String())
+		}
+		sigBytes, err := base64.RawStdEncoding.DecodeString(sigBase64.Str)
+		if err != nil {
+			t.Fatalf("signatures: Signature for key '%s' failed to decode as ed25519 base64: %s", keyName, err)
+		}
+
+		signatures[keyName] = sigWithKey{key: keyBytes, signature: sigBytes, old: false}
+	}
+
+	// Check if there's any leftover signatures, add them if they exist in the expired keys
+	for keyName, sig := range sigServerObj {
+		if _, ok := signatures[keyName]; ok {
+			continue
+		}
+
+		// Found a signature that was leftover, this *should* be an expired key, if not, abort.
+		keyBytes, ok := oldKeys[keyName]
+		if !ok {
+			t.Fatalf("signatures: Unknown signature for key '%s'", keyName)
+		}
+
+		if sig.Type != gjson.String {
+			t.Fatalf("signatures: Signature for Old Key '%s' has unexpected type, expected String, got '%s'", keyName, sig.Type.String())
+		}
+		sigBytes, err := base64.RawStdEncoding.DecodeString(sig.Str)
+		if err != nil {
+			t.Fatalf("signatures: Signature for Old key '%s' failed to decode as ed25519 base64: %s", keyName, err)
+		}
+
+		signatures[keyName] = sigWithKey{key: keyBytes, signature: sigBytes, old: true}
 	}
 
 	bodyWithoutSig, err := sjson.DeleteBytes(body, "signatures")
 	if err != nil {
 		t.Fatalf("failed to delete 'signatures' key: %s", err)
 	}
-	if !ed25519.Verify(key, bodyWithoutSig, sigBytes) {
-		t.Fatalf("message was not signed by server: %s", string(bodyWithoutSig))
+
+	for keyName, val := range signatures {
+		if !ed25519.Verify(val.key, bodyWithoutSig, val.signature) {
+			var oldClause = ""
+			if val.old {
+				oldClause = "Old "
+			}
+			t.Fatalf("Message signature failed to verify for %sKey '%s': %s", oldClause, keyName, string(bodyWithoutSig))
+		}
 	}
 }

--- a/tests/federation_keys_test.go
+++ b/tests/federation_keys_test.go
@@ -144,6 +144,12 @@ func TestInboundFederationKeys(t *testing.T) {
 		t.Errorf("valid_until_ts: timestamp is in the past: %s < %s", gotTime, wantTime)
 	}
 
+	checkKeysAndSignatures(t, body, jsonObj, keys, oldKeys)
+}
+
+func checkKeysAndSignatures(t *testing.T, body []byte, jsonObj gjson.Result, keys, oldKeys map[string]ed25519.PublicKey) {
+	var err error
+
 	if len(keys) == 0 {
 		t.Fatalf("verify_keys: missing any ed25519: key")
 	}

--- a/tests/federation_keys_test.go
+++ b/tests/federation_keys_test.go
@@ -119,11 +119,11 @@ func TestInboundFederationKeys(t *testing.T) {
 				for key, v := range v.Map() {
 					// Check for ed25519 prefix
 					if !strings.HasPrefix(key, "ed25519:") {
-						return fmt.Errorf("signatures: Key '%s' for server '%s' has no 'ed25519:' prefix", key, k)
+						return fmt.Errorf("signatures: Key '%s' for server '%s' has no 'ed25519:' prefix", key, k.Str)
 					}
 
 					if v.Type != gjson.String {
-						return fmt.Errorf("signatures: Key '%s' for server '%s' has unexpected type, expected String, got '%s'", k.Str, v.Type.String())
+						return fmt.Errorf("signatures: Key '%s' for server '%s' has unexpected type, expected String, got '%s'", key, k.Str, v.Type.String())
 					}
 
 					_, err = base64.RawStdEncoding.DecodeString(v.Str)
@@ -195,7 +195,9 @@ func TestInboundFederationKeys(t *testing.T) {
 		if sigBase64.Type != gjson.String {
 			t.Fatalf("signatures: Signature for Key '%s' has unexpected type, expected String, got '%s'", keyName, sigBase64.Type.String())
 		}
-		sigBytes, err := base64.RawStdEncoding.DecodeString(sigBase64.Str)
+
+		var sigBytes []byte
+		sigBytes, err = base64.RawStdEncoding.DecodeString(sigBase64.Str)
 		if err != nil {
 			t.Fatalf("signatures: Signature for key '%s' failed to decode as ed25519 base64: %s", keyName, err)
 		}
@@ -218,7 +220,9 @@ func TestInboundFederationKeys(t *testing.T) {
 		if sig.Type != gjson.String {
 			t.Fatalf("signatures: Signature for Old Key '%s' has unexpected type, expected String, got '%s'", keyName, sig.Type.String())
 		}
-		sigBytes, err := base64.RawStdEncoding.DecodeString(sig.Str)
+
+		var sigBytes []byte
+		sigBytes, err = base64.RawStdEncoding.DecodeString(sig.Str)
 		if err != nil {
 			t.Fatalf("signatures: Signature for Old key '%s' failed to decode as ed25519 base64: %s", keyName, err)
 		}
@@ -226,7 +230,8 @@ func TestInboundFederationKeys(t *testing.T) {
 		signatures[keyName] = sigWithKey{key: keyBytes, signature: sigBytes, old: true}
 	}
 
-	bodyWithoutSig, err := sjson.DeleteBytes(body, "signatures")
+	var bodyWithoutSig []byte
+	bodyWithoutSig, err = sjson.DeleteBytes(body, "signatures")
 	if err != nil {
 		t.Fatalf("failed to delete 'signatures' key: %s", err)
 	}

--- a/tests/federation_keys_test.go
+++ b/tests/federation_keys_test.go
@@ -58,10 +58,10 @@ func TestInboundFederationKeys(t *testing.T) {
 
 				// Test key existence and string type
 				if !key.Exists() {
-					return fmt.Errorf("verify_keys: Key '%s' has no expired_ts in value", k.Str)
+					return fmt.Errorf("verify_keys: Key '%s' has no 'key' field", k.Str)
 				}
 				if key.Type != gjson.String {
-					return fmt.Errorf("verify_keys: Key '%s' has expired_ts with unexpected type, expected String, got '%s'", k.Str, key.Type.String())
+					return fmt.Errorf("verify_keys: Key '%s' has 'key' with unexpected type, expected String, got '%s'", k.Str, key.Type.String())
 				}
 
 				var keyBytes []byte
@@ -93,10 +93,10 @@ func TestInboundFederationKeys(t *testing.T) {
 
 				// Test key existence and string type
 				if !key.Exists() {
-					return fmt.Errorf("old_verify_keys: Key '%s' has no expired_ts in value", k.Str)
+					return fmt.Errorf("old_verify_keys: Key '%s' has no 'key' field", k.Str)
 				}
 				if key.Type != gjson.String {
-					return fmt.Errorf("old_verify_keys: Key '%s' has expired_ts with unexpected type, expected String, got '%s'", k.Str, key.Type.String())
+					return fmt.Errorf("old_verify_keys: Key '%s' has 'key' with unexpected type, expected String, got '%s'", k.Str, key.Type.String())
 				}
 
 				var keyBytes []byte

--- a/tests/federation_keys_test.go
+++ b/tests/federation_keys_test.go
@@ -83,7 +83,7 @@ func TestInboundFederationKeys(t *testing.T) {
 
 				// Test expired_ts existence and number type
 				if !expiredTs.Exists() {
-					return fmt.Errorf("old_verify_keys: Key '%s' has no expired_ts in value", k.Str)
+					return fmt.Errorf("old_verify_keys: Key '%s' has no 'expired_ts' field", k.Str)
 				}
 				if expiredTs.Type != gjson.Number {
 					return fmt.Errorf("old_verify_keys: Key '%s' has expired_ts with unexpected type, expected Number, got '%s'", k.Str, expiredTs.Type.String())
@@ -193,17 +193,10 @@ func checkKeysAndSignatures(t *testing.T, body []byte, jsonObj gjson.Result, key
 
 	// Test signatures for all verify_keys, these *have* to exist.
 	for keyName, keyBytes := range keys {
-		sigBase64 := jsonObj.Get(fmt.Sprintf("signatures.hs1.%s", keyName))
-		if !sigBase64.Exists() {
-			t.Fatalf("signatures: missing signature for Key '%s'", keyName)
-		}
-
-		if sigBase64.Type != gjson.String {
-			t.Fatalf("signatures: Signature for Key '%s' has unexpected type, expected String, got '%s'", keyName, sigBase64.Type.String())
-		}
+		sigBase64 := must.GetJSONFieldStr(t, body, fmt.Sprintf("signatures.hs1.%s", keyName))
 
 		var sigBytes []byte
-		sigBytes, err = base64.RawStdEncoding.DecodeString(sigBase64.Str)
+		sigBytes, err = base64.RawStdEncoding.DecodeString(sigBase64)
 		if err != nil {
 			t.Fatalf("signatures: Signature for key '%s' failed to decode as ed25519 base64: %s", keyName, err)
 		}

--- a/tests/federation_keys_test.go
+++ b/tests/federation_keys_test.go
@@ -38,8 +38,8 @@ func TestInboundFederationKeys(t *testing.T) {
 	res, err := fedClient.Get("https://hs1/_matrix/key/v2/server")
 	must.NotError(t, "failed to GET /keys", err)
 
-	var keys map[string]ed25519.PublicKey
-	var oldKeys map[string]ed25519.PublicKey
+	var keys = map[string]ed25519.PublicKey{}
+	var oldKeys = map[string]ed25519.PublicKey{}
 
 	body := must.MatchResponse(t, res, match.HTTPResponse{
 		StatusCode: 200,
@@ -183,7 +183,7 @@ func TestInboundFederationKeys(t *testing.T) {
 		old       bool
 	}
 
-	var signatures map[string]sigWithKey
+	var signatures = map[string]sigWithKey{}
 
 	// Test signatures for all verify_keys, these *have* to exist.
 	for keyName, keyBytes := range keys {


### PR DESCRIPTION
I was taking a cursory glance at `federation_keys_test.go`, and comparing it with its sytest equivalent, when i noticed that the bare test would slip through a lot of potential problems, type mismatches, and other invariants.

I've cleaned those up a little, but some decisions are a bit opinionated.