### PR TITLE
Change `SyncUntil` to `SyncUntilArray`

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -216,11 +216,11 @@ func (c *CSAPI) SyncUntil(t *testing.T, since, filter, key string, check func(gj
 func (c *CSAPI) syncUntilInternal(t *testing.T, since, filter, key string, wasFailed, timedOut *bool, checkCounter *int, check func(gjson.Result) bool) {
 	t.Helper()
 	start := time.Now()
-	*checkCounter = 0
 
 	// Initialize values
 	*wasFailed = t.Failed()
 	*timedOut = false
+	*checkCounter = 0
 
 	for {
 		if time.Since(start) > c.SyncUntilTimeout {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -158,9 +158,14 @@ func (c *CSAPI) SyncUntilInvitedTo(t *testing.T, roomID string) {
 // If the `check` function fails the test, the failing value will be automatically logged.
 // Will time out after CSAPI.SyncUntilTimeout.
 func (c *CSAPI) SyncUntilArray(t *testing.T, since, filter, key string, check func(gjson.Result) bool) {
-	var wasFailed *bool
-	var timedOut *bool
-	var checkCounter *int
+	var wasFailedBacking = false
+	var timedOutBacking = false
+	var checkCounterBacking = 0
+
+	var wasFailed = &wasFailedBacking
+	var timedOut = &timedOutBacking
+	var checkCounter = &checkCounterBacking
+
 	var lastElement *gjson.Result
 
 	// Print failing events in a defer() so we handle t.Fatalf in the same way as t.Errorf
@@ -205,22 +210,19 @@ func (c *CSAPI) SyncUntilArray(t *testing.T, since, filter, key string, check fu
 // - the corresponding value makes the `check` function return true.
 // Will time out after CSAPI.SyncUntilTimeout.
 func (c *CSAPI) SyncUntil(t *testing.T, since, filter, key string, check func(gjson.Result) bool) {
-	var wasFailed *bool
-	var timedOut *bool
-	var checkCounter *int
+	var wasFailedBacking = false
+	var timedOutBacking = false
+	var checkCounterBacking = 0
 
-	c.syncUntilInternal(t, since, filter, key, wasFailed, timedOut, checkCounter, check)
+	c.syncUntilInternal(t, since, filter, key, &wasFailedBacking, &timedOutBacking, &checkCounterBacking, check)
 }
 
-// Internal function helping both SyncUntil and SyncUntilArray with some logging coordination upon failure
+// Internal function helping both SyncUntil and SyncUntilArray with some logging coordination upon failure.
 func (c *CSAPI) syncUntilInternal(t *testing.T, since, filter, key string, wasFailed, timedOut *bool, checkCounter *int, check func(gjson.Result) bool) {
 	t.Helper()
 	start := time.Now()
 
-	// Initialize values
 	*wasFailed = t.Failed()
-	*timedOut = false
-	*checkCounter = 0
 
 	for {
 		if time.Since(start) > c.SyncUntilTimeout {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -182,7 +182,7 @@ func (c *CSAPI) SyncUntilArray(t *testing.T, since, filter, key string, check fu
 			elements := result.Array()
 
 			for i, el := range elements {
-				lastElement = &el
+				lastElement = &elements[i]
 				if check(el) {
 					return true
 				}

--- a/tests/msc2403_test.go
+++ b/tests/msc2403_test.go
@@ -179,7 +179,7 @@ func knockingBetweenTwoUsersTest(t *testing.T, roomID string, inRoomUser, knocki
 
 			// Use our sync token from earlier to carry out an incremental sync. Initial syncs may not contain room
 			// leave information for obvious reasons
-			knockingUser.SyncUntil(
+			knockingUser.SyncUntilArray(
 				t,
 				since,
 				"",
@@ -311,7 +311,7 @@ func knockOnRoomSynced(t *testing.T, c *client.CSAPI, roomID, reason string, ser
 	knockOnRoomWithStatus(t, c, roomID, reason, serverNames, 200)
 
 	// The knock should have succeeded. Block until we see the knock appear down sync
-	c.SyncUntil(
+	c.SyncUntilArray(
 		t,
 		"",
 		"",

--- a/tests/msc2716_test.go
+++ b/tests/msc2716_test.go
@@ -263,7 +263,7 @@ func TestImportHistoricalMessages(t *testing.T) {
 			// eventIDAfterHistoricalImport without any the
 			// historicalEventIDs/historicalStateEventIDs in between, we're probably
 			// safe to assume it won't sync.
-			alice.SyncUntil(t, since, "", "rooms.join."+client.GjsonEscape(roomID)+".timeline.events", func(r gjson.Result) bool {
+			alice.SyncUntilArray(t, since, "", "rooms.join."+client.GjsonEscape(roomID)+".timeline.events", func(r gjson.Result) bool {
 				if includes(r.Get("event_id").Str, historicalEventIDs) || includes(r.Get("event_id").Str, historicalStateEventIDs) {
 					t.Fatalf("We should not see the %s historical event in /sync response but it was present", r.Get("event_id").Str)
 				}


### PR DESCRIPTION
Fixes https://github.com/matrix-org/complement/issues/245

Turns out i actually do need a `SyncUtil` as described above (for SYN-627, I need to receive events from different rooms and log them individually as they come in, I need to wait for and process an arbitrary value), so just I'll rename this alongside it.

I'm refactoring this in a seperate PR instead of the same PR for SYN-627, because this PR would be easier to review comparatively when bundled with the other helper function changes.