### PR TITLE
Put the federation tests under their own section be able to filter (MSC2716)

### DIFF
--- a/tests/msc2716_test.go
+++ b/tests/msc2716_test.go
@@ -549,338 +549,340 @@ func TestImportHistoricalMessages(t *testing.T) {
 			t.Skip("Skipping until implemented")
 		})
 
-		t.Run("Historical messages are visible when joining on federated server - auto-generated base insertion event", func(t *testing.T) {
-			t.Parallel()
+		t.Run("Federation", func(t *testing.T) {
+			t.Run("Historical messages are visible when joining on federated server - auto-generated base insertion event", func(t *testing.T) {
+				t.Parallel()
 
-			roomID := as.CreateRoom(t, createPublicRoomOpts)
-			alice.JoinRoom(t, roomID, nil)
+				roomID := as.CreateRoom(t, createPublicRoomOpts)
+				alice.JoinRoom(t, roomID, nil)
 
-			eventIDsBefore := createMessagesInRoom(t, alice, roomID, 1)
-			eventIdBefore := eventIDsBefore[0]
-			timeAfterEventBefore := time.Now()
+				eventIDsBefore := createMessagesInRoom(t, alice, roomID, 1)
+				eventIdBefore := eventIDsBefore[0]
+				timeAfterEventBefore := time.Now()
 
-			// eventIDsAfter
-			createMessagesInRoom(t, alice, roomID, 3)
+				// eventIDsAfter
+				createMessagesInRoom(t, alice, roomID, 3)
 
-			batchSendRes := batchSendHistoricalMessages(
-				t,
-				as,
-				roomID,
-				eventIdBefore,
-				"",
-				createJoinStateEventsForBatchSendRequest([]string{virtualUserID}, timeAfterEventBefore),
-				createMessageEventsForBatchSendRequest([]string{virtualUserID}, timeAfterEventBefore, 2),
-				// Status
-				200,
-			)
-			batchSendResBody := client.ParseJSON(t, batchSendRes)
-			historicalEventIDs := client.GetJSONFieldStringArray(t, batchSendResBody, "event_ids")
-			baseInsertionEventID := client.GetJSONFieldStr(t, batchSendResBody, "base_insertion_event_id")
+				batchSendRes := batchSendHistoricalMessages(
+					t,
+					as,
+					roomID,
+					eventIdBefore,
+					"",
+					createJoinStateEventsForBatchSendRequest([]string{virtualUserID}, timeAfterEventBefore),
+					createMessageEventsForBatchSendRequest([]string{virtualUserID}, timeAfterEventBefore, 2),
+					// Status
+					200,
+				)
+				batchSendResBody := client.ParseJSON(t, batchSendRes)
+				historicalEventIDs := client.GetJSONFieldStringArray(t, batchSendResBody, "event_ids")
+				baseInsertionEventID := client.GetJSONFieldStr(t, batchSendResBody, "base_insertion_event_id")
 
-			// Send the marker event which lets remote homeservers know there are
-			// some historical messages back at the given insertion event.
-			sendMarkerAndEnsureBackfilled(t, as, alice, roomID, baseInsertionEventID)
+				// Send the marker event which lets remote homeservers know there are
+				// some historical messages back at the given insertion event.
+				sendMarkerAndEnsureBackfilled(t, as, alice, roomID, baseInsertionEventID)
 
-			// Join the room from a remote homeserver after the historical messages were sent
-			remoteCharlie.JoinRoom(t, roomID, []string{"hs1"})
+				// Join the room from a remote homeserver after the historical messages were sent
+				remoteCharlie.JoinRoom(t, roomID, []string{"hs1"})
 
-			// Make sure all of the events have been backfilled
-			fetchUntilMessagesResponseHas(t, remoteCharlie, roomID, func(ev gjson.Result) bool {
-				if ev.Get("event_id").Str == eventIdBefore {
-					return true
+				// Make sure all of the events have been backfilled
+				fetchUntilMessagesResponseHas(t, remoteCharlie, roomID, func(ev gjson.Result) bool {
+					if ev.Get("event_id").Str == eventIdBefore {
+						return true
+					}
+
+					return false
+				})
+
+				// FIXME: In the future, we should probably replace the following logic
+				// with `validateBatchSendRes` to re-use and have some more robust
+				// assertion logic here. We're currently not using it because the message
+				// order isn't quite perfect when a remote federated homeserver gets
+				// backfilled.
+				// validateBatchSendRes(t, remoteCharlie, roomID, batchSendRes, false)
+				messagesRes := remoteCharlie.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "messages"}, client.WithContentType("application/json"), client.WithQueries(url.Values{
+					"dir":   []string{"b"},
+					"limit": []string{"100"},
+				}))
+
+				must.MatchResponse(t, messagesRes, match.HTTPResponse{
+					JSON: []match.JSON{
+						match.JSONCheckOffAllowUnwanted("chunk", makeInterfaceSlice(historicalEventIDs), func(r gjson.Result) interface{} {
+							return r.Get("event_id").Str
+						}, nil),
+					},
+				})
+			})
+
+			t.Run("Historical messages are visible when joining on federated server - pre-made insertion event", func(t *testing.T) {
+				t.Parallel()
+
+				roomID := as.CreateRoom(t, createPublicRoomOpts)
+				alice.JoinRoom(t, roomID, nil)
+
+				eventIDsBefore := createMessagesInRoom(t, alice, roomID, 1)
+				eventIdBefore := eventIDsBefore[0]
+				timeAfterEventBefore := time.Now()
+
+				// Create insertion event in the normal DAG
+				batchID := "mynextBatchID123"
+				insertionEvent := b.Event{
+					Type: insertionEventType,
+					Content: map[string]interface{}{
+						nextBatchIDContentField: batchID,
+						historicalContentField:  true,
+					},
+				}
+				// We can't use as.SendEventSynced(...) because application services can't use the /sync API
+				txnId := getTxnID("sendInsertionAndEnsureBackfilled-txn")
+				insertionSendRes := as.MustDoFunc(t, "PUT", []string{"_matrix", "client", "r0", "rooms", roomID, "send", insertionEvent.Type, txnId}, client.WithJSONBody(t, insertionEvent.Content))
+				insertionSendBody := client.ParseJSON(t, insertionSendRes)
+				insertionEventID := client.GetJSONFieldStr(t, insertionSendBody, "event_id")
+				// Make sure the insertion event has reached the homeserver
+				alice.SyncUntilTimelineHas(t, roomID, func(ev gjson.Result) bool {
+					return ev.Get("event_id").Str == insertionEventID
+				})
+
+				// eventIDsAfter
+				createMessagesInRoom(t, alice, roomID, 3)
+
+				batchSendRes := batchSendHistoricalMessages(
+					t,
+					as,
+					roomID,
+					eventIdBefore,
+					batchID,
+					createJoinStateEventsForBatchSendRequest([]string{virtualUserID}, timeAfterEventBefore),
+					createMessageEventsForBatchSendRequest([]string{virtualUserID}, timeAfterEventBefore, 2),
+					// Status
+					200,
+				)
+				batchSendResBody := client.ParseJSON(t, batchSendRes)
+				historicalEventIDs := client.GetJSONFieldStringArray(t, batchSendResBody, "event_ids")
+
+				// Send the marker event which lets remote homeservers know there are
+				// some historical messages back at the given insertion event.
+				sendMarkerAndEnsureBackfilled(t, as, alice, roomID, insertionEventID)
+
+				// Join the room from a remote homeserver after the historical messages were sent
+				remoteCharlie.JoinRoom(t, roomID, []string{"hs1"})
+
+				// Make sure all of the events have been backfilled
+				fetchUntilMessagesResponseHas(t, remoteCharlie, roomID, func(ev gjson.Result) bool {
+					if ev.Get("event_id").Str == eventIdBefore {
+						return true
+					}
+
+					return false
+				})
+
+				// FIXME: In the future, we should probably replace the following logic
+				// with `validateBatchSendRes` to re-use and have some more robust
+				// assertion logic here. We're currently not using it because the message
+				// order isn't quite perfect when a remote federated homeserver gets
+				// backfilled.
+				// validateBatchSendRes(t, remoteCharlie, roomID, batchSendRes, false)
+				messagesRes := remoteCharlie.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "messages"}, client.WithContentType("application/json"), client.WithQueries(url.Values{
+					"dir":   []string{"b"},
+					"limit": []string{"100"},
+				}))
+
+				must.MatchResponse(t, messagesRes, match.HTTPResponse{
+					JSON: []match.JSON{
+						match.JSONCheckOffAllowUnwanted("chunk", makeInterfaceSlice(historicalEventIDs), func(r gjson.Result) interface{} {
+							return r.Get("event_id").Str
+						}, nil),
+					},
+				})
+			})
+
+			t.Run("Historical messages are visible when already joined on federated server", func(t *testing.T) {
+				t.Parallel()
+
+				roomID := as.CreateRoom(t, createPublicRoomOpts)
+				alice.JoinRoom(t, roomID, nil)
+
+				// Join the room from a remote homeserver before any historical messages are sent
+				remoteCharlie.JoinRoom(t, roomID, []string{"hs1"})
+
+				eventIDsBefore := createMessagesInRoom(t, alice, roomID, 1)
+				eventIdBefore := eventIDsBefore[0]
+				timeAfterEventBefore := time.Now()
+
+				// eventIDsAfter
+				createMessagesInRoom(t, alice, roomID, 10)
+
+				// Mimic scrollback just through the latest messages
+				remoteCharlie.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "messages"}, client.WithContentType("application/json"), client.WithQueries(url.Values{
+					"dir": []string{"b"},
+					// Limited so we can only see a portion of the latest messages
+					"limit": []string{"5"},
+				}))
+
+				numMessagesSent := 2
+				batchSendRes := batchSendHistoricalMessages(
+					t,
+					as,
+					roomID,
+					eventIdBefore,
+					"",
+					createJoinStateEventsForBatchSendRequest([]string{virtualUserID}, timeAfterEventBefore),
+					createMessageEventsForBatchSendRequest([]string{virtualUserID}, timeAfterEventBefore, numMessagesSent),
+					// Status
+					200,
+				)
+				batchSendResBody := client.ParseJSON(t, batchSendRes)
+				historicalEventIDs := client.GetJSONFieldStringArray(t, batchSendResBody, "event_ids")
+				baseInsertionEventID := client.GetJSONFieldStr(t, batchSendResBody, "base_insertion_event_id")
+
+				if len(historicalEventIDs) != numMessagesSent {
+					t.Fatalf("Expected %d event_ids in the response that correspond to the %d events we sent in the request but saw %d: %s", numMessagesSent, numMessagesSent, len(historicalEventIDs), historicalEventIDs)
 				}
 
-				return false
+				beforeMarkerMessagesRes := remoteCharlie.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "messages"}, client.WithContentType("application/json"), client.WithQueries(url.Values{
+					"dir":   []string{"b"},
+					"limit": []string{"100"},
+				}))
+				beforeMarkerMesssageResBody := client.ParseJSON(t, beforeMarkerMessagesRes)
+				eventDebugStringsFromBeforeMarkerResponse := mustGetRelevantEventDebugStringsFromMessagesResponse(t, "chunk", beforeMarkerMesssageResBody, relevantToScrollbackEventFilter)
+				// Since the original body can only be read once, create a new one from the body bytes we just read
+				beforeMarkerMessagesRes.Body = ioutil.NopCloser(bytes.NewBuffer(beforeMarkerMesssageResBody))
+
+				// Make sure the history isn't visible before we expect it to be there.
+				// This is to avoid some bug in the homeserver using some unknown
+				// mechanism to distribute the historical messages to other homeservers.
+				must.MatchResponse(t, beforeMarkerMessagesRes, match.HTTPResponse{
+					JSON: []match.JSON{
+						match.JSONArrayEach("chunk", func(r gjson.Result) error {
+							// Throw if we find one of the historical events in the message response
+							for _, historicalEventID := range historicalEventIDs {
+								if r.Get("event_id").Str == historicalEventID {
+									return fmt.Errorf("Historical event (%s) found on remote homeserver before marker event was sent out\nmessage response (%d): %v\nhistoricalEventIDs (%d): %v", historicalEventID, len(eventDebugStringsFromBeforeMarkerResponse), eventDebugStringsFromBeforeMarkerResponse, len(historicalEventIDs), historicalEventIDs)
+								}
+							}
+
+							return nil
+						}),
+					},
+				})
+
+				// Send the marker event which lets remote homeservers know there are
+				// some historical messages back at the given insertion event.
+				sendMarkerAndEnsureBackfilled(t, as, remoteCharlie, roomID, baseInsertionEventID)
+
+				// FIXME: In the future, we should probably replace the following logic
+				// with `validateBatchSendRes` to re-use and have some more robust
+				// assertion logic here. We're currently not using it because the message
+				// order isn't quite perfect when a remote federated homeserver gets
+				// backfilled.
+				// validateBatchSendRes(t, remoteCharlie, roomID, batchSendRes, false)
+				remoteMessagesRes := remoteCharlie.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "messages"}, client.WithContentType("application/json"), client.WithQueries(url.Values{
+					"dir":   []string{"b"},
+					"limit": []string{"100"},
+				}))
+
+				// Make sure all of the historical messages are visible when we scrollback again
+				must.MatchResponse(t, remoteMessagesRes, match.HTTPResponse{
+					JSON: []match.JSON{
+						match.JSONCheckOffAllowUnwanted("chunk", makeInterfaceSlice(historicalEventIDs), func(r gjson.Result) interface{} {
+							return r.Get("event_id").Str
+						}, nil),
+					},
+				})
 			})
 
-			// FIXME: In the future, we should probably replace the following logic
-			// with `validateBatchSendRes` to re-use and have some more robust
-			// assertion logic here. We're currently not using it because the message
-			// order isn't quite perfect when a remote federated homeserver gets
-			// backfilled.
-			// validateBatchSendRes(t, remoteCharlie, roomID, batchSendRes, false)
-			messagesRes := remoteCharlie.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "messages"}, client.WithContentType("application/json"), client.WithQueries(url.Values{
-				"dir":   []string{"b"},
-				"limit": []string{"100"},
-			}))
+			t.Run("When messages have already been scrolled back through, new historical messages are visible in next scroll back on federated server", func(t *testing.T) {
+				t.Parallel()
 
-			must.MatchResponse(t, messagesRes, match.HTTPResponse{
-				JSON: []match.JSON{
-					match.JSONCheckOffAllowUnwanted("chunk", makeInterfaceSlice(historicalEventIDs), func(r gjson.Result) interface{} {
-						return r.Get("event_id").Str
-					}, nil),
-				},
-			})
-		})
+				roomID := as.CreateRoom(t, createPublicRoomOpts)
+				alice.JoinRoom(t, roomID, nil)
 
-		t.Run("Historical messages are visible when joining on federated server - pre-made insertion event", func(t *testing.T) {
-			t.Parallel()
+				// Join the room from a remote homeserver before any historical messages are sent
+				remoteCharlie.JoinRoom(t, roomID, []string{"hs1"})
 
-			roomID := as.CreateRoom(t, createPublicRoomOpts)
-			alice.JoinRoom(t, roomID, nil)
+				eventIDsBefore := createMessagesInRoom(t, alice, roomID, 1)
+				eventIdBefore := eventIDsBefore[0]
+				timeAfterEventBefore := time.Now()
 
-			eventIDsBefore := createMessagesInRoom(t, alice, roomID, 1)
-			eventIdBefore := eventIDsBefore[0]
-			timeAfterEventBefore := time.Now()
+				// eventIDsAfter
+				createMessagesInRoom(t, alice, roomID, 3)
 
-			// Create insertion event in the normal DAG
-			batchID := "mynextBatchID123"
-			insertionEvent := b.Event{
-				Type: insertionEventType,
-				Content: map[string]interface{}{
-					nextBatchIDContentField: batchID,
-					historicalContentField:  true,
-				},
-			}
-			// We can't use as.SendEventSynced(...) because application services can't use the /sync API
-			txnId := getTxnID("sendInsertionAndEnsureBackfilled-txn")
-			insertionSendRes := as.MustDoFunc(t, "PUT", []string{"_matrix", "client", "r0", "rooms", roomID, "send", insertionEvent.Type, txnId}, client.WithJSONBody(t, insertionEvent.Content))
-			insertionSendBody := client.ParseJSON(t, insertionSendRes)
-			insertionEventID := client.GetJSONFieldStr(t, insertionSendBody, "event_id")
-			// Make sure the insertion event has reached the homeserver
-			alice.SyncUntilTimelineHas(t, roomID, func(ev gjson.Result) bool {
-				return ev.Get("event_id").Str == insertionEventID
-			})
+				// Mimic scrollback to all of the messages
+				// scrollbackMessagesRes
+				remoteCharlie.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "messages"}, client.WithContentType("application/json"), client.WithQueries(url.Values{
+					"dir":   []string{"b"},
+					"limit": []string{"100"},
+				}))
 
-			// eventIDsAfter
-			createMessagesInRoom(t, alice, roomID, 3)
+				// Historical messages are inserted where we have already scrolled back to
+				numMessagesSent := 2
+				batchSendRes := batchSendHistoricalMessages(
+					t,
+					as,
+					roomID,
+					eventIdBefore,
+					"",
+					createJoinStateEventsForBatchSendRequest([]string{virtualUserID}, timeAfterEventBefore),
+					createMessageEventsForBatchSendRequest([]string{virtualUserID}, timeAfterEventBefore, numMessagesSent),
+					// Status
+					200,
+				)
+				batchSendResBody := client.ParseJSON(t, batchSendRes)
+				historicalEventIDs := client.GetJSONFieldStringArray(t, batchSendResBody, "event_ids")
+				baseInsertionEventID := client.GetJSONFieldStr(t, batchSendResBody, "base_insertion_event_id")
 
-			batchSendRes := batchSendHistoricalMessages(
-				t,
-				as,
-				roomID,
-				eventIdBefore,
-				batchID,
-				createJoinStateEventsForBatchSendRequest([]string{virtualUserID}, timeAfterEventBefore),
-				createMessageEventsForBatchSendRequest([]string{virtualUserID}, timeAfterEventBefore, 2),
-				// Status
-				200,
-			)
-			batchSendResBody := client.ParseJSON(t, batchSendRes)
-			historicalEventIDs := client.GetJSONFieldStringArray(t, batchSendResBody, "event_ids")
-
-			// Send the marker event which lets remote homeservers know there are
-			// some historical messages back at the given insertion event.
-			sendMarkerAndEnsureBackfilled(t, as, alice, roomID, insertionEventID)
-
-			// Join the room from a remote homeserver after the historical messages were sent
-			remoteCharlie.JoinRoom(t, roomID, []string{"hs1"})
-
-			// Make sure all of the events have been backfilled
-			fetchUntilMessagesResponseHas(t, remoteCharlie, roomID, func(ev gjson.Result) bool {
-				if ev.Get("event_id").Str == eventIdBefore {
-					return true
+				if len(historicalEventIDs) != numMessagesSent {
+					t.Fatalf("Expected %d event_ids in the response that correspond to the %d events we sent in the request but saw %d: %s", numMessagesSent, numMessagesSent, len(historicalEventIDs), historicalEventIDs)
 				}
 
-				return false
-			})
-
-			// FIXME: In the future, we should probably replace the following logic
-			// with `validateBatchSendRes` to re-use and have some more robust
-			// assertion logic here. We're currently not using it because the message
-			// order isn't quite perfect when a remote federated homeserver gets
-			// backfilled.
-			// validateBatchSendRes(t, remoteCharlie, roomID, batchSendRes, false)
-			messagesRes := remoteCharlie.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "messages"}, client.WithContentType("application/json"), client.WithQueries(url.Values{
-				"dir":   []string{"b"},
-				"limit": []string{"100"},
-			}))
-
-			must.MatchResponse(t, messagesRes, match.HTTPResponse{
-				JSON: []match.JSON{
-					match.JSONCheckOffAllowUnwanted("chunk", makeInterfaceSlice(historicalEventIDs), func(r gjson.Result) interface{} {
-						return r.Get("event_id").Str
-					}, nil),
-				},
-			})
-		})
-
-		t.Run("Historical messages are visible when already joined on federated server", func(t *testing.T) {
-			t.Parallel()
-
-			roomID := as.CreateRoom(t, createPublicRoomOpts)
-			alice.JoinRoom(t, roomID, nil)
-
-			// Join the room from a remote homeserver before any historical messages are sent
-			remoteCharlie.JoinRoom(t, roomID, []string{"hs1"})
-
-			eventIDsBefore := createMessagesInRoom(t, alice, roomID, 1)
-			eventIdBefore := eventIDsBefore[0]
-			timeAfterEventBefore := time.Now()
-
-			// eventIDsAfter
-			createMessagesInRoom(t, alice, roomID, 10)
-
-			// Mimic scrollback just through the latest messages
-			remoteCharlie.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "messages"}, client.WithContentType("application/json"), client.WithQueries(url.Values{
-				"dir": []string{"b"},
-				// Limited so we can only see a portion of the latest messages
-				"limit": []string{"5"},
-			}))
-
-			numMessagesSent := 2
-			batchSendRes := batchSendHistoricalMessages(
-				t,
-				as,
-				roomID,
-				eventIdBefore,
-				"",
-				createJoinStateEventsForBatchSendRequest([]string{virtualUserID}, timeAfterEventBefore),
-				createMessageEventsForBatchSendRequest([]string{virtualUserID}, timeAfterEventBefore, numMessagesSent),
-				// Status
-				200,
-			)
-			batchSendResBody := client.ParseJSON(t, batchSendRes)
-			historicalEventIDs := client.GetJSONFieldStringArray(t, batchSendResBody, "event_ids")
-			baseInsertionEventID := client.GetJSONFieldStr(t, batchSendResBody, "base_insertion_event_id")
-
-			if len(historicalEventIDs) != numMessagesSent {
-				t.Fatalf("Expected %d event_ids in the response that correspond to the %d events we sent in the request but saw %d: %s", numMessagesSent, numMessagesSent, len(historicalEventIDs), historicalEventIDs)
-			}
-
-			beforeMarkerMessagesRes := remoteCharlie.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "messages"}, client.WithContentType("application/json"), client.WithQueries(url.Values{
-				"dir":   []string{"b"},
-				"limit": []string{"100"},
-			}))
-			beforeMarkerMesssageResBody := client.ParseJSON(t, beforeMarkerMessagesRes)
-			eventDebugStringsFromBeforeMarkerResponse := mustGetRelevantEventDebugStringsFromMessagesResponse(t, "chunk", beforeMarkerMesssageResBody, relevantToScrollbackEventFilter)
-			// Since the original body can only be read once, create a new one from the body bytes we just read
-			beforeMarkerMessagesRes.Body = ioutil.NopCloser(bytes.NewBuffer(beforeMarkerMesssageResBody))
-
-			// Make sure the history isn't visible before we expect it to be there.
-			// This is to avoid some bug in the homeserver using some unknown
-			// mechanism to distribute the historical messages to other homeservers.
-			must.MatchResponse(t, beforeMarkerMessagesRes, match.HTTPResponse{
-				JSON: []match.JSON{
-					match.JSONArrayEach("chunk", func(r gjson.Result) error {
-						// Throw if we find one of the historical events in the message response
-						for _, historicalEventID := range historicalEventIDs {
-							if r.Get("event_id").Str == historicalEventID {
-								return fmt.Errorf("Historical event (%s) found on remote homeserver before marker event was sent out\nmessage response (%d): %v\nhistoricalEventIDs (%d): %v", historicalEventID, len(eventDebugStringsFromBeforeMarkerResponse), eventDebugStringsFromBeforeMarkerResponse, len(historicalEventIDs), historicalEventIDs)
+				beforeMarkerMessagesRes := remoteCharlie.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "messages"}, client.WithContentType("application/json"), client.WithQueries(url.Values{
+					"dir":   []string{"b"},
+					"limit": []string{"100"},
+				}))
+				beforeMarkerMesssageResBody := client.ParseJSON(t, beforeMarkerMessagesRes)
+				eventDebugStringsFromBeforeMarkerResponse := mustGetRelevantEventDebugStringsFromMessagesResponse(t, "chunk", beforeMarkerMesssageResBody, relevantToScrollbackEventFilter)
+				// Since the original body can only be read once, create a new one from the body bytes we just read
+				beforeMarkerMessagesRes.Body = ioutil.NopCloser(bytes.NewBuffer(beforeMarkerMesssageResBody))
+				// Make sure the history isn't visible before we expect it to be there.
+				// This is to avoid some bug in the homeserver using some unknown
+				// mechanism to distribute the historical messages to other homeservers.
+				must.MatchResponse(t, beforeMarkerMessagesRes, match.HTTPResponse{
+					JSON: []match.JSON{
+						match.JSONArrayEach("chunk", func(r gjson.Result) error {
+							// Throw if we find one of the historical events in the message response
+							for _, historicalEventID := range historicalEventIDs {
+								if r.Get("event_id").Str == historicalEventID {
+									return fmt.Errorf("Historical event (%s) found on remote homeserver before marker event was sent out\nmessage response (%d): %v\nhistoricalEventIDs (%d): %v", historicalEventID, len(eventDebugStringsFromBeforeMarkerResponse), eventDebugStringsFromBeforeMarkerResponse, len(historicalEventIDs), historicalEventIDs)
+								}
 							}
-						}
+							return nil
+						}),
+					},
+				})
 
-						return nil
-					}),
-				},
-			})
+				// Send the marker event which lets remote homeservers know there are
+				// some historical messages back at the given insertion event.
+				sendMarkerAndEnsureBackfilled(t, as, remoteCharlie, roomID, baseInsertionEventID)
 
-			// Send the marker event which lets remote homeservers know there are
-			// some historical messages back at the given insertion event.
-			sendMarkerAndEnsureBackfilled(t, as, remoteCharlie, roomID, baseInsertionEventID)
+				// FIXME: In the future, we should probably replace the following logic
+				// with `validateBatchSendRes` to re-use and have some more robust
+				// assertion logic here. We're currently not using it because the message
+				// order isn't quite perfect when a remote federated homeserver gets
+				// backfilled.
+				// validateBatchSendRes(t, remoteCharlie, roomID, batchSendRes, false)
+				remoteMessagesRes := remoteCharlie.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "messages"}, client.WithContentType("application/json"), client.WithQueries(url.Values{
+					"dir":   []string{"b"},
+					"limit": []string{"100"},
+				}))
 
-			// FIXME: In the future, we should probably replace the following logic
-			// with `validateBatchSendRes` to re-use and have some more robust
-			// assertion logic here. We're currently not using it because the message
-			// order isn't quite perfect when a remote federated homeserver gets
-			// backfilled.
-			// validateBatchSendRes(t, remoteCharlie, roomID, batchSendRes, false)
-			remoteMessagesRes := remoteCharlie.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "messages"}, client.WithContentType("application/json"), client.WithQueries(url.Values{
-				"dir":   []string{"b"},
-				"limit": []string{"100"},
-			}))
-
-			// Make sure all of the historical messages are visible when we scrollback again
-			must.MatchResponse(t, remoteMessagesRes, match.HTTPResponse{
-				JSON: []match.JSON{
-					match.JSONCheckOffAllowUnwanted("chunk", makeInterfaceSlice(historicalEventIDs), func(r gjson.Result) interface{} {
-						return r.Get("event_id").Str
-					}, nil),
-				},
-			})
-		})
-
-		t.Run("When messages have already been scrolled back through, new historical messages are visible in next scroll back on federated server", func(t *testing.T) {
-			t.Parallel()
-
-			roomID := as.CreateRoom(t, createPublicRoomOpts)
-			alice.JoinRoom(t, roomID, nil)
-
-			// Join the room from a remote homeserver before any historical messages are sent
-			remoteCharlie.JoinRoom(t, roomID, []string{"hs1"})
-
-			eventIDsBefore := createMessagesInRoom(t, alice, roomID, 1)
-			eventIdBefore := eventIDsBefore[0]
-			timeAfterEventBefore := time.Now()
-
-			// eventIDsAfter
-			createMessagesInRoom(t, alice, roomID, 3)
-
-			// Mimic scrollback to all of the messages
-			// scrollbackMessagesRes
-			remoteCharlie.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "messages"}, client.WithContentType("application/json"), client.WithQueries(url.Values{
-				"dir":   []string{"b"},
-				"limit": []string{"100"},
-			}))
-
-			// Historical messages are inserted where we have already scrolled back to
-			numMessagesSent := 2
-			batchSendRes := batchSendHistoricalMessages(
-				t,
-				as,
-				roomID,
-				eventIdBefore,
-				"",
-				createJoinStateEventsForBatchSendRequest([]string{virtualUserID}, timeAfterEventBefore),
-				createMessageEventsForBatchSendRequest([]string{virtualUserID}, timeAfterEventBefore, numMessagesSent),
-				// Status
-				200,
-			)
-			batchSendResBody := client.ParseJSON(t, batchSendRes)
-			historicalEventIDs := client.GetJSONFieldStringArray(t, batchSendResBody, "event_ids")
-			baseInsertionEventID := client.GetJSONFieldStr(t, batchSendResBody, "base_insertion_event_id")
-
-			if len(historicalEventIDs) != numMessagesSent {
-				t.Fatalf("Expected %d event_ids in the response that correspond to the %d events we sent in the request but saw %d: %s", numMessagesSent, numMessagesSent, len(historicalEventIDs), historicalEventIDs)
-			}
-
-			beforeMarkerMessagesRes := remoteCharlie.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "messages"}, client.WithContentType("application/json"), client.WithQueries(url.Values{
-				"dir":   []string{"b"},
-				"limit": []string{"100"},
-			}))
-			beforeMarkerMesssageResBody := client.ParseJSON(t, beforeMarkerMessagesRes)
-			eventDebugStringsFromBeforeMarkerResponse := mustGetRelevantEventDebugStringsFromMessagesResponse(t, "chunk", beforeMarkerMesssageResBody, relevantToScrollbackEventFilter)
-			// Since the original body can only be read once, create a new one from the body bytes we just read
-			beforeMarkerMessagesRes.Body = ioutil.NopCloser(bytes.NewBuffer(beforeMarkerMesssageResBody))
-			// Make sure the history isn't visible before we expect it to be there.
-			// This is to avoid some bug in the homeserver using some unknown
-			// mechanism to distribute the historical messages to other homeservers.
-			must.MatchResponse(t, beforeMarkerMessagesRes, match.HTTPResponse{
-				JSON: []match.JSON{
-					match.JSONArrayEach("chunk", func(r gjson.Result) error {
-						// Throw if we find one of the historical events in the message response
-						for _, historicalEventID := range historicalEventIDs {
-							if r.Get("event_id").Str == historicalEventID {
-								return fmt.Errorf("Historical event (%s) found on remote homeserver before marker event was sent out\nmessage response (%d): %v\nhistoricalEventIDs (%d): %v", historicalEventID, len(eventDebugStringsFromBeforeMarkerResponse), eventDebugStringsFromBeforeMarkerResponse, len(historicalEventIDs), historicalEventIDs)
-							}
-						}
-						return nil
-					}),
-				},
-			})
-
-			// Send the marker event which lets remote homeservers know there are
-			// some historical messages back at the given insertion event.
-			sendMarkerAndEnsureBackfilled(t, as, remoteCharlie, roomID, baseInsertionEventID)
-
-			// FIXME: In the future, we should probably replace the following logic
-			// with `validateBatchSendRes` to re-use and have some more robust
-			// assertion logic here. We're currently not using it because the message
-			// order isn't quite perfect when a remote federated homeserver gets
-			// backfilled.
-			// validateBatchSendRes(t, remoteCharlie, roomID, batchSendRes, false)
-			remoteMessagesRes := remoteCharlie.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "messages"}, client.WithContentType("application/json"), client.WithQueries(url.Values{
-				"dir":   []string{"b"},
-				"limit": []string{"100"},
-			}))
-
-			// Make sure all of the historical messages are visible when we scrollback again
-			must.MatchResponse(t, remoteMessagesRes, match.HTTPResponse{
-				JSON: []match.JSON{
-					match.JSONCheckOffAllowUnwanted("chunk", makeInterfaceSlice(historicalEventIDs), func(r gjson.Result) interface{} {
-						return r.Get("event_id").Str
-					}, nil),
-				},
+				// Make sure all of the historical messages are visible when we scrollback again
+				must.MatchResponse(t, remoteMessagesRes, match.HTTPResponse{
+					JSON: []match.JSON{
+						match.JSONCheckOffAllowUnwanted("chunk", makeInterfaceSlice(historicalEventIDs), func(r gjson.Result) interface{} {
+							return r.Get("event_id").Str
+						}, nil),
+					},
+				})
 			})
 		})
 


### PR DESCRIPTION
Put all federation tests under a `Federation` section.

To avoid conflicts, I made this as a follow-up to https://github.com/matrix-org/complement/pull/248 so the diff from that PR is within this one as well. The extra new commit on this PR just indents the tests.

```diff
  --- FAIL: TestImportHistoricalMessages (22.74s)
      --- FAIL: TestImportHistoricalMessages/parallel (8.01s)
          --- SKIP: TestImportHistoricalMessages/parallel/TODO:_Trying_to_send_insertion_event_with_same_`next_batch_id`_will_reject (0.00s)
          --- SKIP: TestImportHistoricalMessages/parallel/TODO:_What_happens_when_you_point_multiple_batches_at_the_same_insertion_event? (0.00s)
+         --- PASS: TestImportHistoricalMessages/parallel/Federation (0.00s)
+             --- PASS: TestImportHistoricalMessages/parallel/Federation/Historical_messages_are_visible_when_joining_on_federated_server_-_auto-generated_base_insertion_event (5.07s)
+             --- PASS: TestImportHistoricalMessages/parallel/Federation/Historical_messages_are_visible_when_joining_on_federated_server_-_pre-made_insertion_event (6.26s)
+             --- PASS: TestImportHistoricalMessages/parallel/Federation/Historical_messages_are_visible_when_already_joined_on_federated_server (6.37s)
+             --- PASS: TestImportHistoricalMessages/parallel/Federation/When_messages_have_already_been_scrolled_back_through,_new_historical_messages_are_visible_in_next_scroll_back_on_federated_server (7.02s)
          --- FAIL: TestImportHistoricalMessages/parallel/Existing_room_versions (0.00s)
              --- FAIL: TestImportHistoricalMessages/parallel/Existing_room_versions/Not_allowed_to_redact_MSC2716_insertion,_batch,_marker_events (0.82s)
              --- FAIL: TestImportHistoricalMessages/parallel/Existing_room_versions/Room_creator_can_send_MSC2716_events (0.99s)
          --- FAIL: TestImportHistoricalMessages/parallel/Unrecognised_prev_event_ID_will_throw_an_error (1.51s)
          --- PASS: TestImportHistoricalMessages/parallel/Duplicate_next_batch_id_on_insertion_event_will_be_rejected (2.28s)
          --- PASS: TestImportHistoricalMessages/parallel/Normal_users_aren't_allowed_to_batch_send_historical_messages (2.43s)
          --- PASS: TestImportHistoricalMessages/parallel/Unrecognised_batch_id_will_throw_an_error (2.45s)
          --- PASS: TestImportHistoricalMessages/parallel/Batch_send_endpoint_only_returns_state_events_that_we_passed_in_via_state_events_at_start (3.09s)
          --- PASS: TestImportHistoricalMessages/parallel/Should_be_able_to_send_a_batch_without_any_state_events_at_start_-_user_already_joined_in_the_current_room_state (3.37s)
          --- PASS: TestImportHistoricalMessages/parallel/Should_be_able_to_batch_send_historical_messages_into_private_room (4.05s)
          --- PASS: TestImportHistoricalMessages/parallel/Historical_events_from_multiple_users_in_the_same_batch (4.07s)
          --- PASS: TestImportHistoricalMessages/parallel/Historical_events_resolve_in_the_correct_order (4.85s)
          --- PASS: TestImportHistoricalMessages/parallel/Historical_events_from_batch_send_do_not_come_down_in_an_incremental_sync (4.85s)
          --- PASS: TestImportHistoricalMessages/parallel/should_resolve_member_state_events_for_historical_events (4.93s)
  FAIL
  FAIL    github.com/matrix-org/complement/tests  23.409s
  FAIL
```


Part of MSC2716: https://github.com/matrix-org/matrix-doc/pull/2716

