### PR TITLE
Add request query parameters to Complement request debug logs

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -332,7 +332,7 @@ func (c *CSAPI) DoFunc(t *testing.T, method string, paths []string, opts ...Requ
 	}
 	// debug log the request
 	if c.Debug {
-		t.Logf("Making %s request to %s", method, reqURL)
+		t.Logf("Making %s request to %s", method, req.URL)
 		contentType := req.Header.Get("Content-Type")
 		if contentType == "application/json" || strings.HasPrefix(contentType, "text/") {
 			if req.Body != nil {


### PR DESCRIPTION
Add request query parameters to Complement request debug logs (`COMPLEMENT_DEBUG=1`), https://github.com/matrix-org/complement/blob/master/ONBOARDING.md#i-think-complement-is-doing-something-weird-can-i-get-more-logs

Before:
```
msc2716_test.go:899: Making POST request to http://localhost:57176/_matrix/client/unstable/org.matrix.msc2716/rooms/%21WfOaOcxJTCHBxspVgq:hs1/batch_send
msc2716_test.go:899: Request body: {"events":[{"content":{"body":"Historical 0 (batch=0)","msgtype":"m.text","org.matrix.msc2716.historical":true},"origin_server_ts":1638404618714,"sender":"@maria:hs1","type":"m.room.message"}],"state_events_at_start":[{"content":{"displayname":"some-display-name-for-@maria:hs1","membership":"join"},"origin_server_ts":1638404618714,"sender":"@maria:hs1","state_key":"@maria:hs1","type":"m.room.member"}]}
```

After:
```
msc2716_test.go:899: Making POST request to http://localhost:57160/_matrix/client/unstable/org.matrix.msc2716/rooms/%21KblUOBFIMMmAVoZnpQ:hs1/batch_send?prev_event_id=%241GidKbmhon-1habkcZokuhcjjvcLLQ5xq2FoVHrdk1E
msc2716_test.go:899: Request body: {"events":[{"content":{"body":"Historical 0 (batch=0)","msgtype":"m.text","org.matrix.msc2716.historical":true},"origin_server_ts":1638404572878,"sender":"@maria:hs1","type":"m.room.message"}],"state_events_at_start":[{"content":{"displayname":"some-display-name-for-@maria:hs1","membership":"join"},"origin_server_ts":1638404572878,"sender":"@maria:hs1","state_key":"@maria:hs1","type":"m.room.member"}]}
```

Split out from https://github.com/matrix-org/complement/pull/214