### PR TITLE
Improve versions test a bit

### DIFF
--- a/tests/csapi/apidoc_version_test.go
+++ b/tests/csapi/apidoc_version_test.go
@@ -2,6 +2,7 @@ package csapi_tests
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/tidwall/gjson"
@@ -14,10 +15,20 @@ import (
 func TestVersionStructure(t *testing.T) {
 	deployment := Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
-	unauthedClient := deployment.Client(t, "hs1", "")
+
+	client := deployment.Client(t, "hs1", "")
+
 	// sytest: Version responds 200 OK with valid structure
 	t.Run("Version responds 200 OK with valid structure", func(t *testing.T) {
-		res := unauthedClient.MustDo(t, "GET", []string{"_matrix", "client", "versions"}, nil)
+		res := client.MustDoFunc(t, "GET", []string{"_matrix", "client", "versions"})
+
+		// Matches;
+		// - r0.?.?
+		//  where ? is any single digit
+		// - v1^.*
+		//  where 1^ is 1 through 9 for the first digit, then any digit thereafter,
+		//  and * is any single or multiple of digits
+		versionRegex, _ := regexp.Compile(`^(v[1-9]\d*\.\d+|r0\.\d\.\d)$`)
 
 		must.MatchResponse(t, res, match.HTTPResponse{
 			JSON: []match.JSON{
@@ -26,8 +37,22 @@ func TestVersionStructure(t *testing.T) {
 					if val.Type != gjson.String {
 						return fmt.Errorf("'versions' value is not a string: %s", val.Raw)
 					}
+					if !versionRegex.MatchString(val.Str) {
+						return fmt.Errorf("'versions' value did not match version regex: %s", val.Str)
+					}
 					return nil
 				}),
+				// Check when unstable_features is present if it's an object
+				func(body []byte) error {
+					res := gjson.GetBytes(body, "unstable_features")
+					if !res.Exists() {
+						return nil
+					}
+					if !res.IsObject() {
+						return fmt.Errorf("unstable_features was present, and wasn't an object")
+					}
+					return nil
+				},
 			},
 		})
 	})

--- a/tests/csapi/apidoc_version_test.go
+++ b/tests/csapi/apidoc_version_test.go
@@ -2,7 +2,6 @@ package csapi_tests
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/tidwall/gjson"
@@ -22,14 +21,6 @@ func TestVersionStructure(t *testing.T) {
 	t.Run("Version responds 200 OK with valid structure", func(t *testing.T) {
 		res := client.MustDoFunc(t, "GET", []string{"_matrix", "client", "versions"})
 
-		// Matches;
-		// - r0.?.?
-		//  where ? is any single digit
-		// - v1^.*
-		//  where 1^ is 1 through 9 for the first digit, then any digit thereafter,
-		//  and * is any single or multiple of digits
-		versionRegex, _ := regexp.Compile(`^(v[1-9]\d*\.\d+|r0\.\d\.\d)$`)
-
 		must.MatchResponse(t, res, match.HTTPResponse{
 			JSON: []match.JSON{
 				match.JSONKeyPresent("versions"),
@@ -37,9 +28,7 @@ func TestVersionStructure(t *testing.T) {
 					if val.Type != gjson.String {
 						return fmt.Errorf("'versions' value is not a string: %s", val.Raw)
 					}
-					if !versionRegex.MatchString(val.Str) {
-						return fmt.Errorf("'versions' value did not match version regex: %s", val.Str)
-					}
+					// versions format is currently relatively undefined, see https://github.com/matrix-org/matrix-doc/issues/3594
 					return nil
 				}),
 				// Check when unstable_features is present if it's an object

--- a/tests/csapi/apidoc_version_test.go
+++ b/tests/csapi/apidoc_version_test.go
@@ -36,7 +36,7 @@ func TestVersionStructure(t *testing.T) {
 		// - v1^.*(-#)
 		//  where 1^ is 1 through 9 for the first digit, then any digit thereafter,
 		//  and * is any single or multiple of digits
-		//  optionally with dash-seperated metadata: (-#)
+		//  optionally with dash-separated metadata: (-#)
 		versionRegex, _ := regexp.Compile("^(" + r0Regex + "|" + GlobalVersionRegex + ")$")
 
 		must.MatchResponse(t, res, match.HTTPResponse{

--- a/tests/csapi/apidoc_version_test.go
+++ b/tests/csapi/apidoc_version_test.go
@@ -2,6 +2,7 @@ package csapi_tests
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/tidwall/gjson"
@@ -10,6 +11,14 @@ import (
 	"github.com/matrix-org/complement/internal/match"
 	"github.com/matrix-org/complement/internal/must"
 )
+
+// https://spec.matrix.org/v1.1/#specification-versions
+// altered to limit to X = 1+, as v0 has never existed
+const GlobalVersionRegex = `v[1-9]\d*\.\d+(?:-\S+)?`
+
+// https://github.com/matrix-org/matrix-doc/blob/client_server/r0.6.1/specification/index.rst#specification-versions
+// altered to limit to X = 0 (r0), as r1+ will never exist.
+const r0Regex = `r0\.\d+\.\d+`
 
 func TestVersionStructure(t *testing.T) {
 	deployment := Deploy(t, b.BlueprintAlice)
@@ -21,6 +30,15 @@ func TestVersionStructure(t *testing.T) {
 	t.Run("Version responds 200 OK with valid structure", func(t *testing.T) {
 		res := client.MustDoFunc(t, "GET", []string{"_matrix", "client", "versions"})
 
+		// Matches;
+		// - r0.?.?
+		//  where ? is any single digit
+		// - v1^.*(-#)
+		//  where 1^ is 1 through 9 for the first digit, then any digit thereafter,
+		//  and * is any single or multiple of digits
+		//  optionally with dash-seperated metadata: (-#)
+		versionRegex, _ := regexp.Compile("^(" + r0Regex + "|" + GlobalVersionRegex + ")$")
+
 		must.MatchResponse(t, res, match.HTTPResponse{
 			JSON: []match.JSON{
 				match.JSONKeyPresent("versions"),
@@ -28,7 +46,9 @@ func TestVersionStructure(t *testing.T) {
 					if val.Type != gjson.String {
 						return fmt.Errorf("'versions' value is not a string: %s", val.Raw)
 					}
-					// versions format is currently relatively undefined, see https://github.com/matrix-org/matrix-doc/issues/3594
+					if !versionRegex.MatchString(val.Str) {
+						return fmt.Errorf("value in 'versions' array did not match version regex: %s", val.Str)
+					}
 					return nil
 				}),
 				// Check when unstable_features is present if it's an object
@@ -39,6 +59,12 @@ func TestVersionStructure(t *testing.T) {
 					}
 					if !res.IsObject() {
 						return fmt.Errorf("unstable_features was present, and wasn't an object")
+					}
+					for k, v := range res.Map() {
+						// gjson doesn't have a "boolean" type to check against
+						if v.Type != gjson.True && v.Type != gjson.False {
+							return fmt.Errorf("value for key 'unstable_features.%s' is of the wrong type, got %s want boolean", k, v.Type)
+						}
 					}
 					return nil
 				},


### PR DESCRIPTION
This has an opinionated section, even though the spec doesnt really strictly mandate version strings in an explicit sense, i thought it is reasonable to add a regex matcher in here.