### PR TITLE
Add 3 sytests

### DIFF
--- a/tests/csapi/push_test.go
+++ b/tests/csapi/push_test.go
@@ -1,0 +1,43 @@
+package csapi_tests
+
+import (
+	"testing"
+
+	"github.com/matrix-org/complement/internal/b"
+	"github.com/matrix-org/complement/internal/client"
+	"github.com/matrix-org/complement/internal/match"
+	"github.com/matrix-org/complement/internal/must"
+	"github.com/matrix-org/complement/runtime"
+)
+
+// @shadowjonathan: do we need this test anymore?
+// sytest: Getting push rules doesn't corrupt the cache SYN-390
+func TestPushRuleCacheHealth(t *testing.T) {
+	runtime.SkipIf(t, runtime.Dendrite) // Dendrite does not support push notifications (yet)
+
+	deployment := Deploy(t, b.BlueprintAlice)
+	defer deployment.Destroy(t)
+
+	alice := deployment.Client(t, "hs1", "@alice:hs1")
+
+	alice.MustDoFunc(t, "PUT", []string{"_matrix", "client", "r0", "pushrules", "global", "sender", alice.UserID}, client.WithJSONBody(t, map[string]interface{}{
+		"actions": []string{"dont_notify"},
+	}))
+
+	// the extra "" is to make sure the submitted URL ends with a trailing slash
+	res := alice.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "pushrules", ""})
+
+	must.MatchResponse(t, res, match.HTTPResponse{
+		JSON: []match.JSON{
+			match.JSONKeyEqual("global.sender.0.actions.0", "dont_notify"),
+		},
+	})
+
+	res = alice.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "pushrules", ""})
+
+	must.MatchResponse(t, res, match.HTTPResponse{
+		JSON: []match.JSON{
+			match.JSONKeyEqual("global.sender.0.actions.0", "dont_notify"),
+		},
+	})
+}

--- a/tests/csapi/room_ban_test.go
+++ b/tests/csapi/room_ban_test.go
@@ -1,13 +1,14 @@
 package csapi_tests
 
 import (
-	"io/ioutil"
 	"testing"
 
 	"github.com/tidwall/gjson"
 
 	"github.com/matrix-org/complement/internal/b"
 	"github.com/matrix-org/complement/internal/client"
+	"github.com/matrix-org/complement/internal/match"
+	"github.com/matrix-org/complement/internal/must"
 )
 
 // This is technically a tad different from the sytest, in that it doesnt try to ban a @random_dude:test,
@@ -70,9 +71,7 @@ func TestNotPresentUserCannotBanOthers(t *testing.T) {
 		"reason":  "testing",
 	}))
 
-	if res.StatusCode != 403 {
-		defer res.Body.Close()
-		body, _ := ioutil.ReadAll(res.Body)
-		t.Fatalf("Banning a user succeeded where it shouldn't: (%d) %s", res.StatusCode, string(body))
-	}
+	must.MatchResponse(t, res, match.HTTPResponse{
+		StatusCode: 403,
+	})
 }

--- a/tests/csapi/room_ban_test.go
+++ b/tests/csapi/room_ban_test.go
@@ -1,0 +1,78 @@
+package csapi_tests
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/tidwall/gjson"
+
+	"github.com/matrix-org/complement/internal/b"
+	"github.com/matrix-org/complement/internal/client"
+)
+
+// This is technically a tad different from the sytest, in that it doesnt try to ban a @random_dude:test,
+// but this will actually validate against a present user in the room.
+// sytest: Non-present room members cannot ban others
+func TestNotPresentUserCannotBanOthers(t *testing.T) {
+	deployment := Deploy(t, b.MustValidate(b.Blueprint{
+		Name: "one_to_one_room",
+		Homeservers: []b.Homeserver{
+			{
+				Name: "hs1",
+				Users: []b.User{
+					{
+						Localpart:   "@alice",
+						DisplayName: "Alice",
+					},
+					{
+						Localpart:   "@bob",
+						DisplayName: "Bob",
+					},
+					{
+						Localpart:   "@charlie",
+						DisplayName: "Charlie",
+					},
+				},
+			},
+		},
+	}))
+	defer deployment.Destroy(t)
+
+	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	bob := deployment.Client(t, "hs1", "@bob:hs1")
+	charlie := deployment.Client(t, "hs1", "@charlie:hs1")
+
+	roomID := alice.CreateRoom(t, map[string]interface{}{
+		"preset": "public_chat",
+	})
+
+	bob.JoinRoom(t, roomID, nil)
+
+	alice.SendEventSynced(t, roomID, b.Event{
+		Type:     "m.room.power_levels",
+		StateKey: b.Ptr(""),
+		Content: map[string]interface{}{
+			"users": map[string]interface{}{
+				charlie.UserID: 100,
+			},
+		},
+	})
+
+	// todo: replace with `SyncUntilJoined`
+	bob.SyncUntilTimelineHas(t, roomID, func(event gjson.Result) bool {
+		return event.Get("type").Str == "m.room.member" &&
+			event.Get("content.membership").Str == "join" &&
+			event.Get("state_key").Str == bob.UserID
+	})
+
+	res := charlie.DoFunc(t, "POST", []string{"_matrix", "client", "r0", "rooms", roomID, "ban"}, client.WithJSONBody(t, map[string]interface{}{
+		"user_id": bob.UserID,
+		"reason":  "testing",
+	}))
+
+	if res.StatusCode != 403 {
+		defer res.Body.Close()
+		body, _ := ioutil.ReadAll(res.Body)
+		t.Fatalf("Banning a user succeeded where it shouldn't: (%d) %s", res.StatusCode, string(body))
+	}
+}

--- a/tests/csapi/room_ban_test.go
+++ b/tests/csapi/room_ban_test.go
@@ -15,7 +15,7 @@ import (
 // sytest: Non-present room members cannot ban others
 func TestNotPresentUserCannotBanOthers(t *testing.T) {
 	deployment := Deploy(t, b.MustValidate(b.Blueprint{
-		Name: "one_to_one_room",
+		Name: "abc",
 		Homeservers: []b.Homeserver{
 			{
 				Name: "hs1",


### PR DESCRIPTION
This adds 3 miscellaneous sytests;
- Rooms can be created with an initial invite list (SYN-205)
- Getting push rules doesn't corrupt the cache SYN-390
- Non-present room members cannot ban others