### PR TITLE
Test that invites from ignored users are omitted from incremental syncs

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -153,6 +153,7 @@ func (c *CSAPI) SyncUntilGlobalAccountDataHas(t *testing.T, check func(gjson.Res
 	t.Helper()
 	return c.SyncUntil(t, "", "", "account_data.events", check)
 }
+
 // SyncUntilInvitedTo is a wrapper around SyncUntil.
 // It blocks and continually calls `/sync` until we've been invited to the given room.
 // Will time out after CSAPI.SyncUntilTimeout.

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -141,6 +141,18 @@ func (c *CSAPI) SyncUntilTimelineHas(t *testing.T, roomID string, check func(gjs
 	return c.SyncUntil(t, "", "", "rooms.join."+GjsonEscape(roomID)+".timeline.events", check)
 }
 
+// SyncUntilGlobalAccountDataHas is a wrapper around `SyncUntil`.
+// It blocks and continually calls `/sync` until
+// - we an event in the global account data for which the `check` function returns True
+// If the `check` function fails the test, the failing event will be automatically logged.
+// Will time out after CSAPI.SyncUntilTimeout.
+//
+// Returns the `next_batch` token from the last /sync response. This can be passed as
+// `since` to sync from this point forward only.
+func (c *CSAPI) SyncUntilGlobalAccountDataHas(t *testing.T, check func(gjson.Result) bool) string {
+	t.Helper()
+	return c.SyncUntil(t, "", "", "account_data.events", check)
+}
 // SyncUntilInvitedTo is a wrapper around SyncUntil.
 // It blocks and continually calls `/sync` until we've been invited to the given room.
 // Will time out after CSAPI.SyncUntilTimeout.

--- a/internal/match/json.go
+++ b/internal/match/json.go
@@ -41,6 +41,18 @@ func JSONKeyPresent(wantKey string) JSON {
 	}
 }
 
+// JSONKeyMissing returns a matcher which will check that `forbiddenKey` is not present in the JSON object.
+// `forbiddenKey` can be nested, see https://godoc.org/github.com/tidwall/gjson#Get for details.
+func JSONKeyMissing(forbiddenKey string) JSON {
+	return func(body []byte) error {
+		res := gjson.GetBytes(body, forbiddenKey)
+		if res.Exists() {
+			return fmt.Errorf("key '%s' present", forbiddenKey)
+		}
+		return nil
+	}
+}
+
 // JSONKeyTypeEqual returns a matcher which will check that `wantKey` is present and its value is of the type `wantType`.
 // `wantKey` can be nested, see https://godoc.org/github.com/tidwall/gjson#Get for details.
 func JSONKeyTypeEqual(wantKey string, wantType gjson.Type) JSON {

--- a/tests/csapi/ignored_users_test.go
+++ b/tests/csapi/ignored_users_test.go
@@ -20,9 +20,9 @@ import (
 // that
 // > Servers must not send room invites from ignored users to clients.
 //
-// Synapse does not have this property, as detailed in
-// https://github.com/matrix-org/synapse/issues/11506.
-// This reproduces that bug.
+// This is a regression test for
+// https://github.com/matrix-org/synapse/issues/11506
+// to ensure that Synapse complies with this part of the spec.
 func TestInviteFromIgnoredUsersDoesNotAppearInSync(t *testing.T) {
 	deployment := Deploy(t, b.BlueprintCleanHS)
 	defer deployment.Destroy(t)

--- a/tests/csapi/ignored_users_test.go
+++ b/tests/csapi/ignored_users_test.go
@@ -48,7 +48,7 @@ func TestInviteFromIgnoredUsersDoesNotAppearInSync(t *testing.T) {
 	alice.MustDoFunc(
 		t,
 		"PUT",
-		[]string{"_matrix", "client", "v3", "user", alice.UserID, "account_data", "m.ignored_user_list"},
+		[]string{"_matrix", "client", "r0", "user", alice.UserID, "account_data", "m.ignored_user_list"},
 		client.WithJSONBody(t, map[string]interface{}{
 			"ignored_users": map[string]interface{}{
 				bob.UserID: map[string]interface{}{},
@@ -91,7 +91,7 @@ func TestInviteFromIgnoredUsersDoesNotAppearInSync(t *testing.T) {
 	response := alice.MustDoFunc(
 		t,
 		"GET",
-		[]string{"_matrix", "client", "v3", "sync"},
+		[]string{"_matrix", "client", "r0", "sync"},
 		client.WithQueries(queryParams),
 	)
 	bobRoomPath := "rooms.invite." + client.GjsonEscape(bobRoom)

--- a/tests/csapi/ignored_users_test.go
+++ b/tests/csapi/ignored_users_test.go
@@ -47,10 +47,8 @@ func TestInviteFromIgnoredUsersDoesNotAppearInSync(t *testing.T) {
 		"PUT",
 		[]string{"_matrix", "client", "v3", "user", alice.UserID, "account_data", "m.ignored_user_list"},
 		client.WithJSONBody(t, map[string]interface{}{
-			"content": map[string]interface{}{
-				"ignored_users": map[string]interface{}{
-					bob.UserID: map[string]interface{}{},
-				},
+			"ignored_users": map[string]interface{}{
+				bob.UserID: map[string]interface{}{},
 			},
 		}),
 	)

--- a/tests/csapi/ignored_users_test.go
+++ b/tests/csapi/ignored_users_test.go
@@ -1,0 +1,92 @@
+package csapi_tests
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/matrix-org/complement/internal/b"
+	"github.com/matrix-org/complement/internal/client"
+	"github.com/matrix-org/complement/internal/match"
+	"github.com/matrix-org/complement/internal/must"
+	"github.com/tidwall/gjson"
+)
+
+// The Spec says here
+//     https://spec.matrix.org/v1.1/client-server-api/#server-behaviour-13
+// that
+// > Servers must not send room invites from ignored users to clients.
+//
+// Synapse does not have this property, as detailed in
+// https://github.com/matrix-org/synapse/issues/11506.
+// This reproduces that bug.
+func TestInviteFromIgnoredUsersDoesNotAppearInSync(t *testing.T) {
+	deployment := Deploy(t, b.BlueprintCleanHS)
+	defer deployment.Destroy(t)
+	alice := deployment.RegisterUser(t, "hs1", "alice", "sufficiently_long_password_alice")
+	bob := deployment.RegisterUser(t, "hs1", "bob", "sufficiently_long_password_bob")
+	chris := deployment.RegisterUser(t, "hs1", "chris", "sufficiently_long_password_chris")
+
+	// Alice creates a room for herself.
+	public_room := alice.CreateRoom(t, map[string]interface{}{
+		"preset": "public_chat",
+	})
+
+	// Alice ignores Bob.
+	alice.MustDoFunc(
+		t,
+		"PUT",
+		[]string{"_matrix", "client", "v3", "user", alice.UserID, "account_data", "m.ignored_user_list"},
+		client.WithJSONBody(t, map[string]interface{}{
+			"content": map[string]interface{}{
+				"ignored_users": map[string]interface{}{
+					bob.UserID: map[string]interface{}{},
+				},
+			},
+		}),
+	)
+
+	start := alice.SyncUntilTimelineHas(
+		t, public_room, func(ev gjson.Result) bool {
+			return ev.Get("type").Str == "m.room.member" &&
+				ev.Get("state_key").Str == alice.UserID &&
+				ev.Get("content.membership").Str == "join"
+		},
+	)
+
+	// Bob invites Alice to a private room.
+	bobRoom := bob.CreateRoom(t, map[string]interface{}{
+		"preset": "private_chat",
+		"invite": []string{alice.UserID},
+	})
+
+	// So does Chris.
+	chrisRoom := chris.CreateRoom(t, map[string]interface{}{
+		"preset": "private_chat",
+		"invite": []string{alice.UserID},
+	})
+
+	// Alice waits until she's seen Chris's invite.
+	alice.SyncUntilInvitedTo(t, chrisRoom)
+
+	// We re-request the sync with a `since` token. We should see Chris's invite, but not Bob's.
+	queryParams := url.Values{
+		"since":   {start},
+		"timeout": {"0"},
+	}
+	// Note: SyncUntil only runs its callback on array elements. I want to investigate an object.
+	// So let's make the HTTP request more directly.
+	response := alice.MustDoFunc(
+		t,
+		"GET",
+		[]string{"_matrix", "client", "v3", "sync"},
+		client.WithQueries(queryParams),
+	)
+	bobRoomPath := "rooms.invite." + client.GjsonEscape(bobRoom)
+	chrisRoomPath := "rooms.invite." + client.GjsonEscape(chrisRoom)
+	must.MatchResponse(t, response, match.HTTPResponse{
+		JSON: []match.JSON{
+			match.JSONKeyMissing(bobRoomPath),
+			match.JSONKeyPresent(chrisRoomPath),
+		},
+	})
+}

--- a/tests/csapi/ignored_users_test.go
+++ b/tests/csapi/ignored_users_test.go
@@ -4,11 +4,12 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/tidwall/gjson"
+
 	"github.com/matrix-org/complement/internal/b"
 	"github.com/matrix-org/complement/internal/client"
 	"github.com/matrix-org/complement/internal/match"
 	"github.com/matrix-org/complement/internal/must"
-	"github.com/tidwall/gjson"
 )
 
 // The Spec says here

--- a/tests/csapi/ignored_users_test.go
+++ b/tests/csapi/ignored_users_test.go
@@ -31,13 +31,13 @@ func TestInviteFromIgnoredUsersDoesNotAppearInSync(t *testing.T) {
 	chris := deployment.RegisterUser(t, "hs1", "chris", "sufficiently_long_password_chris")
 
 	// Alice creates a room for herself.
-	public_room := alice.CreateRoom(t, map[string]interface{}{
+	publicRoom := alice.CreateRoom(t, map[string]interface{}{
 		"preset": "public_chat",
 	})
 
 	// Alice waits to see the join event.
 	alice.SyncUntilTimelineHas(
-		t, public_room, func(ev gjson.Result) bool {
+		t, publicRoom, func(ev gjson.Result) bool {
 			return ev.Get("type").Str == "m.room.member" &&
 				ev.Get("state_key").Str == alice.UserID &&
 				ev.Get("content.membership").Str == "join"

--- a/tests/csapi/ignored_users_test.go
+++ b/tests/csapi/ignored_users_test.go
@@ -1,3 +1,6 @@
+// +build !dendrite_blacklist
+
+// Rationale for being included in Dendrite's blacklist: https://github.com/matrix-org/dendrite/issues/600
 package csapi_tests
 
 import (

--- a/tests/csapi/ignored_users_test.go
+++ b/tests/csapi/ignored_users_test.go
@@ -1,6 +1,3 @@
-// +build !dendrite_blacklist
-
-// Rationale for being included in Dendrite's blacklist: https://github.com/matrix-org/dendrite/issues/600
 package csapi_tests
 
 import (


### PR DESCRIPTION
Reproduces matrix-org/synapse#11506.

Leaving this as a draft until I fix the issue in Synapse. Sticking up a PR for now to see what Dendrite does.

Also note:  fd3a555  is cherry-picked from #237 