### PR TITLE
Use server's default room version to create new rooms

### DIFF
--- a/internal/federation/server.go
+++ b/internal/federation/server.go
@@ -133,6 +133,7 @@ func (s *Server) MakeAliasMapping(aliasLocalpart, roomID string) string {
 // The `events` will be added to this room. Returns the created room.
 func (s *Server) MustMakeRoom(t *testing.T, roomVer gomatrixserverlib.RoomVersion, events []b.Event) *ServerRoom {
 	roomID := fmt.Sprintf("!%d:%s", len(s.rooms), s.ServerName)
+	t.Logf("Creating room %s with version %s", roomID, roomVer)
 	room := newRoom(roomVer, roomID)
 
 	// sign all these events

--- a/tests/federation_room_get_missing_events_test.go
+++ b/tests/federation_room_get_missing_events_test.go
@@ -36,6 +36,9 @@ import (
 func TestOutboundFederationIgnoresMissingEventWithBadJSONForRoomVersion6(t *testing.T) {
 	deployment := Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
+
+	alice := deployment.Client(t, "hs1", "@alice:hs1")
+
 	srv := federation.NewServer(t, deployment,
 		federation.HandleKeyRequests(),
 		federation.HandleMakeSendJoinRequests(),
@@ -52,12 +55,11 @@ func TestOutboundFederationIgnoresMissingEventWithBadJSONForRoomVersion6(t *test
 		onGetMissingEvents(w, req)
 	}).Methods("POST")
 
-	ver := gomatrixserverlib.RoomVersionV6
+	ver := alice.GetDefaultRoomVersion(t)
 	charlie := srv.UserID("charlie")
 	room := srv.MustMakeRoom(t, ver, federation.InitialRoomEvents(ver, charlie))
 	roomAlias := srv.MakeAliasMapping("flibble", room.RoomID)
 	// join the room
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
 	alice.JoinRoom(t, roomAlias, nil)
 
 	latestEvent := room.Timeline[len(room.Timeline)-1]

--- a/tests/federation_room_send_test.go
+++ b/tests/federation_room_send_test.go
@@ -22,6 +22,8 @@ func TestOutboundFederationSend(t *testing.T) {
 	deployment := Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
+	alice := deployment.Client(t, "hs1", "@alice:hs1")
+
 	waiter := NewWaiter()
 	wantEventType := "m.room.message"
 
@@ -45,13 +47,12 @@ func TestOutboundFederationSend(t *testing.T) {
 	defer cancel()
 
 	// the remote homeserver creates a public room
-	ver := gomatrixserverlib.RoomVersionV5
+	ver := alice.GetDefaultRoomVersion(t)
 	charlie := srv.UserID("charlie")
 	serverRoom := srv.MustMakeRoom(t, ver, federation.InitialRoomEvents(ver, charlie))
 	roomAlias := srv.MakeAliasMapping("flibble", serverRoom.RoomID)
 
 	// the local homeserver joins the room
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
 	alice.JoinRoom(t, roomAlias, []string{docker.HostnameRunningComplement})
 
 	// the local homeserver sends an event into the room

--- a/tests/msc2836_test.go
+++ b/tests/msc2836_test.go
@@ -187,6 +187,9 @@ func TestEventRelationships(t *testing.T) {
 func TestFederatedEventRelationships(t *testing.T) {
 	deployment := Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
+
+	alice := deployment.Client(t, "hs1", "@alice:hs1")
+
 	srv := federation.NewServer(t, deployment,
 		federation.HandleKeyRequests(),
 		federation.HandleMakeSendJoinRequests(),
@@ -195,7 +198,7 @@ func TestFederatedEventRelationships(t *testing.T) {
 	defer cancel()
 
 	// create a room on Complement, add some events to walk.
-	roomVer := gomatrixserverlib.RoomVersionV6
+	ver := alice.GetDefaultRoomVersion(t)
 	charlie := srv.UserID("charlie")
 	room := srv.MustMakeRoom(t, roomVer, federation.InitialRoomEvents(roomVer, charlie))
 	eventA := srv.MustCreateEvent(t, room, b.Event{
@@ -293,7 +296,6 @@ func TestFederatedEventRelationships(t *testing.T) {
 
 	// join the room on HS1
 	// HS1 will not have any of these messages, only the room state.
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
 	alice.JoinRoom(t, room.RoomID, []string{srv.ServerName})
 
 	// send a new child in the thread (child of D) so the HS has something to latch on to.

--- a/tests/msc2836_test.go
+++ b/tests/msc2836_test.go
@@ -198,7 +198,7 @@ func TestFederatedEventRelationships(t *testing.T) {
 	defer cancel()
 
 	// create a room on Complement, add some events to walk.
-	ver := alice.GetDefaultRoomVersion(t)
+	roomVer := alice.GetDefaultRoomVersion(t)
 	charlie := srv.UserID("charlie")
 	room := srv.MustMakeRoom(t, roomVer, federation.InitialRoomEvents(roomVer, charlie))
 	eventA := srv.MustCreateEvent(t, room, b.Event{


### PR DESCRIPTION
When we are creating a test room on the Complement server, use the same version
as the server defaults to.