### PR TITLE
Re-design client.SyncUntil

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -251,7 +251,7 @@ func (c *CSAPI) MustSyncUntil(t *testing.T, syncReq SyncReq, checks ...SyncCheck
 		err := "Checkers:\n"
 		for _, c := range checkers {
 			err += strings.Join(c.errs, "\n")
-			err += ", "
+			err += ", \n"
 		}
 		return err
 	}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -607,7 +607,7 @@ func SyncJoinedTo(userID, roomID string) SyncCheckOpt {
 }
 
 // Calls the `check` function for each global account data event, and returns with success if the
-// check function returns true.
+// `check` function returns true for at least one event.
 func SyncGlobalAccountDataHas(check func(gjson.Result) bool) SyncCheckOpt {
 	return func(clientUserID string, topLevelSyncJSON gjson.Result) error {
 		return loopArray(topLevelSyncJSON, "account_data.events", check)

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -161,9 +161,9 @@ func (c *CSAPI) SendEventSynced(t *testing.T, roomID string, e b.Event) string {
 	body := ParseJSON(t, res)
 	eventID := GetJSONFieldStr(t, body, "event_id")
 	t.Logf("SendEventSynced waiting for event ID %s", eventID)
-	c.SyncUntilTimelineHas(t, roomID, func(r gjson.Result) bool {
+	c.MustSyncUntil(t, SyncReq{}, SyncTimelineHas(roomID, func(r gjson.Result) bool {
 		return r.Get("event_id").Str == eventID
-	})
+	}))
 	return eventID
 }
 
@@ -280,17 +280,6 @@ func (c *CSAPI) MustSyncUntil(t *testing.T, syncReq SyncReq, checks ...SyncCheck
 			return syncReq.Since
 		}
 	}
-}
-
-// SyncUntilTimelineHas is a wrapper around `SyncUntil`.
-// It blocks and continually calls `/sync` until
-// - we have joined the given room
-// - we see an event in the room for which the `check` function returns True
-// If the `check` function fails the test, the failing event will be automatically logged.
-// Will time out after CSAPI.SyncUntilTimeout.
-func (c *CSAPI) SyncUntilTimelineHas(t *testing.T, roomID string, check func(gjson.Result) bool) {
-	t.Helper()
-	c.SyncUntil(t, "", "", "rooms.join."+GjsonEscape(roomID)+".timeline.events", check)
 }
 
 // SyncUntil blocks and continually calls /sync until

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -685,5 +685,5 @@ func loopArray(object gjson.Result, key string, check func(gjson.Result) bool) e
 			return nil
 		}
 	}
-	return fmt.Errorf("check function did not pass for %d elements", len(goArray))
+	return fmt.Errorf("check function did not pass for %d elements: %v", len(goArray), array.Raw)
 }

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -628,5 +628,5 @@ func loopArray(object gjson.Result, key string, check func(gjson.Result) bool) e
 			return nil
 		}
 	}
-	return fmt.Errorf("check function did not pass for %d elements: %v", len(goArray), array.Raw)
+	return fmt.Errorf("check function did not pass while iterating over %d elements: %v", len(goArray), array.Raw)
 }

--- a/tests/csapi/apidoc_room_create_test.go
+++ b/tests/csapi/apidoc_room_create_test.go
@@ -159,10 +159,5 @@ func TestRoomCreateWithInvites(t *testing.T) {
 		"invite": []string{bob.UserID},
 	})
 
-	bob.SyncUntil(t, "", "", "rooms.invite."+client.GjsonEscape(roomID)+".invite_state.events", func(event gjson.Result) bool {
-		return event.Get("type").Str == "m.room.member" &&
-			event.Get("content.membership").Str == "invite" &&
-			event.Get("state_key").Str == bob.UserID &&
-			event.Get("sender").Str == alice.UserID
-	})
+	bob.MustSyncUntil(t, client.SyncReq{}, client.SyncInvitedTo(bob.UserID, roomID))
 }

--- a/tests/csapi/apidoc_room_members_test.go
+++ b/tests/csapi/apidoc_room_members_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/tidwall/gjson"
 
 	"github.com/matrix-org/complement/internal/b"
+	"github.com/matrix-org/complement/internal/client"
 	"github.com/matrix-org/complement/internal/match"
 	"github.com/matrix-org/complement/internal/must"
 )
@@ -116,12 +117,12 @@ func TestRoomMembers(t *testing.T) {
 
 			alice.InviteRoom(t, roomID, bob.UserID)
 
-			bob.SyncUntilInvitedTo(t, roomID)
+			bob.MustSyncUntil(t, client.SyncReq{}, client.SyncInvitedTo(bob.UserID, roomID))
 
 			bob.JoinRoom(t, roomID, nil)
 
 			// Sync to make sure bob has joined
-			bob.SyncUntilJoined(t, roomID)
+			bob.MustSyncUntil(t, client.SyncReq{}, client.SyncJoinedTo(bob.UserID, roomID))
 
 			stateKey := ""
 			alice.SendEventSynced(t, roomID, b.Event{
@@ -151,11 +152,11 @@ func TestRoomMembers(t *testing.T) {
 
 			bob.InviteRoom(t, roomID, alice.UserID)
 
-			alice.SyncUntilInvitedTo(t, roomID)
+			since := alice.MustSyncUntil(t, client.SyncReq{}, client.SyncInvitedTo(alice.UserID, roomID))
 
 			alice.JoinRoom(t, roomID, nil)
 
-			alice.SyncUntilJoined(t, roomID)
+			alice.MustSyncUntil(t, client.SyncReq{Since: since}, client.SyncJoinedTo(alice.UserID, roomID))
 		})
 	})
 }

--- a/tests/csapi/apidoc_room_members_test.go
+++ b/tests/csapi/apidoc_room_members_test.go
@@ -35,17 +35,7 @@ func TestRoomMembers(t *testing.T) {
 				},
 			})
 
-			bob.SyncUntilTimelineHas(
-				t,
-				roomID,
-				func(ev gjson.Result) bool {
-					if ev.Get("type").Str != "m.room.member" || ev.Get("state_key").Str != bob.UserID {
-						return false
-					}
-					must.EqualStr(t, ev.Get("content").Get("membership").Str, "join", "Bob failed to join the room")
-					return true
-				},
-			)
+			bob.MustSyncUntil(t, client.SyncReq{}, client.SyncJoinedTo(bob.UserID, roomID))
 		})
 		// sytest: POST /join/:room_alias can join a room
 		t.Run("POST /join/:room_alias can join a room", func(t *testing.T) {
@@ -66,17 +56,7 @@ func TestRoomMembers(t *testing.T) {
 				},
 			})
 
-			bob.SyncUntilTimelineHas(
-				t,
-				roomID,
-				func(ev gjson.Result) bool {
-					if ev.Get("type").Str != "m.room.member" || ev.Get("state_key").Str != bob.UserID {
-						return false
-					}
-					must.EqualStr(t, ev.Get("content").Get("membership").Str, "join", "Bob failed to join the room")
-					return true
-				},
-			)
+			bob.MustSyncUntil(t, client.SyncReq{}, client.SyncJoinedTo(bob.UserID, roomID))
 		})
 		// sytest: POST /join/:room_id can join a room
 		t.Run("POST /join/:room_id can join a room", func(t *testing.T) {
@@ -96,8 +76,7 @@ func TestRoomMembers(t *testing.T) {
 				},
 			})
 
-			bob.SyncUntilTimelineHas(
-				t,
+			bob.MustSyncUntil(t, client.SyncReq{}, client.SyncTimelineHas(
 				roomID,
 				func(ev gjson.Result) bool {
 					if ev.Get("type").Str != "m.room.member" || ev.Get("state_key").Str != bob.UserID {
@@ -106,7 +85,7 @@ func TestRoomMembers(t *testing.T) {
 					must.EqualStr(t, ev.Get("content").Get("membership").Str, "join", "Bob failed to join the room")
 					return true
 				},
-			)
+			))
 		})
 		// sytest: Test that we can be reinvited to a room we created
 		t.Run("Test that we can be reinvited to a room we created", func(t *testing.T) {
@@ -140,15 +119,14 @@ func TestRoomMembers(t *testing.T) {
 			alice.LeaveRoom(t, roomID)
 
 			// Wait until alice has left the room
-			bob.SyncUntilTimelineHas(
-				t,
+			bob.MustSyncUntil(t, client.SyncReq{}, client.SyncTimelineHas(
 				roomID,
 				func(ev gjson.Result) bool {
 					return ev.Get("type").Str == "m.room.member" &&
 						ev.Get("content.membership").Str == "leave" &&
 						ev.Get("state_key").Str == alice.UserID
 				},
-			)
+			))
 
 			bob.InviteRoom(t, roomID, alice.UserID)
 			since := alice.MustSyncUntil(t, client.SyncReq{}, client.SyncInvitedTo(alice.UserID, roomID))

--- a/tests/csapi/apidoc_room_members_test.go
+++ b/tests/csapi/apidoc_room_members_test.go
@@ -151,11 +151,8 @@ func TestRoomMembers(t *testing.T) {
 			)
 
 			bob.InviteRoom(t, roomID, alice.UserID)
-
 			since := alice.MustSyncUntil(t, client.SyncReq{}, client.SyncInvitedTo(alice.UserID, roomID))
-
 			alice.JoinRoom(t, roomID, nil)
-
 			alice.MustSyncUntil(t, client.SyncReq{Since: since}, client.SyncJoinedTo(alice.UserID, roomID))
 		})
 	})

--- a/tests/csapi/room_ban_test.go
+++ b/tests/csapi/room_ban_test.go
@@ -3,8 +3,6 @@ package csapi_tests
 import (
 	"testing"
 
-	"github.com/tidwall/gjson"
-
 	"github.com/matrix-org/complement/internal/b"
 	"github.com/matrix-org/complement/internal/client"
 	"github.com/matrix-org/complement/internal/match"
@@ -59,12 +57,7 @@ func TestNotPresentUserCannotBanOthers(t *testing.T) {
 		},
 	})
 
-	// todo: replace with `SyncUntilJoined`
-	bob.SyncUntilTimelineHas(t, roomID, func(event gjson.Result) bool {
-		return event.Get("type").Str == "m.room.member" &&
-			event.Get("content.membership").Str == "join" &&
-			event.Get("state_key").Str == bob.UserID
-	})
+	bob.MustSyncUntil(t, client.SyncReq{}, client.SyncJoinedTo(bob.UserID, roomID))
 
 	res := charlie.DoFunc(t, "POST", []string{"_matrix", "client", "r0", "rooms", roomID, "ban"}, client.WithJSONBody(t, map[string]interface{}{
 		"user_id": bob.UserID,

--- a/tests/csapi/rooms_state_test.go
+++ b/tests/csapi/rooms_state_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/tidwall/gjson"
 
 	"github.com/matrix-org/complement/internal/b"
+	"github.com/matrix-org/complement/internal/client"
 	"github.com/matrix-org/complement/internal/must"
 )
 
@@ -32,20 +33,20 @@ func TestRoomCreationReportsEventsToMyself(t *testing.T) {
 		t.Run("Room creation reports m.room.create to myself", func(t *testing.T) {
 			t.Parallel()
 			alice := deployment.Client(t, "hs1", userID)
-			alice.SyncUntilTimelineHas(t, roomID, func(ev gjson.Result) bool {
+			alice.MustSyncUntil(t, client.SyncReq{}, client.SyncTimelineHas(roomID, func(ev gjson.Result) bool {
 				if ev.Get("type").Str != "m.room.create" {
 					return false
 				}
 				must.EqualStr(t, ev.Get("sender").Str, userID, "wrong sender")
 				must.EqualStr(t, ev.Get("content").Get("creator").Str, userID, "wrong content.creator")
 				return true
-			})
+			}))
 		})
 		// sytest: Room creation reports m.room.member to myself
 		t.Run("Room creation reports m.room.member to myself", func(t *testing.T) {
 			t.Parallel()
 			alice := deployment.Client(t, "hs1", userID)
-			alice.SyncUntilTimelineHas(t, roomID, func(ev gjson.Result) bool {
+			alice.MustSyncUntil(t, client.SyncReq{}, client.SyncTimelineHas(roomID, func(ev gjson.Result) bool {
 				if ev.Get("type").Str != "m.room.member" {
 					return false
 				}
@@ -53,7 +54,7 @@ func TestRoomCreationReportsEventsToMyself(t *testing.T) {
 				must.EqualStr(t, ev.Get("state_key").Str, userID, "wrong state_key")
 				must.EqualStr(t, ev.Get("content").Get("membership").Str, "join", "wrong content.membership")
 				return true
-			})
+			}))
 		})
 	})
 }

--- a/tests/csapi/user_directory_display_names_test.go
+++ b/tests/csapi/user_directory_display_names_test.go
@@ -140,7 +140,7 @@ func TestRoomSpecificUsernameChange(t *testing.T) {
 	})
 
 	// Alice waits until she sees the invite, then accepts.
-	alice.SyncUntilInvitedTo(t, privateRoom)
+	alice.MustSyncUntil(t, client.SyncReq{}, client.SyncInvitedTo(alice.UserID, privateRoom))
 	alice.JoinRoom(t, privateRoom, nil)
 
 	// Alice reveals her private name to Bob
@@ -169,7 +169,7 @@ func TestRoomSpecificUsernameAtJoin(t *testing.T) {
 
 	// Alice waits until she sees the invite, then accepts.
 	// When she accepts, she does so with a specific displayname.
-	alice.SyncUntilInvitedTo(t, privateRoom)
+	alice.MustSyncUntil(t, client.SyncReq{}, client.SyncInvitedTo(alice.UserID, privateRoom))
 	alice.JoinRoom(t, privateRoom, nil)
 
 	// Alice reveals her private name to Bob

--- a/tests/federation_room_event_auth_test.go
+++ b/tests/federation_room_event_auth_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/tidwall/gjson"
 
 	"github.com/matrix-org/complement/internal/b"
+	"github.com/matrix-org/complement/internal/client"
 	"github.com/matrix-org/complement/internal/federation"
 	"github.com/matrix-org/complement/internal/must"
 )
@@ -208,13 +209,12 @@ func TestInboundFederationRejectsEventsWithRejectedAuthEvents(t *testing.T) {
 	t.Logf("Sent transaction; awaiting arrival")
 
 	// wait for alice to receive sentinelEvent
-	alice.SyncUntilTimelineHas(
-		t,
+	alice.MustSyncUntil(t, client.SyncReq{}, client.SyncTimelineHas(
 		room.RoomID,
 		func(ev gjson.Result) bool {
 			return ev.Get("event_id").Str == sentinelEvent.EventID()
 		},
-	)
+	))
 
 	// now inspect the results. Each of the rejected events should give a 404 for /event
 	t.Run("Outlier should be rejected", func(t *testing.T) {


### PR DESCRIPTION
See https://github.com/matrix-org/complement/issues/271 for the rationale why this is being changed. All affected tests have been updated.

Using functional options similar to `client.MustDoFunc`, API usage now looks like:

Initial sync:
```go
bob.InviteRoom(t, roomID, alice.UserID)
alice.JoinRoom(t, roomID, nil)
alice.MustSyncUntil(t, client.SyncReq{}, client.SyncJoinedTo(alice.UserID, roomID))
```

Incremental sync:
```go
since := alice.MustSyncUntil(t, client.SyncReq{TimeoutMillis: "0"}) // get a since token
bob.InviteRoom(t, roomID, alice.UserID)
since = alice.MustSyncUntil(t, client.SyncReq{Since: since}, client.SyncInvitedTo(alice.UserID, roomID))
alice.JoinRoom(t, roomID, nil)
alice.MustSyncUntil(t, client.SyncReq{Since: since}, client.SyncJoinedTo(alice.UserID, roomID))
```

The full list of check functions currently supported mirrors the removed functions:
 - `SyncTimelineHas(roomID, func(gjson.Result) bool)`
 - `SyncInvitedTo(userID, roomID)`
 - `SyncJoinedTo(userID, roomID)`
 - `SyncGlobalAccountDataHas(func(gjson.Result) bool)`

The addition of a `client.SyncReq` struct also now allows test writers to either do initial or incremental syncs. Previously, all the helper Sync functions would be doing initial syncs. Furthermore, helper functions for "X must be joined|invited to room Y" can now be done via a passive watching user in the room, whereas previously the user being invited|joined had to be the one syncing.

In addition, when `MustSyncUntil` fails, it produces more structured output like this:
```
@alice:hs1 MustSyncUntil: timed out after 5.042472596s. Seen 7 /sync responses. Checkers:
                [t=17.011919ms] Response #1: SyncJoinedTo(no-body-here,!R8eqLIUTShHAAOMs:hs1): SyncTimelineHas(!R8eqLIUTShHAAOMs:hs1): check function did not pass for 1 elements: [{"content":{"displayname":"Alice","membership":"invite"},"event_id":"$_b969RP9k7W_igBzH7u3a5J-gRjrpBAEcBvoae3GBuY","origin_server_ts":1639072742359,"sender":"@bob:hs1","state_key":"@alice:hs1","type":"m.room.member","unsigned":{"prev_content":{"membership":"leave"},"prev_sender":"@alice:hs1","replaces_state":"$zIyl36Gdk4y-yFKfI7xiNBDASjOamA6XjQHnF_Ra1Mc"}}]
                [t=27.172348ms] Response #2: SyncJoinedTo(no-body-here,!R8eqLIUTShHAAOMs:hs1): SyncTimelineHas(!R8eqLIUTShHAAOMs:hs1): check function did not pass for 1 elements: [{"content":{"avatar_url":"","displayname":"Alice","membership":"join"},"event_id":"$lD1wxscnoiptouGcSlNaFcos-aTarQhReKlKna4Q2nQ","origin_server_ts":1639072742422,"sender":"@alice:hs1","state_key":"@alice:hs1","type":"m.room.member","unsigned":{"prev_content":{"displayname":"Alice","membership":"invite"},"prev_sender":"@bob:hs1","replaces_state":"$_b969RP9k7W_igBzH7u3a5J-gRjrpBAEcBvoae3GBuY"}}]
                [t=1.028929806s] Response #3: SyncJoinedTo(no-body-here,!R8eqLIUTShHAAOMs:hs1): SyncTimelineHas(!R8eqLIUTShHAAOMs:hs1): Key rooms.join.!R8eqLIUTShHAAOMs:hs1.timeline.events does not exist
                [t=2.032334539s] Response #4: SyncJoinedTo(no-body-here,!R8eqLIUTShHAAOMs:hs1): SyncTimelineHas(!R8eqLIUTShHAAOMs:hs1): Key rooms.join.!R8eqLIUTShHAAOMs:hs1.timeline.events does not exist
                [t=3.034670555s] Response #5: SyncJoinedTo(no-body-here,!R8eqLIUTShHAAOMs:hs1): SyncTimelineHas(!R8eqLIUTShHAAOMs:hs1): Key rooms.join.!R8eqLIUTShHAAOMs:hs1.timeline.events does not exist
                [t=4.037416588s] Response #6: SyncJoinedTo(no-body-here,!R8eqLIUTShHAAOMs:hs1): SyncTimelineHas(!R8eqLIUTShHAAOMs:hs1): Key rooms.join.!R8eqLIUTShHAAOMs:hs1.timeline.events does not exist
                [t=5.042470504s] Response #7: SyncJoinedTo(no-body-here,!R8eqLIUTShHAAOMs:hs1): SyncTimelineHas(!R8eqLIUTShHAAOMs:hs1): Key rooms.join.!R8eqLIUTShHAAOMs:hs1.timeline.events does not exist
```

cc @clokep @richvdh @ShadowJonathan @MadLittleMods @DMRobertson  as you have all recently contributed code to this project.