### PR TITLE
Add 2 sytests and de-boilerplate `apidoc_room_create_test.go`

### DIFF
--- a/tests/csapi/apidoc_room_create_test.go
+++ b/tests/csapi/apidoc_room_create_test.go
@@ -1,6 +1,7 @@
 package csapi_tests
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/tidwall/gjson"
@@ -11,23 +12,31 @@ import (
 	"github.com/matrix-org/complement/internal/must"
 )
 
+func doCreateRoom(t *testing.T, c *client.CSAPI, json map[string]interface{}, match match.HTTPResponse) {
+	res := c.DoFunc(t, "POST", []string{"_matrix", "client", "r0", "createRoom"}, client.WithJSONBody(t, json))
+	must.MatchResponse(t, res, match)
+}
+
 func TestRoomCreate(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
-	authedClient := deployment.Client(t, "hs1", "@alice:hs1")
+
+	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	bob := deployment.Client(t, "hs1", "@bob:hs1")
+
 	t.Run("Parallel", func(t *testing.T) {
 		// sytest: POST /createRoom makes a public room
 		t.Run("POST /createRoom makes a public room", func(t *testing.T) {
 			t.Parallel()
-			reqBody := client.WithJSONBody(t, map[string]interface{}{
+			roomAlias := "30-room-create-alias-random"
+
+			doCreateRoom(t, alice, map[string]interface{}{
 				"visibility":      "public",
-				"room_alias_name": "30-room-create-alias-random",
-			})
-			res := authedClient.MustDoFunc(t, "POST", []string{"_matrix", "client", "r0", "createRoom"}, reqBody)
-			must.MatchResponse(t, res, match.HTTPResponse{
+				"room_alias_name": roomAlias,
+			}, match.HTTPResponse{
+				StatusCode: 200,
 				JSON: []match.JSON{
-					match.JSONKeyPresent("room_id"),
-					match.JSONKeyPresent("room_alias"),
+					match.JSONKeyEqual("room_alias", fmt.Sprintf("#%s:hs1", roomAlias)),
 					match.JSONKeyTypeEqual("room_id", gjson.String),
 				},
 			})
@@ -35,13 +44,12 @@ func TestRoomCreate(t *testing.T) {
 		// sytest: POST /createRoom makes a private room
 		t.Run("POST /createRoom makes a private room", func(t *testing.T) {
 			t.Parallel()
-			reqBody := client.WithJSONBody(t, map[string]interface{}{
+
+			doCreateRoom(t, alice, map[string]interface{}{
 				"visibility": "private",
-			})
-			res := authedClient.MustDoFunc(t, "POST", []string{"_matrix", "client", "r0", "createRoom"}, reqBody)
-			must.MatchResponse(t, res, match.HTTPResponse{
+			}, match.HTTPResponse{
+				StatusCode: 200,
 				JSON: []match.JSON{
-					match.JSONKeyPresent("room_id"),
 					match.JSONKeyTypeEqual("room_id", gjson.String),
 				},
 			})
@@ -49,15 +57,15 @@ func TestRoomCreate(t *testing.T) {
 		// sytest: POST /createRoom makes a room with a topic
 		t.Run("POST /createRoom makes a room with a topic", func(t *testing.T) {
 			t.Parallel()
-			roomID := authedClient.CreateRoom(t, map[string]interface{}{
+
+			roomID := alice.CreateRoom(t, map[string]interface{}{
 				"topic":  "Test Room",
 				"preset": "public_chat",
 			})
-			res := authedClient.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "state", "m.room.topic"})
+			res := alice.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "state", "m.room.topic"})
 			must.MatchResponse(t, res, match.HTTPResponse{
+				StatusCode: 200,
 				JSON: []match.JSON{
-					match.JSONKeyPresent("topic"),
-					match.JSONKeyTypeEqual("topic", gjson.String),
 					match.JSONKeyEqual("topic", "Test Room"),
 				},
 			})
@@ -65,15 +73,14 @@ func TestRoomCreate(t *testing.T) {
 		// sytest: POST /createRoom makes a room with a name
 		t.Run("POST /createRoom makes a room with a name", func(t *testing.T) {
 			t.Parallel()
-			roomID := authedClient.CreateRoom(t, map[string]interface{}{
+			roomID := alice.CreateRoom(t, map[string]interface{}{
 				"name":   "Test Room",
 				"preset": "public_chat",
 			})
-			res := authedClient.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "state", "m.room.name"})
+			res := alice.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "state", "m.room.name"})
 			must.MatchResponse(t, res, match.HTTPResponse{
+				StatusCode: 200,
 				JSON: []match.JSON{
-					match.JSONKeyPresent("name"),
-					match.JSONKeyTypeEqual("name", gjson.String),
 					match.JSONKeyEqual("name", "Test Room"),
 				},
 			})
@@ -81,15 +88,14 @@ func TestRoomCreate(t *testing.T) {
 		// sytest: POST /createRoom creates a room with the given version
 		t.Run("POST /createRoom creates a room with the given version", func(t *testing.T) {
 			t.Parallel()
-			roomID := authedClient.CreateRoom(t, map[string]interface{}{
+			roomID := alice.CreateRoom(t, map[string]interface{}{
 				"room_version": "2",
 				"preset":       "public_chat",
 			})
-			res := authedClient.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "state", "m.room.create"})
+			res := alice.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "state", "m.room.create"})
 			must.MatchResponse(t, res, match.HTTPResponse{
+				StatusCode: 200,
 				JSON: []match.JSON{
-					match.JSONKeyPresent("room_version"),
-					match.JSONKeyTypeEqual("room_version", gjson.String),
 					match.JSONKeyEqual("room_version", "2"),
 				},
 			})
@@ -97,15 +103,13 @@ func TestRoomCreate(t *testing.T) {
 		// sytest: POST /createRoom makes a private room with invites
 		t.Run("POST /createRoom makes a private room with invites", func(t *testing.T) {
 			t.Parallel()
-			userInvite := deployment.RegisterUser(t, "hs1", "create_room", "superuser")
-			reqBody := client.WithJSONBody(t, map[string]interface{}{
+
+			doCreateRoom(t, alice, map[string]interface{}{
 				"visibility": "private",
-				"invite":     []string{userInvite.UserID},
-			})
-			res := authedClient.MustDoFunc(t, "POST", []string{"_matrix", "client", "r0", "createRoom"}, reqBody)
-			must.MatchResponse(t, res, match.HTTPResponse{
+				"invite":     []string{bob.UserID},
+			}, match.HTTPResponse{
+				StatusCode: 200,
 				JSON: []match.JSON{
-					match.JSONKeyPresent("room_id"),
 					match.JSONKeyTypeEqual("room_id", gjson.String),
 				},
 			})
@@ -113,16 +117,14 @@ func TestRoomCreate(t *testing.T) {
 		// sytest: POST /createRoom rejects attempts to create rooms with numeric versions
 		t.Run("POST /createRoom rejects attempts to create rooms with numeric versions", func(t *testing.T) {
 			t.Parallel()
-			reqBody := client.WithJSONBody(t, map[string]interface{}{
+
+			doCreateRoom(t, alice, map[string]interface{}{
 				"visibility":   "private",
 				"room_version": 1,
 				"preset":       "public_chat",
-			})
-			res := authedClient.DoFunc(t, "POST", []string{"_matrix", "client", "r0", "createRoom"}, reqBody)
-			must.MatchResponse(t, res, match.HTTPResponse{
+			}, match.HTTPResponse{
 				StatusCode: 400,
 				JSON: []match.JSON{
-					match.JSONKeyPresent("errcode"),
 					match.JSONKeyEqual("errcode", "M_BAD_JSON"),
 				},
 			})
@@ -130,34 +132,77 @@ func TestRoomCreate(t *testing.T) {
 		// sytest: POST /createRoom rejects attempts to create rooms with unknown versions
 		t.Run("POST /createRoom rejects attempts to create rooms with unknown versions", func(t *testing.T) {
 			t.Parallel()
-			reqBody := client.WithJSONBody(t, map[string]interface{}{
+
+			doCreateRoom(t, alice, map[string]interface{}{
 				"visibility":   "private",
 				"room_version": "ahfgwjyerhgiuveisbruvybseyrugvi",
 				"preset":       "public_chat",
-			})
-			res := authedClient.DoFunc(t, "POST", []string{"_matrix", "client", "r0", "createRoom"}, reqBody)
-			must.MatchResponse(t, res, match.HTTPResponse{
+			}, match.HTTPResponse{
 				StatusCode: 400,
 				JSON: []match.JSON{
-					match.JSONKeyPresent("errcode"),
 					match.JSONKeyEqual("errcode", "M_UNSUPPORTED_ROOM_VERSION"),
 				},
 			})
 		})
+		// sytest: Rooms can be created with an initial invite list (SYN-205)
+		t.Run("Rooms can be created with an initial invite list (SYN-205)", func(t *testing.T) {
+			roomID := alice.CreateRoom(t, map[string]interface{}{
+				"invite": []string{bob.UserID},
+			})
+
+			bob.MustSyncUntil(t, client.SyncReq{}, client.SyncInvitedTo(bob.UserID, roomID))
+		})
+
+		// sytest: Can /sync newly created room
+		t.Run("Can /sync newly created room", func(t *testing.T) {
+			roomID := alice.CreateRoom(t, map[string]interface{}{})
+
+			// This will do the syncing for us
+			alice.SendEventSynced(t, roomID, b.Event{
+				Type:    "m.room.test",
+				Content: map[string]interface{}{},
+			})
+		})
+
+		// sytest: POST /createRoom ignores attempts to set the room version via creation_content
+		t.Run("POST /createRoom ignores attempts to set the room version via creation_content", func(t *testing.T) {
+			roomID := alice.CreateRoom(t, map[string]interface{}{
+				"creation_content": map[string]interface{}{
+					"test":         "azerty",
+					"room_version": "test",
+				},
+			})
+
+			// Wait until user has joined the room
+			alice.MustSyncUntil(t, client.SyncReq{}, client.SyncJoinedTo(alice.UserID, roomID))
+
+			// Get ordered timeline via a full sync
+			res, _ := alice.MustSync(t, client.SyncReq{})
+
+			roomObj := res.Get("rooms.join." + client.GjsonEscape(roomID))
+
+			if !roomObj.Exists() {
+				t.Fatalf("Room did not appear in sync")
+			}
+
+			event0 := roomObj.Get("timeline.events.0")
+
+			if !event0.Exists() {
+				t.Fatalf("First timeline event does not exist")
+			}
+
+			if event0.Get("type").Str != "m.room.create" {
+				t.Fatalf("First event was not m.room.create: %s", event0)
+			}
+			if !event0.Get("content.room_version").Exists() {
+				t.Fatalf("Room creation event did not have room version: %s", event0)
+			}
+			if event0.Get("content.room_version").Str == "test" {
+				t.Fatalf("Room creation event room_version was a bogus room version: %s", event0)
+			}
+			if event0.Get("content.test").Str != "azerty" {
+				t.Fatalf("Room creation event content 'test' key did not have expected value of 'azerty': %s", event0)
+			}
+		})
 	})
-}
-
-// sytest: Rooms can be created with an initial invite list (SYN-205)
-func TestRoomCreateWithInvites(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintOneToOneRoom)
-	defer deployment.Destroy(t)
-
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	bob := deployment.Client(t, "hs1", "@bob:hs1")
-
-	roomID := alice.CreateRoom(t, map[string]interface{}{
-		"invite": []string{bob.UserID},
-	})
-
-	bob.MustSyncUntil(t, client.SyncReq{}, client.SyncInvitedTo(bob.UserID, roomID))
 }


### PR DESCRIPTION
This adds;
- `Can /sync newly created room`
- `POST /createRoom ignores attempts to set the room version via creation_content`