### PR TITLE
Fix CA mount problems in local dev

### DIFF
--- a/internal/docker/deployer.go
+++ b/internal/docker/deployer.go
@@ -173,8 +173,12 @@ func deployImage(
 	}
 
 	toMount := []Volume{
-		&VolumeCA{}, &VolumeAppService{},
+		&VolumeAppService{},
 	}
+	if os.Getenv("COMPLEMENT_CA") == "true" {
+		toMount = append(toMount, &VolumeCA{})
+	}
+
 	for _, m := range toMount {
 		err = m.Prepare(ctx, docker, contextStr)
 		if err != nil {

--- a/internal/docker/volumes.go
+++ b/internal/docker/volumes.go
@@ -73,6 +73,7 @@ func (v *VolumeCA) Prepare(ctx context.Context, docker *client.Client, x string)
 			}
 		}
 		v.source = path.Join(cwd, "ca")
+		v.typ = mount.TypeBind
 	}
 	return nil
 }


### PR DESCRIPTION
Fix CA mount problems in local dev

Fix https://github.com/matrix-org/complement/pull/283#discussion_r783448724

 1. Fix mount type not being defined on for the CA cert bind mount:
    ```
    failed to deployBaseImage: Error response from daemon: invalid mount config for type "": mount type unknown
    ```
 1. Fix CA volume being created even when the `COMPLEMENT_CA` environment variable isn't defined which leads to `unable to load certificate` errors because `/ca/ca.crt` does not exist.
 

## Dev notes
 
```go
logrus.WithFields(logrus.Fields{
  "mounts": fmt.Sprintf("%+v", mounts),
}).Error("ContainerCreate")
```

---
 
```
Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
Images built; running complement
2022/01/12 14:50:45 config: &{BaseImageURI:complement-synapse BaseImageArgs:[] DebugLoggingEnabled:false AlwaysPrintServerLogs:true BestEffort:false SpawnHSTimeout:30s KeepBlueprints:[] PackageNamespace:pkg}
=== RUN   TestImportHistoricalMessages
2022/01/12 14:50:45 pkg.hs_with_application_service.hs1 : failed to deployBaseImage: Error response from daemon: invalid mount config for type "": mount type unknown
2022/01/12 14:50:45 pkg.hs_with_application_service.hs2 : failed to deployBaseImage: Error response from daemon: invalid mount config for type "": mount type unknown
    msc2716_test.go:63: Deploy: Failed to construct blueprint: Error response from daemon: invalid mount config for type "": mount type unknown
--- FAIL: TestImportHistoricalMessages (0.10s)
FAIL
FAIL	github.com/matrix-org/complement/tests	0.522s
2022/01/12 14:50:45 config: &{BaseImageURI:complement-synapse BaseImageArgs:[] DebugLoggingEnabled:false AlwaysPrintServerLogs:true BestEffort:false SpawnHSTimeout:30s KeepBlueprints:[] PackageNamespace:csapi}
testing: warning: no tests to run
PASS
ok  	github.com/matrix-org/complement/tests/csapi	0.270s [no tests to run]
FAIL
```
 
 ```
 2022/01/12 16:25:11 pkg.hs_with_application_service.hs1 : Server logs:
Signature ok
subject=CN = hs1
Can't open /ca/ca.crt for reading, No such file or directory
140140056409408:error:02001002:system library:fopen:No such file or directory:../crypto/bio/bss_file.c:69:fopen('/ca/ca.crt','r')
140140056409408:error:2006D080:BIO routines:BIO_new_file:no such file:../crypto/bio/bss_file.c:76:
unable to load certificate
```


