### PR TITLE
Fix `/send_join` response

### DIFF
--- a/internal/federation/handle.go
+++ b/internal/federation/handle.go
@@ -96,13 +96,18 @@ func SendJoinRequestsHandler(s *Server, w http.ResponseWriter, req *http.Request
 		w.WriteHeader(500)
 		w.Write([]byte("complement: HandleMakeSendJoinRequests send_join cannot parse event JSON: " + err.Error()))
 	}
+
+	// build the state list *before* we insert the new event
+	var stateEvents = room.AllCurrentState()
+	var authEvents = room.AuthChain()
+
 	// insert the join event into the room state
 	room.AddEvent(event)
 
-	// return current state and auth chain
+	// return state and auth chain
 	b, err := json.Marshal(gomatrixserverlib.RespSendJoin{
-		AuthEvents:  room.AuthChain(),
-		StateEvents: room.AllCurrentState(),
+		AuthEvents:  authEvents,
+		StateEvents: stateEvents,
 		Origin:      gomatrixserverlib.ServerName(s.ServerName),
 	})
 	if err != nil {


### PR DESCRIPTION
The [spec](https://spec.matrix.org/v1.1/server-server-api/#put_matrixfederationv1send_joinroomideventid) is explicit that the response to `/send_join` should give "The resolved current room state *prior* to the join event", so make that so.