### PR TITLE
Don't listen on :8448 for the Complement federation server

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,9 +32,9 @@ jobs:
             default_branch: master
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2 # Checkout complement
 
-      # Env vars are set file a file given by $GITHUB_PATH
+      # Env vars are set file a file given by $GITHUB_PATH. We need both Go 1.17 and GOPATH on env.
       # See https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-system-path
       - name: "Set Go Version"
         run: |
@@ -49,9 +49,8 @@ jobs:
         # We don't need to install Go because it is included on the Ubuntu 20.04 image:
         # See https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md specifically GOROOT_1_17_X64
         run: |
-          sudo apt-get update && sudo apt-get install -y libolm3
+          sudo apt-get update && sudo apt-get install -y libolm3 libolm-dev
           go get -v github.com/haveyoudebuggedit/gotestfmt/v2/cmd/gotestfmt@latest
-
 
       - name: "Checkout corresponding ${{ matrix.homeserver }} branch"
         # This is only done for Synapse since Dendrite's docker file pulls in

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,12 @@ jobs:
       # servers which listen on random high numbered ports.
       - name: "Install Complement Dependencies"
         run: |
-          sudo apt-get update && sudo apt-get install -y libolm3 golang-go
+          sudo apt-get update && sudo apt-get install -y libolm3
+          sudo apt-get remove golang-go
+          wget https://dl.google.com/go/go1.16.4.linux-amd64.tar.gz 
+          tar -xvf go1.16.4.linux-amd64.tar.gz  
+          mv go /usr/local 
+          export PATH=$PATH:/usr/local/go/bin
           go get github.com/haveyoudebuggedit/gotestfmt/v2/cmd/gotestfmt@latest
 
 
@@ -83,7 +88,7 @@ jobs:
         working-directory: homeserver
 
       - run: docker build -t homeserver -f dockerfiles/${{ matrix.homeserver }}.Dockerfile dockerfiles/
-      - run: set -o pipefail && cd complement-master && go test -p 2 -v -json -tags "${{ matrix.tags }}" ./tests/... 2>&1 | gotestfmt
+      - run: export PATH=$PATH:/usr/local/go/bin && set -o pipefail && cd complement-master && go test -p 2 -v -json -tags "${{ matrix.tags }}" ./tests/... 2>&1 | gotestfmt
         shell: bash # required for pipefail to be A Thing. pipefail is required to stop gotestfmt swallowing non-zero exit codes
         env:
           COMPLEMENT_BASE_IMAGE: homeserver

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,7 +91,9 @@ jobs:
           DOCKER_BUILDKIT: 1
 
       - run: docker build -t homeserver -f dockerfiles/${{ matrix.homeserver }}.Dockerfile dockerfiles/
-      - run: export PATH=$PATH:/usr/local/go/bin && set -o pipefail && cd complement-master && go test -p 2 -v -json -tags "${{ matrix.tags }}" ./tests/... 2>&1 | gotestfmt
+      - run: |
+          set -o pipefail &&
+          go test -p 2 -v -json -tags "${{ matrix.tags }}" ./tests/... 2>&1 | gotestfmt
         shell: bash # required for pipefail to be A Thing. pipefail is required to stop gotestfmt swallowing non-zero exit codes
         env:
           COMPLEMENT_BASE_IMAGE: homeserver

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,9 +87,12 @@ jobs:
         # built docker image).
         if: ${{ matrix.homeserver == 'Synapse' }}
         working-directory: homeserver
+        env:
+          DOCKER_BUILDKIT: 1
 
       - run: docker build -t homeserver -f dockerfiles/${{ matrix.homeserver }}.Dockerfile dockerfiles/
       - run: export PATH=$PATH:/usr/local/go/bin && set -o pipefail && cd complement-master && go test -p 2 -v -json -tags "${{ matrix.tags }}" ./tests/... 2>&1 | gotestfmt
         shell: bash # required for pipefail to be A Thing. pipefail is required to stop gotestfmt swallowing non-zero exit codes
         env:
           COMPLEMENT_BASE_IMAGE: homeserver
+          DOCKER_BUILDKIT: 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,6 +42,18 @@ jobs:
         - /var/run/docker.sock:/var/run/docker.sock
 
     steps:
+      # TODO: Make a shell script to install all Complement deps and use that here and in the Dockerfile
+      # Exactly the same steps as dockerfiles/ComplementCIBuildkite.Dockerfile but on the host. We need
+      # to do this so we can _be_ the host when running Complement so we can snaffle all the ports. If
+      # we run Complement _in_ Docker then we can't -p all high numbered ports which then breaks federation
+      # servers which listen on random high numbered ports.
+      - run: |
+          echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/complement.list && add-apt-repository ppa:longsleep/golang-backports && apt-get update && apt-get install -y libolm3 golang-go libolm-dev/buster-backports
+          curl -fsSL https://get.docker.com -o get-docker.sh && sh get-docker.sh
+          wget https://github.com/matrix-org/complement/archive/master.tar.gz
+          tar -xzf master.tar.gz && cd complement-master && go mod download 
+          cd complement-master && go get github.com/haveyoudebuggedit/gotestfmt/v2/cmd/gotestfmt@latest
+
       - uses: actions/checkout@v2
 
       - name: "Checkout corresponding ${{ matrix.homeserver }} branch"
@@ -82,7 +94,7 @@ jobs:
         working-directory: homeserver
 
       - run: docker build -t homeserver -f dockerfiles/${{ matrix.homeserver }}.Dockerfile dockerfiles/
-      - run: set -o pipefail && go test -p 2 -v -json -tags "${{ matrix.tags }}" ./tests/... 2>&1 | gotestfmt
+      - run: set -o pipefail && cd complement-master && go test -p 2 -v -json -tags "${{ matrix.tags }}" ./tests/... 2>&1 | gotestfmt
         shell: bash # required for pipefail to be A Thing. pipefail is required to stop gotestfmt swallowing non-zero exit codes
         env:
           COMPLEMENT_BASE_IMAGE: homeserver

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,18 +35,16 @@ jobs:
       - uses: actions/checkout@v2
 
       # TODO: Make a shell script to install all Complement deps and use that here and in the Dockerfile
-      # Exactly the same steps as dockerfiles/ComplementCIBuildkite.Dockerfile but on the host. We need
+      # Similar steps as dockerfiles/ComplementCIBuildkite.Dockerfile but on the host. We need
       # to do this so we can _be_ the host when running Complement so we can snaffle all the ports. If
       # we run Complement _in_ Docker then we can't -p all high numbered ports which then breaks federation
       # servers which listen on random high numbered ports.
       - name: "Install Complement Dependencies"
+        # We don't need to install Go because it is included on the Ubuntu 20.04 image:
+        # See https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md specifically GOROOT_1_17_X64
         run: |
           sudo apt-get update && sudo apt-get install -y libolm3
-          sudo apt-get remove golang-go
-          wget https://dl.google.com/go/go1.16.4.linux-amd64.tar.gz 
-          tar -xvf go1.16.4.linux-amd64.tar.gz  
-          mv go /usr/local 
-          export PATH=$PATH:/usr/local/go/bin
+          echo "$GOROOT_1_17_X64/bin" >> $GITHUB_PATH
           go get github.com/haveyoudebuggedit/gotestfmt/v2/cmd/gotestfmt@latest
 
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,7 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install -y libolm3
           echo "$GOROOT_1_17_X64/bin" >> $GITHUB_PATH
-          go get github.com/haveyoudebuggedit/gotestfmt/v2/cmd/gotestfmt@latest
+          GOROOT=$GOROOT_1_17_X64 go get github.com/haveyoudebuggedit/gotestfmt/v2/cmd/gotestfmt@latest
 
 
       - name: "Checkout corresponding ${{ matrix.homeserver }} branch"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      # TODO: Make a shell script to install all Complement deps and use that here and in the Dockerfile
+      # Env vars are set file a file given by $GITHUB_PATH
+      # See https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-system-path
+      - name: "Set Go Version"
+        run: echo "$GOROOT_1_17_X64/bin" >> $GITHUB_PATH
+
       # Similar steps as dockerfiles/ComplementCIBuildkite.Dockerfile but on the host. We need
       # to do this so we can _be_ the host when running Complement so we can snaffle all the ports. If
       # we run Complement _in_ Docker then we can't -p all high numbered ports which then breaks federation
@@ -44,8 +48,7 @@ jobs:
         # See https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md specifically GOROOT_1_17_X64
         run: |
           sudo apt-get update && sudo apt-get install -y libolm3
-          echo "$GOROOT_1_17_X64/bin" >> $GITHUB_PATH
-          GOROOT=$GOROOT_1_17_X64 go get github.com/haveyoudebuggedit/gotestfmt/v2/cmd/gotestfmt@latest
+          go get github.com/haveyoudebuggedit/gotestfmt/v2/cmd/gotestfmt@latest
 
 
       - name: "Checkout corresponding ${{ matrix.homeserver }} branch"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,7 @@ jobs:
       # servers which listen on random high numbered ports.
       - name: "Install Complement Dependencies"
         run: |
-          sudo echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/complement.list && sudo add-apt-repository ppa:longsleep/golang-backports && sudo apt-get update && sudo apt-get install -y libolm3 golang-go libolm-dev/buster-backports
+          sudo apt-get update && sudo apt-get install -y libolm3 golang-go libolm-dev/buster-backports
           go get github.com/haveyoudebuggedit/gotestfmt/v2/cmd/gotestfmt@latest
 
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,8 +41,7 @@ jobs:
       # servers which listen on random high numbered ports.
       - name: "Install Complement Dependencies"
         run: |
-          echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/complement.list && add-apt-repository ppa:longsleep/golang-backports && apt-get update && apt-get install -y libolm3 golang-go libolm-dev/buster-backports
-          curl -fsSL https://get.docker.com -o get-docker.sh && sh get-docker.sh
+          sudo echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/complement.list && sudo add-apt-repository ppa:longsleep/golang-backports && sudo apt-get update && sudo apt-get install -y libolm3 golang-go libolm-dev/buster-backports
           go get github.com/haveyoudebuggedit/gotestfmt/v2/cmd/gotestfmt@latest
 
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,7 +96,7 @@ jobs:
           set -o pipefail &&
           go test -p 2 -v -json -tags "${{ matrix.tags }}" ./tests/... 2>&1 | gotestfmt
         shell: bash # required for pipefail to be A Thing. pipefail is required to stop gotestfmt swallowing non-zero exit codes
+        name: Run Complement Tests
         env:
           COMPLEMENT_BASE_IMAGE: homeserver
           DOCKER_BUILDKIT: 1
-          CI: false # hacky hack hack to avoid talking to 172. addresses and assuming /ca/crt exists. We should remove this env var entirely

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,7 @@ jobs:
       # servers which listen on random high numbered ports.
       - name: "Install Complement Dependencies"
         run: |
-          sudo apt-get update && sudo apt-get install -y libolm3 golang-go libolm-dev/buster-backports
+          sudo apt-get update && sudo apt-get install -y libolm3 golang-go
           go get github.com/haveyoudebuggedit/gotestfmt/v2/cmd/gotestfmt@latest
 
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,9 @@ jobs:
       # Env vars are set file a file given by $GITHUB_PATH
       # See https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-system-path
       - name: "Set Go Version"
-        run: echo "$GOROOT_1_17_X64/bin" >> $GITHUB_PATH
+        run: |
+          echo "$GOROOT_1_17_X64/bin" >> $GITHUB_PATH
+          echo "~/go/bin" >> $GITHUB_PATH
 
       # Similar steps as dockerfiles/ComplementCIBuildkite.Dockerfile but on the host. We need
       # to do this so we can _be_ the host when running Complement so we can snaffle all the ports. If
@@ -48,7 +50,7 @@ jobs:
         # See https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md specifically GOROOT_1_17_X64
         run: |
           sudo apt-get update && sudo apt-get install -y libolm3
-          go get github.com/haveyoudebuggedit/gotestfmt/v2/cmd/gotestfmt@latest
+          go get -v github.com/haveyoudebuggedit/gotestfmt/v2/cmd/gotestfmt@latest
 
 
       - name: "Checkout corresponding ${{ matrix.homeserver }} branch"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,30 +31,20 @@ jobs:
             tags: msc2836 dendrite_blacklist
             default_branch: master
 
-    container:
-      image: matrixdotorg/complement  # dockerfiles/ComplementCIBuildkite.Dockerfile
-      env:
-        CI: true
-        DOCKER_BUILDKIT: 1
-      ports:
-        - 8448:8448
-      volumes:
-        - /var/run/docker.sock:/var/run/docker.sock
-
     steps:
+      - uses: actions/checkout@v2
+
       # TODO: Make a shell script to install all Complement deps and use that here and in the Dockerfile
       # Exactly the same steps as dockerfiles/ComplementCIBuildkite.Dockerfile but on the host. We need
       # to do this so we can _be_ the host when running Complement so we can snaffle all the ports. If
       # we run Complement _in_ Docker then we can't -p all high numbered ports which then breaks federation
       # servers which listen on random high numbered ports.
-      - run: |
+      - name: "Install Complement Dependencies"
+        run: |
           echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/complement.list && add-apt-repository ppa:longsleep/golang-backports && apt-get update && apt-get install -y libolm3 golang-go libolm-dev/buster-backports
           curl -fsSL https://get.docker.com -o get-docker.sh && sh get-docker.sh
-          wget https://github.com/matrix-org/complement/archive/master.tar.gz
-          tar -xzf master.tar.gz && cd complement-master && go mod download 
-          cd complement-master && go get github.com/haveyoudebuggedit/gotestfmt/v2/cmd/gotestfmt@latest
+          go get github.com/haveyoudebuggedit/gotestfmt/v2/cmd/gotestfmt@latest
 
-      - uses: actions/checkout@v2
 
       - name: "Checkout corresponding ${{ matrix.homeserver }} branch"
         # This is only done for Synapse since Dendrite's docker file pulls in

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -99,3 +99,4 @@ jobs:
         env:
           COMPLEMENT_BASE_IMAGE: homeserver
           DOCKER_BUILDKIT: 1
+          CI: false # hacky hack hack to avoid talking to 172. addresses and assuming /ca/crt exists. We should remove this env var entirely

--- a/internal/docker/builder.go
+++ b/internal/docker/builder.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"os"
 	"strings"
 	"time"
 
@@ -38,15 +37,6 @@ var (
 	// HostnameRunningDocker is the hostname of the docker daemon from the perspective of Complement.
 	HostnameRunningDocker = "localhost"
 )
-
-func init() {
-	if os.Getenv("CI") == "true" {
-		log.Println("Running under CI: redirecting localhost to docker host on 172.17.0.1")
-		// this assumes we are running inside docker so they have
-		// forwarded the docker socket to us and we're in a container.
-		HostnameRunningDocker = "172.17.0.1"
-	}
-}
 
 const complementLabel = "complement_context"
 

--- a/internal/docker/volumes.go
+++ b/internal/docker/volumes.go
@@ -1,13 +1,9 @@
 package docker
 
 import (
-	"bufio"
 	"context"
-	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
-	"strings"
 
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/volume"
@@ -31,50 +27,21 @@ type VolumeCA struct {
 // Prepare the Certificate Authority volume. This is independent of the homeserver calling Prepare
 // hence the contextual string is unused.
 func (v *VolumeCA) Prepare(ctx context.Context, docker *client.Client, x string) error {
-	// TODO: wrap in a lockfile
-	if os.Getenv("CI") == "true" {
-		// When in CI, Complement itself is a container with the CA volume mounted at /ca.
-		// We need to mount this volume to all homeserver containers to synchronize the CA cert.
-		// This is needed to establish trust among all containers.
-
-		containerID := getContainerID()
-		if containerID == "" {
-			return fmt.Errorf("failed to get container ID")
-		}
-		container, err := docker.ContainerInspect(ctx, containerID)
-		if err != nil {
-			return err
-		}
-		// Get the volume that matches the destination in our complement container
-		for i := range container.Mounts {
-			if container.Mounts[i].Destination == "/ca" {
-				v.source = container.Mounts[i].Name
-				v.typ = container.Mounts[i].Type
-				break
-			}
-		}
-		if v.source == "" {
-			// We did not find a volume. This container might be created without a volume,
-			// or CI=true is passed but we are not running in a container.
-			return fmt.Errorf("CI=true but there is no /ca mounted to Complement's container")
-		}
-	} else {
-		// When not in CI, our CA cert is placed in the current working dir.
-		// We bind mount this directory to all homeserver containers.
-		cwd, err := os.Getwd()
-		if err != nil {
-			return err
-		}
-		caCertificateDirHost := path.Join(cwd, "ca")
-		if _, err := os.Stat(caCertificateDirHost); os.IsNotExist(err) {
-			err = os.Mkdir(caCertificateDirHost, 0770)
-			if err != nil {
-				return err
-			}
-		}
-		v.source = path.Join(cwd, "ca")
-		v.typ = mount.TypeBind
+	// Our CA cert is placed in the current working dir.
+	// We bind mount this directory to all homeserver containers.
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
 	}
+	caCertificateDirHost := path.Join(cwd, "ca")
+	if _, err := os.Stat(caCertificateDirHost); os.IsNotExist(err) {
+		err = os.Mkdir(caCertificateDirHost, 0770)
+		if err != nil {
+			return err
+		}
+	}
+	v.source = path.Join(cwd, "ca")
+	v.typ = mount.TypeBind
 	return nil
 }
 
@@ -107,61 +74,4 @@ func (v *VolumeAppService) Mount() mount.Mount {
 		Source: v.source,
 		Target: "/appservices",
 	}
-}
-
-func getContainerID() string {
-	cid, err := getContainerIDViaCPUSet()
-	if err == nil {
-		return cid
-	}
-	fmt.Printf("failed to get container ID via cpuset, trying alternatives: %s\n", err)
-
-	cid, err = getContainerIDViaCGroups()
-	if err == nil {
-		return cid
-	}
-
-	fmt.Printf("failed to get container ID via cgroups, out of options: %s\n", err)
-	return ""
-}
-
-func getContainerIDViaCGroups() (string, error) {
-	file, err := os.Open("/proc/self/cgroup")
-	if err != nil {
-		return "", err
-	}
-
-	scanner := bufio.NewScanner(file)
-	defer file.Close()
-
-	scanner.Split(bufio.ScanLines)
-	for scanner.Scan() {
-		// Returns entries like this on github actions
-		// 9:memory:/actions_job/c8d555525bad6cd896c5aa985ef68010be47b1fb321c95547761c8f1a053b86e
-		line := scanner.Text()
-		segments := strings.Split(line, "/")
-		containerID := segments[len(segments)-1]
-		if containerID == "" || len(containerID) < 64 {
-			continue
-		}
-		return containerID, nil
-	}
-	return "", fmt.Errorf("faild to find container id in cgroups")
-}
-
-func getContainerIDViaCPUSet() (string, error) {
-	// /proc/1/cpuset should be /docker/<containerID>
-	cpuset, err := ioutil.ReadFile("/proc/1/cpuset")
-	if err != nil {
-		return "", err
-	}
-	if !strings.Contains(string(cpuset), "docker") {
-		return "", fmt.Errorf("could not identify container ID using /proc/1/cpuset - cpuset=%s", string(cpuset))
-	}
-	cpusetList := strings.Split(strings.TrimSpace(string(cpuset)), "/")
-	containerID := cpusetList[len(cpusetList)-1]
-	if len(containerID) == 0 {
-		return "", fmt.Errorf("cpuset missing container ID")
-	}
-	return containerID, nil
 }

--- a/internal/federation/handle.go
+++ b/internal/federation/handle.go
@@ -18,7 +18,7 @@ import (
 func MakeJoinRequestsHandler(s *Server, w http.ResponseWriter, req *http.Request) {
 	// Check federation signature
 	fedReq, errResp := gomatrixserverlib.VerifyHTTPRequest(
-		req, time.Now(), gomatrixserverlib.ServerName(s.ServerName), s.keyRing,
+		req, time.Now(), gomatrixserverlib.ServerName(s.serverName), s.keyRing,
 	)
 	if fedReq == nil {
 		w.WriteHeader(errResp.Code)
@@ -74,7 +74,7 @@ func MakeJoinRequestsHandler(s *Server, w http.ResponseWriter, req *http.Request
 // HandleMakeSendJoinRequests.
 func SendJoinRequestsHandler(s *Server, w http.ResponseWriter, req *http.Request) {
 	fedReq, errResp := gomatrixserverlib.VerifyHTTPRequest(
-		req, time.Now(), gomatrixserverlib.ServerName(s.ServerName), s.keyRing,
+		req, time.Now(), gomatrixserverlib.ServerName(s.serverName), s.keyRing,
 	)
 	if fedReq == nil {
 		w.WriteHeader(errResp.Code)
@@ -103,7 +103,7 @@ func SendJoinRequestsHandler(s *Server, w http.ResponseWriter, req *http.Request
 	b, err := json.Marshal(gomatrixserverlib.RespSendJoin{
 		AuthEvents:  room.AuthChain(),
 		StateEvents: room.AllCurrentState(),
-		Origin:      gomatrixserverlib.ServerName(s.ServerName),
+		Origin:      gomatrixserverlib.ServerName(s.serverName),
 	})
 	if err != nil {
 		w.WriteHeader(500)
@@ -136,7 +136,7 @@ func HandleInviteRequests(inviteCallback func(*gomatrixserverlib.Event)) func(*S
 		// https://matrix.org/docs/spec/server_server/r0.1.4#put-matrix-federation-v2-invite-roomid-eventid
 		s.mux.Handle("/_matrix/federation/v2/invite/{roomID}/{eventID}", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			fedReq, errResp := gomatrixserverlib.VerifyHTTPRequest(
-				req, time.Now(), gomatrixserverlib.ServerName(s.ServerName), s.keyRing,
+				req, time.Now(), gomatrixserverlib.ServerName(s.serverName), s.keyRing,
 			)
 			if fedReq == nil {
 				w.WriteHeader(errResp.Code)
@@ -164,7 +164,7 @@ func HandleInviteRequests(inviteCallback func(*gomatrixserverlib.Event)) func(*S
 			}
 
 			// Sign the event before we send it back
-			signedEvent := inviteRequest.Event().Sign(s.ServerName, s.KeyID, s.Priv)
+			signedEvent := inviteRequest.Event().Sign(s.serverName, s.KeyID, s.Priv)
 
 			// Send the response
 			res := map[string]interface{}{
@@ -190,7 +190,7 @@ func HandleDirectoryLookups() func(*Server) {
 				b, err := json.Marshal(gomatrixserverlib.RespDirectory{
 					RoomID: roomID,
 					Servers: []gomatrixserverlib.ServerName{
-						gomatrixserverlib.ServerName(s.ServerName),
+						gomatrixserverlib.ServerName(s.serverName),
 					},
 				})
 				if err != nil {
@@ -230,7 +230,7 @@ func HandleEventRequests() func(*Server) {
 			}
 
 			txn := gomatrixserverlib.Transaction{
-				Origin:         gomatrixserverlib.ServerName(srv.ServerName),
+				Origin:         gomatrixserverlib.ServerName(srv.serverName),
 				OriginServerTS: gomatrixserverlib.AsTimestamp(time.Now()),
 				PDUs: []json.RawMessage{
 					event.JSON(),
@@ -254,7 +254,7 @@ func HandleKeyRequests() func(*Server) {
 		keymux := srv.mux.PathPrefix("/_matrix/key/v2").Subrouter()
 		keyFn := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			k := gomatrixserverlib.ServerKeys{}
-			k.ServerName = gomatrixserverlib.ServerName(srv.ServerName)
+			k.ServerName = gomatrixserverlib.ServerName(srv.serverName)
 			publicKey := srv.Priv.Public().(ed25519.PublicKey)
 			k.VerifyKeys = map[gomatrixserverlib.KeyID]gomatrixserverlib.VerifyKey{
 				srv.KeyID: {
@@ -271,7 +271,7 @@ func HandleKeyRequests() func(*Server) {
 			}
 
 			k.Raw, err = gomatrixserverlib.SignJSON(
-				string(srv.ServerName), srv.KeyID, srv.Priv, toSign,
+				string(srv.serverName), srv.KeyID, srv.Priv, toSign,
 			)
 			if err != nil {
 				w.WriteHeader(500)
@@ -299,9 +299,9 @@ func HandleMediaRequests(mediaIds map[string]func(w http.ResponseWriter)) func(*
 			origin := vars["origin"]
 			mediaId := vars["mediaId"]
 
-			if origin != srv.ServerName {
+			if origin != srv.serverName {
 				w.WriteHeader(400)
-				w.Write([]byte("complement: Invalid Origin; Expected " + srv.ServerName))
+				w.Write([]byte("complement: Invalid Origin; Expected " + srv.serverName))
 				return
 			}
 
@@ -333,7 +333,7 @@ func HandleTransactionRequests(pduCallback func(*gomatrixserverlib.Event), eduCa
 
 			// Check federation signature
 			fedReq, errResp := gomatrixserverlib.VerifyHTTPRequest(
-				req, time.Now(), gomatrixserverlib.ServerName(srv.ServerName), srv.keyRing,
+				req, time.Now(), gomatrixserverlib.ServerName(srv.serverName), srv.keyRing,
 			)
 			if fedReq == nil {
 				log.Printf(

--- a/internal/federation/server.go
+++ b/internal/federation/server.go
@@ -316,7 +316,7 @@ func (s *Server) Listen() (cancel func()) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 
-	ln, err := net.Listen("tcp", ":0")
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		s.t.Fatalf("ListenFederationServer: net.Listen failed: %s", err)
 	}

--- a/internal/federation/server.go
+++ b/internal/federation/server.go
@@ -364,15 +364,15 @@ func GetOrCreateCaCert() (*x509.Certificate, *rsa.PrivateKey, error) {
 	}
 	tlsCACertPath = path.Join(wd, "ca", "ca.crt")
 	tlsCAKeyPath = path.Join(wd, "ca", "ca.key")
-	if _, err := os.Stat(path.Join(wd, "ca")); os.IsNotExist(err) {
+	if _, err = os.Stat(path.Join(wd, "ca")); os.IsNotExist(err) {
 		err = os.Mkdir(path.Join(wd, "ca"), 0770)
 		if err != nil {
 			return nil, nil, err
 		}
 	}
 
-	if _, err := os.Stat(tlsCACertPath); err == nil {
-		if _, err := os.Stat(tlsCAKeyPath); err == nil {
+	if _, err = os.Stat(tlsCACertPath); err == nil {
+		if _, err = os.Stat(tlsCAKeyPath); err == nil {
 			// We already created a CA cert, let's use that.
 			dat, err := ioutil.ReadFile(tlsCACertPath)
 			if err != nil {

--- a/internal/federation/server.go
+++ b/internal/federation/server.go
@@ -115,6 +115,12 @@ func NewServer(t *testing.T, deployment *docker.Deployment, opts ...func(*Server
 	return srv
 }
 
+// Return the server name of this federation server. Only valid AFTER calling Listen() - doing so
+// before will produce an error.
+//
+// It is not supported to call ServerName() before Listen() because Listen() modifies the server name.
+// Listen() will select a random OS-provided high-numbered port to listen on, which then needs to be
+// retrofitted into the server name so containers know how to route to it.
 func (s *Server) ServerName() string {
 	if !s.listening {
 		s.t.Fatalf("ServerName() called before Listen() - this is not supported because Listen() chooses a high-numbered port and thus changes the server name. Ensure you Listen() first!")

--- a/internal/federation/server.go
+++ b/internal/federation/server.go
@@ -60,10 +60,12 @@ func NewServer(t *testing.T, deployment *docker.Deployment, opts ...func(*Server
 	}
 
 	srv := &Server{
-		t:                           t,
-		Priv:                        priv,
-		KeyID:                       "ed25519:complement",
-		mux:                         mux.NewRouter(),
+		t:     t,
+		Priv:  priv,
+		KeyID: "ed25519:complement",
+		mux:   mux.NewRouter(),
+		// The server name will be updated when the caller calls Listen() to include the port number
+		// of the HTTP server e.g "host.docker.internal:56353"
 		serverName:                  docker.HostnameRunningComplement,
 		rooms:                       make(map[string]*ServerRoom),
 		aliases:                     make(map[string]string),

--- a/internal/federation/server.go
+++ b/internal/federation/server.go
@@ -374,7 +374,8 @@ func GetOrCreateCaCert() (*x509.Certificate, *rsa.PrivateKey, error) {
 	if _, err = os.Stat(tlsCACertPath); err == nil {
 		if _, err = os.Stat(tlsCAKeyPath); err == nil {
 			// We already created a CA cert, let's use that.
-			dat, err := ioutil.ReadFile(tlsCACertPath)
+			var dat []byte
+			dat, err = ioutil.ReadFile(tlsCACertPath)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -382,7 +383,8 @@ func GetOrCreateCaCert() (*x509.Certificate, *rsa.PrivateKey, error) {
 			if block == nil || block.Type != "CERTIFICATE" {
 				return nil, nil, errors.New("ca.crt is not a valid pem encoded x509 cert")
 			}
-			caCerts, err := x509.ParseCertificates(block.Bytes)
+			var caCerts []*x509.Certificate
+			caCerts, err = x509.ParseCertificates(block.Bytes)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -398,7 +400,8 @@ func GetOrCreateCaCert() (*x509.Certificate, *rsa.PrivateKey, error) {
 			if block == nil || block.Type != "RSA PRIVATE KEY" {
 				return nil, nil, errors.New("ca.key is not a valid pem encoded rsa private key")
 			}
-			priv, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+			var priv *rsa.PrivateKey
+			priv, err = x509.ParsePKCS1PrivateKey(block.Bytes)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/internal/federation/server.go
+++ b/internal/federation/server.go
@@ -316,7 +316,7 @@ func (s *Server) Listen() (cancel func()) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	ln, err := net.Listen("tcp", ":0") //nolint
 	if err != nil {
 		s.t.Fatalf("ListenFederationServer: net.Listen failed: %s", err)
 	}

--- a/tests/federation_query_profile_test.go
+++ b/tests/federation_query_profile_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/matrix-org/complement/internal/b"
-	"github.com/matrix-org/complement/internal/docker"
 	"github.com/matrix-org/complement/internal/federation"
 	"github.com/matrix-org/complement/internal/match"
 	"github.com/matrix-org/complement/internal/must"
@@ -29,7 +28,7 @@ func TestOutboundFederationProfile(t *testing.T) {
 
 	// sytest: Outbound federation can query profile data
 	t.Run("Outbound federation can query profile data", func(t *testing.T) {
-		remoteUserID := "@user:" + docker.HostnameRunningComplement
+		remoteUserID := srv.UserID("user")
 		remoteDisplayName := "my remote display name"
 
 		srv.Mux().Handle("/_matrix/federation/v1/query/profile", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {

--- a/tests/federation_room_event_auth_test.go
+++ b/tests/federation_room_event_auth_test.go
@@ -1,4 +1,5 @@
 // These tests currently fail on Dendrite, due to Dendrite bugs.
+//go:build !dendrite_blacklist
 // +build !dendrite_blacklist
 
 package tests
@@ -125,7 +126,7 @@ func TestInboundFederationRejectsEventsWithRejectedAuthEvents(t *testing.T) {
 	})
 	_, err := fedClient.SendTransaction(context.Background(), gomatrixserverlib.Transaction{
 		TransactionID:  "complement1",
-		Origin:         gomatrixserverlib.ServerName(srv.ServerName),
+		Origin:         gomatrixserverlib.ServerName(srv.ServerName()),
 		Destination:    "hs1",
 		OriginServerTS: gomatrixserverlib.AsTimestamp(time.Now()),
 		PDUs: []json.RawMessage{
@@ -196,7 +197,7 @@ func TestInboundFederationRejectsEventsWithRejectedAuthEvents(t *testing.T) {
 
 	_, err = fedClient.SendTransaction(context.Background(), gomatrixserverlib.Transaction{
 		TransactionID:  "complement2",
-		Origin:         gomatrixserverlib.ServerName(srv.ServerName),
+		Origin:         gomatrixserverlib.ServerName(srv.ServerName()),
 		Destination:    "hs1",
 		OriginServerTS: gomatrixserverlib.AsTimestamp(time.Now()),
 		PDUs: []json.RawMessage{

--- a/tests/federation_room_get_missing_events_test.go
+++ b/tests/federation_room_get_missing_events_test.go
@@ -92,7 +92,7 @@ func TestOutboundFederationIgnoresMissingEventWithBadJSONForRoomVersion6(t *test
 	}
 	eb.AuthEvents = room.AuthEvents(stateNeeded)
 	// we have to create this event as a v5 event which doesn't assert floats yet
-	signedBadEvent, err := eb.Build(time.Now(), gomatrixserverlib.ServerName(srv.ServerName), srv.KeyID, srv.Priv, gomatrixserverlib.RoomVersionV5)
+	signedBadEvent, err := eb.Build(time.Now(), gomatrixserverlib.ServerName(srv.ServerName()), srv.KeyID, srv.Priv, gomatrixserverlib.RoomVersionV5)
 	if err != nil {
 		t.Fatalf("failed to sign event: %s", err)
 	}

--- a/tests/federation_room_join_test.go
+++ b/tests/federation_room_join_test.go
@@ -67,7 +67,7 @@ func TestJoinViaRoomIDAndServerName(t *testing.T) {
 	serverRoom := srv.MustMakeRoom(t, ver, federation.InitialRoomEvents(ver, charlie))
 
 	// join the room by room ID, providing the serverName to join via
-	alice.JoinRoom(t, serverRoom.RoomID, []string{srv.ServerName})
+	alice.JoinRoom(t, serverRoom.RoomID, []string{srv.ServerName()})
 
 	// remove the make/send join paths from the Complement server to force HS2 to join via HS1
 	acceptMakeSendJoinRequests = false
@@ -290,7 +290,7 @@ func TestBannedUserCannotSendJoin(t *testing.T) {
 	// ... and does a switcheroo to turn it into a join for himself
 	makeJoinResp.JoinEvent.Sender = charlie
 	makeJoinResp.JoinEvent.StateKey = &charlie
-	joinEvent, err := makeJoinResp.JoinEvent.Build(time.Now(), gomatrixserverlib.ServerName(srv.ServerName), srv.KeyID, srv.Priv, makeJoinResp.RoomVersion)
+	joinEvent, err := makeJoinResp.JoinEvent.Build(time.Now(), gomatrixserverlib.ServerName(srv.ServerName()), srv.KeyID, srv.Priv, makeJoinResp.RoomVersion)
 	must.NotError(t, "JoinEvent.Build", err)
 
 	// SendJoin should return a 403.

--- a/tests/media_nofilename_test.go
+++ b/tests/media_nofilename_test.go
@@ -77,7 +77,7 @@ func TestMediaWithoutFileName(t *testing.T) {
 			t.Parallel()
 			alice := deployment.Client(t, "hs1", userID)
 
-			b, ct := alice.DownloadContent(t, fmt.Sprintf("mxc://%s/%s", srv.ServerName, remoteMediaId))
+			b, ct := alice.DownloadContent(t, fmt.Sprintf("mxc://%s/%s", srv.ServerName(), remoteMediaId))
 
 			// Check the Content-Type response header.
 			// NOTSPEC: There is ambiguity over whether the homeserver is allowed to change the

--- a/tests/msc2836_test.go
+++ b/tests/msc2836_test.go
@@ -1,3 +1,4 @@
+//go:build msc2836
 // +build msc2836
 
 package tests
@@ -296,7 +297,7 @@ func TestFederatedEventRelationships(t *testing.T) {
 
 	// join the room on HS1
 	// HS1 will not have any of these messages, only the room state.
-	alice.JoinRoom(t, room.RoomID, []string{srv.ServerName})
+	alice.JoinRoom(t, room.RoomID, []string{srv.ServerName()})
 
 	// send a new child in the thread (child of D) so the HS has something to latch on to.
 	eventE := srv.MustCreateEvent(t, room, b.Event{
@@ -315,7 +316,7 @@ func TestFederatedEventRelationships(t *testing.T) {
 	fedClient := srv.FederationClient(deployment)
 	_, err := fedClient.SendTransaction(context.Background(), gomatrixserverlib.Transaction{
 		TransactionID:  "complement",
-		Origin:         gomatrixserverlib.ServerName(srv.ServerName),
+		Origin:         gomatrixserverlib.ServerName(srv.ServerName()),
 		Destination:    gomatrixserverlib.ServerName("hs1"),
 		OriginServerTS: gomatrixserverlib.AsTimestamp(time.Now()),
 		PDUs: []json.RawMessage{

--- a/tests/room_hierarchy_test.go
+++ b/tests/room_hierarchy_test.go
@@ -1,3 +1,4 @@
+//go:build !dendrite_blacklist
 // +build !dendrite_blacklist
 
 // This file includes tests for MSC2946, the spaces summary API.


### PR DESCRIPTION
Instead, listen on a random OS-allocated high numbered port then
do a switcheroo on the `ServerName` so it reads correctly e.g
`host.docker.internal:56185`. This means the server name will be
invalid if it is read before `Server.Listen()` is called so we now
guard common access points in `Server` which rely on the server
name and fail tests if the server is not yet listening when those
functions are called. To further guard against misuse of server
name whilst it isn't valid, turn it into a private field.

As of this PR, it will now (in theory) be possible to scale out tests indefinitely as we no longer have any central point/resource which all tests rely on. This should make it possible to split `/tests` into more packages which make sense from a Matrix PoV.

Indirectly fixes https://github.com/matrix-org/complement/issues/60