### PR TITLE
 Alter container startup to wait for container healthcheck to OK.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ If you're looking to run against a custom Dockerfile, it must meet the following
 
 - The Dockerfile must `EXPOSE 8008` and `EXPOSE 8448` for client and federation traffic respectively.
 - The homeserver should run and listen on these ports.
+- The homeserver should become healthy within `COMPLEMENT_SPAWN_HS_TIMEOUT_SECS` if a `HEALTHCHECK` is specified in the Dockerfile.
 - The homeserver needs to `200 OK` requests to `GET /_matrix/client/versions`.
 - The homeserver needs to manage its own storage within the image.
 - The homeserver needs to accept the server name given by the environment variable `SERVER_NAME` at runtime.

--- a/dockerfiles/Synapse.Dockerfile
+++ b/dockerfiles/Synapse.Dockerfile
@@ -31,3 +31,6 @@ WORKDIR /data
 EXPOSE 8008 8448
 
 ENTRYPOINT ["/conf/start.sh"]
+
+HEALTHCHECK --start-period=5s --interval=1s --timeout=1s \
+    CMD curl -fSs http://localhost:8008/health || exit 1

--- a/dockerfiles/SynapseWorkers.Dockerfile
+++ b/dockerfiles/SynapseWorkers.Dockerfile
@@ -68,3 +68,6 @@ ENTRYPOINT \
   # Run the script that writes the necessary config files and starts supervisord, which in turn
   # starts everything else
   /configure_workers_and_start.py
+
+HEALTHCHECK --start-period=5s --interval=1s --timeout=1s \
+    CMD /bin/sh /healthcheck.sh

--- a/internal/docker/deployer.go
+++ b/internal/docker/deployer.go
@@ -259,8 +259,8 @@ func deployImage(
 	if debugLoggingEnabled {
 		log.Printf("%s: Started container %s", contextStr, containerID)
 	}
-
-	inspect, err := docker.ContainerInspect(ctx, containerID)
+	var inspect types.ContainerJSON
+	inspect, err = docker.ContainerInspect(ctx, containerID)
 	if err != nil {
 		return nil, err
 	}
@@ -268,11 +268,40 @@ func deployImage(
 	if err != nil {
 		return nil, fmt.Errorf("%s : image %s : %w", contextStr, imageID, err)
 	}
-	versionsURL := fmt.Sprintf("%s/_matrix/client/versions", baseURL)
-	// hit /versions to check it is up
 	var lastErr error
+
+	// Inspect health status of container to check it is up
 	stopTime := time.Now().Add(spawnHSTimeout)
 	iterCount := 0
+	if inspect.State.Health != nil {
+		// If the container has a healthcheck, wait for it first
+		for {
+			iterCount += 1
+			if time.Now().After(stopTime) {
+				lastErr = fmt.Errorf("timed out checking for homeserver to be up: %s", lastErr)
+				break
+			}
+			inspect, err = docker.ContainerInspect(ctx, containerID)
+			if err != nil {
+				lastErr = fmt.Errorf("Inspect container %s => error: %s", containerID, err)
+				time.Sleep(50 * time.Millisecond)
+				continue
+			}
+			if inspect.State.Health.Status != "healthy" {
+				lastErr = fmt.Errorf("Inspect container %s => health: %s", containerID, inspect.State.Health.Status)
+				time.Sleep(50 * time.Millisecond)
+				continue
+			}
+			lastErr = nil
+			break
+
+		}
+	}
+
+	// Having optionally waited for container to self-report healthy
+	// hit /versions to check it is actually responding
+	versionsURL := fmt.Sprintf("%s/_matrix/client/versions", baseURL)
+
 	for {
 		iterCount += 1
 		if time.Now().After(stopTime) {


### PR DESCRIPTION
Rebasing https://github.com/matrix-org/complement/pull/236 

Wait for healthcheck (if it exists) to return OK before checking version endpoint; In all cases, ensure the version endpoint is available before starting.

Users with an image containing a healthcheck they do not want to use can make a tweak to their container by adding

```
HEALTHCHECK NONE
```

to their docker file.