### PR TITLE
Add /get_missing_events test

### DIFF
--- a/internal/federation/server.go
+++ b/internal/federation/server.go
@@ -193,7 +193,7 @@ func (s *Server) MustSendTransaction(t *testing.T, deployment *docker.Deployment
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
 	resp, err := cli.SendTransaction(ctx, gomatrixserverlib.Transaction{
-		TransactionID: gomatrixserverlib.TransactionID(fmt.Sprintf("%d", time.Now().Nanosecond())),
+		TransactionID: gomatrixserverlib.TransactionID(fmt.Sprintf("complement-%d", time.Now().Nanosecond())),
 		Origin:        gomatrixserverlib.ServerName(s.ServerName()),
 		Destination:   gomatrixserverlib.ServerName(destination),
 		PDUs:          pdus,

--- a/internal/must/must.go
+++ b/internal/must/must.go
@@ -10,10 +10,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/tidwall/gjson"
 
 	"github.com/matrix-org/complement/internal/match"
-	"github.com/matrix-org/gomatrixserverlib"
 )
 
 // NotError will ensure `err` is nil else terminate the test with `msg`.

--- a/internal/must/must.go
+++ b/internal/must/must.go
@@ -13,6 +13,7 @@ import (
 	"github.com/tidwall/gjson"
 
 	"github.com/matrix-org/complement/internal/match"
+	"github.com/matrix-org/gomatrixserverlib"
 )
 
 // NotError will ensure `err` is nil else terminate the test with `msg`.
@@ -113,6 +114,21 @@ func MatchResponse(t *testing.T, res *http.Response, m match.HTTPResponse) []byt
 		}
 	}
 	return body
+}
+
+// MatchFederationRequest performs JSON assertions on incoming federation requests.
+func MatchFederationRequest(t *testing.T, fedReq *gomatrixserverlib.FederationRequest, matchers ...match.JSON) {
+	t.Helper()
+	content := fedReq.Content()
+	if !gjson.ValidBytes(content) {
+		t.Fatalf("MatchFederationRequest content is not valid JSON - %s", fedReq.RequestURI())
+	}
+
+	for _, jm := range matchers {
+		if err := jm(content); err != nil {
+			t.Fatalf("MatchFederationRequest %s - %s", err, fedReq.RequestURI())
+		}
+	}
 }
 
 // EqualStr ensures that got==want else logs an error.


### PR DESCRIPTION
Requires a few extra helpers which will be used in other federation tests.