### PR TITLE
Bump Dendrite docker base images to go 1.16

### DIFF
--- a/dockerfiles/Dendrite.Dockerfile
+++ b/dockerfiles/Dendrite.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15-stretch as build
+FROM golang:1.16-stretch as build
 RUN apt-get update && apt-get install -y sqlite3
 WORKDIR /build
 

--- a/dockerfiles/DendritePostgres.Dockerfile
+++ b/dockerfiles/DendritePostgres.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15-stretch as build
+FROM golang:1.16-stretch as build
 RUN apt-get update && apt-get install -y postgresql
 WORKDIR /build
 


### PR DESCRIPTION
I was getting the below errors when trying to build the Dendrite docker images, and I noticed that Dendrite was just bumped to Go 1.16 in matrix-org/dendrite#2122, so figured these needed updating as well ☺️

```
# github.com/Shopify/sarama
/go/pkg/mod/github.com/!shopify/sarama@v1.31.0/config.go:681:37: undefined: io.Discard
/go/pkg/mod/github.com/!shopify/sarama@v1.31.0/decompress.go:43:10: undefined: io.ReadAll
/go/pkg/mod/github.com/!shopify/sarama@v1.31.0/decompress.go:55:10: undefined: io.ReadAll
/go/pkg/mod/github.com/!shopify/sarama@v1.31.0/sarama.go:89:29: undefined: io.Discard
note: module requires Go 1.16
```