### PR TITLE
Always mount CA certificates and keys using in-memory files

### DIFF
--- a/cmd/homerunner/setup.go
+++ b/cmd/homerunner/setup.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/matrix-org/complement/internal/b"
-	"github.com/matrix-org/complement/internal/config"
 	"github.com/matrix-org/complement/internal/docker"
 	"github.com/sirupsen/logrus"
 )
@@ -36,13 +35,7 @@ func (r *Runtime) CreateDeployment(imageURI string, blueprint *b.Blueprint) (*do
 		return nil, expires, fmt.Errorf("blueprint must be supplied")
 	}
 	namespace := "homerunner_" + blueprint.Name
-	cfg := &config.Complement{
-		BaseImageURI:        imageURI,
-		DebugLoggingEnabled: true,
-		SpawnHSTimeout:      r.Config.SpawnHSTimeout,
-		BestEffort:          true,
-		PackageNamespace:    Pkg,
-	}
+	cfg := r.Config.DeriveComplementConfig(imageURI)
 	builder, err := docker.NewBuilder(cfg)
 	if err != nil {
 		return nil, expires, err

--- a/internal/docker/builder.go
+++ b/internal/docker/builder.go
@@ -41,10 +41,8 @@ var (
 const complementLabel = "complement_context"
 
 type Builder struct {
-	Config         *config.Complement
-	CSAPIPort      int
-	FederationPort int
-	Docker         *client.Client
+	Config *config.Complement
+	Docker *client.Client
 }
 
 func NewBuilder(cfg *config.Complement) (*Builder, error) {
@@ -53,10 +51,8 @@ func NewBuilder(cfg *config.Complement) (*Builder, error) {
 		return nil, err
 	}
 	return &Builder{
-		Docker:         cli,
-		Config:         cfg,
-		CSAPIPort:      8008,
-		FederationPort: 8448,
+		Docker: cli,
+		Config: cfg,
 	}, nil
 }
 
@@ -362,9 +358,9 @@ func (d *Builder) deployBaseImage(blueprintName string, hs b.Homeserver, context
 	asIDToRegistrationMap := asIDToRegistrationFromLabels(labelsForApplicationServices(hs))
 
 	return deployImage(
-		d.Docker, d.Config.BaseImageURI, d.CSAPIPort, fmt.Sprintf("complement_%s", contextStr),
+		d.Docker, d.Config.BaseImageURI, fmt.Sprintf("complement_%s", contextStr),
 		d.Config.PackageNamespace, blueprintName, hs.Name, asIDToRegistrationMap, contextStr,
-		networkID, d.Config.SpawnHSTimeout, d.Config.DebugLoggingEnabled,
+		networkID, d.Config,
 	)
 }
 

--- a/internal/docker/deployer.go
+++ b/internal/docker/deployer.go
@@ -157,6 +157,7 @@ func (d *Deployer) Destroy(dep *Deployment, printServerLogs bool) {
 	}
 }
 
+// nolint
 func deployImage(
 	docker *client.Client, imageID string, containerName, pkgNamespace, blueprintName, hsName string,
 	asIDToRegistrationMap map[string]string, contextStr, networkID string, cfg *config.Complement,

--- a/internal/docker/deployer.go
+++ b/internal/docker/deployer.go
@@ -22,7 +22,6 @@ import (
 	"log"
 	"net/http"
 	"net/url"
-	"os"
 	"runtime"
 	"sync"
 	"time"
@@ -71,6 +70,7 @@ func (d *Deployer) Deploy(ctx context.Context, blueprintName string) (*Deploymen
 		Deployer:      d,
 		BlueprintName: blueprintName,
 		HS:            make(map[string]HomeserverDeployment),
+		Config:        d.config,
 	}
 	images, err := d.Docker.ImageList(ctx, types.ImageListOptions{
 		Filters: label(
@@ -106,8 +106,8 @@ func (d *Deployer) Deploy(ctx context.Context, blueprintName string) (*Deploymen
 
 		// TODO: Make CSAPI port configurable
 		deployment, err := deployImage(
-			d.Docker, img.ID, 8008, fmt.Sprintf("complement_%s_%s_%s_%d", d.config.PackageNamespace, d.DeployNamespace, contextStr, counter),
-			d.config.PackageNamespace, blueprintName, hsName, asIDToRegistrationMap, contextStr, networkID, d.config.SpawnHSTimeout, d.config.DebugLoggingEnabled,
+			d.Docker, img.ID, fmt.Sprintf("complement_%s_%s_%s_%d", d.config.PackageNamespace, d.DeployNamespace, contextStr, counter),
+			d.config.PackageNamespace, blueprintName, hsName, asIDToRegistrationMap, contextStr, networkID, d.config,
 		)
 		if err != nil {
 			if deployment != nil && deployment.ContainerID != "" {
@@ -158,9 +158,8 @@ func (d *Deployer) Destroy(dep *Deployment, printServerLogs bool) {
 }
 
 func deployImage(
-	docker *client.Client, imageID string, csPort int, containerName, pkgNamespace, blueprintName, hsName string,
-	asIDToRegistrationMap map[string]string, contextStr, networkID string, spawnHSTimeout time.Duration,
-	debugLoggingEnabled bool,
+	docker *client.Client, imageID string, containerName, pkgNamespace, blueprintName, hsName string,
+	asIDToRegistrationMap map[string]string, contextStr, networkID string, cfg *config.Complement,
 ) (*HomeserverDeployment, error) {
 	ctx := context.Background()
 	var extraHosts []string
@@ -177,9 +176,6 @@ func deployImage(
 	toMount := []Volume{
 		&VolumeAppService{},
 	}
-	if os.Getenv("COMPLEMENT_CA") == "true" {
-		toMount = append(toMount, &VolumeCA{})
-	}
 
 	for _, m := range toMount {
 		err = m.Prepare(ctx, docker, contextStr)
@@ -191,8 +187,8 @@ func deployImage(
 
 	env := []string{
 		"SERVER_NAME=" + hsName,
-		// TODO: Remove once HS images don't rely on this anymore
-		"COMPLEMENT_CA=" + os.Getenv("COMPLEMENT_CA"),
+		// TODO: Remove once Synapse images don't rely on this anymore
+		"COMPLEMENT_CA=1",
 	}
 
 	body, err := docker.ContainerCreate(ctx, &container.Config{
@@ -222,41 +218,41 @@ func deployImage(
 	}
 
 	containerID := body.ID
-	if debugLoggingEnabled {
+	if cfg.DebugLoggingEnabled {
 		log.Printf("%s: Created container %s", contextStr, containerID)
 	}
 
 	// Create the application service files
 	for asID, registration := range asIDToRegistrationMap {
-		// Create a fake/virtual file in memory that we can copy to the container
-		// via https://stackoverflow.com/a/52131297/796832
-		var buf bytes.Buffer
-		tw := tar.NewWriter(&buf)
-		err = tw.WriteHeader(&tar.Header{
-			Name: fmt.Sprintf("/appservices/%s.yaml", url.PathEscape(asID)),
-			Mode: 0777,
-			Size: int64(len(registration)),
-		})
-		if err != nil {
-			return nil, fmt.Errorf("failed to copy regstration to container: %v", err)
-		}
-		tw.Write([]byte(registration))
-		tw.Close()
-
-		// Put our new fake file in the container volume
-		err = docker.CopyToContainer(context.Background(), containerID, "/", &buf, types.CopyToContainerOptions{
-			AllowOverwriteDirWithFile: false,
-		})
+		err = copyToContainer(docker, containerID, fmt.Sprintf("/appservices/%s.yaml", url.PathEscape(asID)), []byte(registration))
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	// Copy CA certificate and key
+	certBytes, err := cfg.CACertificateBytes()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get CA certificate: %s", err)
+	}
+	err = copyToContainer(docker, containerID, "/ca/ca.crt", certBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to copy CA certificate to container: %s", err)
+	}
+	certKeyBytes, err := cfg.CAPrivateKeyBytes()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get CA key: %s", err)
+	}
+	err = copyToContainer(docker, containerID, "/ca/ca.key", certKeyBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to copy CA key to container: %s", err)
 	}
 
 	err = docker.ContainerStart(ctx, containerID, types.ContainerStartOptions{})
 	if err != nil {
 		return nil, err
 	}
-	if debugLoggingEnabled {
+	if cfg.DebugLoggingEnabled {
 		log.Printf("%s: Started container %s", contextStr, containerID)
 	}
 	var inspect types.ContainerJSON
@@ -271,7 +267,7 @@ func deployImage(
 	var lastErr error
 
 	// Inspect health status of container to check it is up
-	stopTime := time.Now().Add(spawnHSTimeout)
+	stopTime := time.Now().Add(cfg.SpawnHSTimeout)
 	iterCount := 0
 	if inspect.State.Health != nil {
 		// If the container has a healthcheck, wait for it first
@@ -333,11 +329,37 @@ func deployImage(
 	if lastErr != nil {
 		return d, fmt.Errorf("%s: failed to check server is up. %w", contextStr, lastErr)
 	} else {
-		if debugLoggingEnabled {
+		if cfg.DebugLoggingEnabled {
 			log.Printf("%s: Server is responding after %d iterations", contextStr, iterCount)
 		}
 	}
 	return d, nil
+}
+
+func copyToContainer(docker *client.Client, containerID, path string, data []byte) error {
+	// Create a fake/virtual file in memory that we can copy to the container
+	// via https://stackoverflow.com/a/52131297/796832
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	err := tw.WriteHeader(&tar.Header{
+		Name: path,
+		Mode: 0777,
+		Size: int64(len(data)),
+	})
+	if err != nil {
+		return fmt.Errorf("copyToContainer: failed to write tarball header for %s: %v", path, err)
+	}
+	tw.Write([]byte(data))
+	tw.Close()
+
+	// Put our new fake file in the container volume
+	err = docker.CopyToContainer(context.Background(), containerID, "/", &buf, types.CopyToContainerOptions{
+		AllowOverwriteDirWithFile: false,
+	})
+	if err != nil {
+		return fmt.Errorf("copyToContainer: failed to copy: %s", err)
+	}
+	return nil
 }
 
 // RoundTripper is a round tripper that maps https://hs1 to the federation port of the container

--- a/internal/docker/deployment.go
+++ b/internal/docker/deployment.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/matrix-org/complement/internal/client"
+	"github.com/matrix-org/complement/internal/config"
 )
 
 // Deployment is the complete instantiation of a Blueprint, with running containers
@@ -15,7 +16,8 @@ type Deployment struct {
 	// The name of the deployed blueprint
 	BlueprintName string
 	// A map of HS name to a HomeserverDeployment
-	HS map[string]HomeserverDeployment
+	HS     map[string]HomeserverDeployment
+	Config *config.Complement
 }
 
 // HomeserverDeployment represents a running homeserver in a container.

--- a/internal/docker/volumes.go
+++ b/internal/docker/volumes.go
@@ -2,8 +2,6 @@ package docker
 
 import (
 	"context"
-	"os"
-	"path"
 
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/volume"
@@ -17,40 +15,6 @@ type Volume interface {
 	// Prepare the mount point. `contextStr` is unique to this blueprint+homeserver for homeserver
 	// specific mounts e.g appservices.
 	Prepare(ctx context.Context, docker *client.Client, contextStr string) error
-}
-
-type VolumeCA struct {
-	source string
-	typ    mount.Type
-}
-
-// Prepare the Certificate Authority volume. This is independent of the homeserver calling Prepare
-// hence the contextual string is unused.
-func (v *VolumeCA) Prepare(ctx context.Context, docker *client.Client, x string) error {
-	// Our CA cert is placed in the current working dir.
-	// We bind mount this directory to all homeserver containers.
-	cwd, err := os.Getwd()
-	if err != nil {
-		return err
-	}
-	caCertificateDirHost := path.Join(cwd, "ca")
-	if _, err := os.Stat(caCertificateDirHost); os.IsNotExist(err) {
-		err = os.Mkdir(caCertificateDirHost, 0770)
-		if err != nil {
-			return err
-		}
-	}
-	v.source = path.Join(cwd, "ca")
-	v.typ = mount.TypeBind
-	return nil
-}
-
-func (v *VolumeCA) Mount() mount.Mount {
-	return mount.Mount{
-		Type:   v.typ,
-		Source: v.source,
-		Target: "/ca",
-	}
 }
 
 type VolumeAppService struct {

--- a/tests/csapi/main_test.go
+++ b/tests/csapi/main_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/matrix-org/complement/internal/b"
 	"github.com/matrix-org/complement/internal/config"
 	"github.com/matrix-org/complement/internal/docker"
-	"github.com/matrix-org/complement/internal/federation"
 )
 
 var namespaceCounter uint64
@@ -39,16 +38,6 @@ func TestMain(m *testing.M) {
 	complementBuilder = builder
 	// remove any old images/containers/networks in case we died horribly before
 	builder.Cleanup()
-
-	if os.Getenv("COMPLEMENT_CA") == "true" {
-		log.Printf("Running with Complement CA")
-		// make sure CA certs are generated
-		_, _, err = federation.GetOrCreateCaCert()
-		if err != nil {
-			fmt.Printf("Error: %s", err)
-			os.Exit(1)
-		}
-	}
 
 	// we use GMSL which uses logrus by default. We don't want those logs in our test output unless they are Serious.
 	logrus.SetLevel(logrus.ErrorLevel)

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/matrix-org/complement/internal/b"
 	"github.com/matrix-org/complement/internal/config"
 	"github.com/matrix-org/complement/internal/docker"
-	"github.com/matrix-org/complement/internal/federation"
 )
 
 var namespaceCounter uint64
@@ -38,16 +37,6 @@ func TestMain(m *testing.M) {
 	complementBuilder = builder
 	// remove any old images/containers/networks in case we died horribly before
 	builder.Cleanup()
-
-	if os.Getenv("COMPLEMENT_CA") == "true" {
-		log.Printf("Running with Complement CA")
-		// make sure CA certs are generated
-		_, _, err = federation.GetOrCreateCaCert()
-		if err != nil {
-			fmt.Printf("Error: %s", err)
-			os.Exit(1)
-		}
-	}
 
 	// we use GMSL which uses logrus by default. We don't want those logs in our test output unless they are Serious.
 	logrus.SetLevel(logrus.ErrorLevel)


### PR DESCRIPTION
- Remove `VolumeCA` as we don't mount the file as a volume anymore.
- Remove `COMPLEMENT_CA` as we always mount regardless of whether or not the Homeserver image uses it.
- Rejig when and where the CA cert/key is made. Now it is automatically made when a `config.Complement` is made.
- Remove unused/redundant params for `deployImage`.

This can be optimised further. Currently, every time an image is deployed we inject the CA files. It would be sneakier to just do this once when a blueprint is made, so that way the files are already there when we deploy the container.

Fixes #65