### PR TITLE
Add `TestUnrejectRejectedEvents`

### DIFF
--- a/internal/b/blueprints.go
+++ b/internal/b/blueprints.go
@@ -106,6 +106,10 @@ type Event struct {
 	// This can be either []EventReference for room v1/v2, or []string for room v3 onwards.
 	// If it is left at nil, MustCreateEvent will populate it automatically based on the room state.
 	AuthEvents interface{}
+
+	// The prev events of the event if we want to override or falsify them.
+	// If it is left at nil, MustCreateEvent will populate it automatically based on the forward extremities.
+	PrevEvents interface{}
 }
 
 func MustValidate(bp Blueprint) Blueprint {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -572,6 +572,13 @@ func SyncTimelineHas(roomID string, check func(gjson.Result) bool) SyncCheckOpt 
 	}
 }
 
+// Check that the timeline for `roomID` has an event which matches the event ID.
+func SyncTimelineHasEventID(roomID string, eventID string) SyncCheckOpt {
+	return SyncTimelineHas(roomID, func(ev gjson.Result) bool {
+		return ev.Get("event_id").Str == eventID
+	})
+}
+
 // Checks that `userID` gets invited to `roomID`.
 //
 // This checks different parts of the /sync response depending on the client making the request.

--- a/internal/federation/server.go
+++ b/internal/federation/server.go
@@ -240,6 +240,17 @@ func (s *Server) MustCreateEvent(t *testing.T, room *ServerRoom, ev b.Event) *go
 			t.Fatalf("MustCreateEvent: failed to marshal event unsigned: %s - %+v", err, ev.Unsigned)
 		}
 	}
+
+	var prevEvents interface{}
+	if ev.PrevEvents != nil {
+		// We deliberately want to set the prev events.
+		prevEvents = ev.PrevEvents
+	} else {
+		// No other prev events were supplied so we'll just
+		// use the forward extremities of the room, which is
+		// the usual behaviour.
+		prevEvents = room.ForwardExtremities
+	}
 	eb := gomatrixserverlib.EventBuilder{
 		Sender:     ev.Sender,
 		Depth:      int64(room.Depth + 1), // depth starts at 1
@@ -247,7 +258,7 @@ func (s *Server) MustCreateEvent(t *testing.T, room *ServerRoom, ev b.Event) *go
 		StateKey:   ev.StateKey,
 		Content:    content,
 		RoomID:     room.RoomID,
-		PrevEvents: room.ForwardExtremities,
+		PrevEvents: prevEvents,
 		Unsigned:   unsigned,
 		AuthEvents: ev.AuthEvents,
 	}

--- a/tests/federation_unreject_rejected_test.go
+++ b/tests/federation_unreject_rejected_test.go
@@ -1,0 +1,83 @@
+package tests
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/matrix-org/complement/internal/b"
+	"github.com/matrix-org/complement/internal/client"
+	"github.com/matrix-org/complement/internal/federation"
+	"github.com/matrix-org/gomatrixserverlib"
+)
+
+// TestUnrejectRejectedEvents creates two events: A and B.
+// To start with, we're going to withhold A from the homeserver
+// and send event B. Event B should get rejected because event A
+// is referred to as a prev event but is missing. Then we'll
+// send event B again after sending event A. That should mean that
+// event B is unrejected on the second pass.
+func TestUnrejectRejectedEvents(t *testing.T) {
+	deployment := Deploy(t, b.BlueprintAlice)
+	defer deployment.Destroy(t)
+	alice := deployment.Client(t, "hs1", "@alice:hs1")
+
+	srv := federation.NewServer(t, deployment,
+		federation.HandleKeyRequests(),
+		federation.HandleMakeSendJoinRequests(),
+	)
+	srv.UnexpectedRequestsAreErrors = false
+	cancel := srv.Listen()
+	defer cancel()
+	bob := srv.UserID("bob")
+
+	// Create a new room on the federation server.
+	ver := gomatrixserverlib.RoomVersionV6 // TODO: use a default
+	serverRoom := srv.MustMakeRoom(t, ver, federation.InitialRoomEvents(ver, bob))
+
+	// Join Alice to the new room on the federation server.
+	alice.JoinRoom(t, serverRoom.RoomID, []string{srv.ServerName()})
+	alice.MustSyncUntil(
+		t, client.SyncReq{},
+		client.SyncJoinedTo(alice.UserID, serverRoom.RoomID),
+	)
+
+	// Create the events. Event A will have whatever the current forward
+	// extremities are as prev events. Event B will refer to event A only
+	// to guarantee the test will work.
+	eventA := srv.MustCreateEvent(t, serverRoom, b.Event{
+		Type:   "m.event.a",
+		Sender: bob,
+	})
+	eventB := srv.MustCreateEvent(t, serverRoom, b.Event{
+		Type:       "m.event.b",
+		Sender:     bob,
+		PrevEvents: []string{eventA.EventID()},
+	})
+
+	// Send event B into the room. Event A at this point is unknown
+	// to the homeserver and we're not going to respond to the events
+	// request for it, so it should get rejected.
+	srv.MustSendTransaction(t, deployment, "hs1", []json.RawMessage{eventB.JSON()}, nil)
+
+	// Now we're going to send Event A into the room, which should give
+	// the server the prerequisite event to pass Event B later.
+	srv.MustSendTransaction(t, deployment, "hs1", []json.RawMessage{eventA.JSON()}, nil)
+
+	// Wait for event A to appear in the room. We're going to store the
+	// sync token here because we want to use it in our next sync request.
+	since := alice.MustSyncUntil(
+		t, client.SyncReq{},
+		client.SyncTimelineHasEventID(serverRoom.RoomID, eventA.EventID()),
+	)
+
+	// Finally, send Event B again. This time it should be unrejected and
+	// should be sent as a new event down /sync.
+	srv.MustSendTransaction(t, deployment, "hs1", []json.RawMessage{eventB.JSON()}, nil)
+
+	// Now see if event B appears in the room. Use the since token to
+	// ensure we're only waiting for new events since event A.
+	alice.MustSyncUntil(
+		t, client.SyncReq{Since: since},
+		client.SyncTimelineHasEventID(serverRoom.RoomID, eventB.EventID()),
+	)
+}


### PR DESCRIPTION
This test is designed to ensure that we unreject a previously rejected event if we now have all of the prerequisites satisfied for it to pass on a second processing attempt. It is designed to ensure we don't regress, as we've been making changes around making sure Dendrite does the right thing in these cases (like matrix-org/dendrite#2159).

Since federation `/event` etc can probably return rejected events, the best way I can see to test this is to ensure that it only appears in sync for the first time *after* the prerequisite event. 