### PR TITLE
Warn about VOLUME

### DIFF
--- a/internal/docker/deployer.go
+++ b/internal/docker/deployer.go
@@ -182,8 +182,6 @@ func deployImage(
 
 	env := []string{
 		"SERVER_NAME=" + hsName,
-		// TODO: Remove once Synapse images don't rely on this anymore
-		"COMPLEMENT_CA=1",
 	}
 
 	body, err := docker.ContainerCreate(ctx, &container.Config{
@@ -255,6 +253,14 @@ func deployImage(
 	if err != nil {
 		return nil, err
 	}
+
+	for vol := range inspect.Config.Volumes {
+		log.Printf(
+			"WARNING: %s has a named VOLUME %s - volumes can lead to unpredictable behaviour due to "+
+				"test pollution. Remove the VOLUME in the Dockerfile to suppress this message.", containerName, vol,
+		)
+	}
+
 	baseURL, fedBaseURL, err := endpoints(inspect.NetworkSettings.Ports, 8008, 8448)
 	if err != nil {
 		return nil, fmt.Errorf("%s : image %s : %w", contextStr, imageID, err)


### PR DESCRIPTION
Fixes #306.

Now displays messages:
```
=== RUN   TestChangePassword
2022/02/11 12:28:46 WARNING: complement_csapi.alice.hs1 has a named VOLUME /etc/dendrite - volumes can lead to unpredictable behaviour due to test pollution. Remove the VOLUME in the Dockerfile to suppress this message.
```