### PR TITLE
Refactor blueprint creation

### DIFF
--- a/cmd/homerunner/setup.go
+++ b/cmd/homerunner/setup.go
@@ -40,7 +40,7 @@ func (r *Runtime) CreateDeployment(imageURI string, blueprint *b.Blueprint) (*do
 	if err != nil {
 		return nil, expires, err
 	}
-	if err = builder.ConstructBlueprintsIfNotExist([]b.Blueprint{*blueprint}); err != nil {
+	if err = builder.ConstructBlueprintIfNotExist(*blueprint); err != nil {
 		return nil, expires, fmt.Errorf("CreateDeployment: Failed to construct blueprint: %s", err)
 	}
 	d, err := docker.NewDeployer(namespace, cfg)

--- a/internal/docker/builder.go
+++ b/internal/docker/builder.go
@@ -201,7 +201,7 @@ func (d *Builder) ConstructBlueprint(bprint b.Blueprint) error {
 	var err error
 	waitTime := 5 * time.Second
 	startTime := time.Now()
-	for time.Now().Sub(startTime) < waitTime {
+	for time.Since(startTime) < waitTime {
 		images, err = d.Docker.ImageList(context.Background(), types.ImageListOptions{
 			Filters: label(
 				complementLabel,

--- a/tests/csapi/main_test.go
+++ b/tests/csapi/main_test.go
@@ -57,7 +57,7 @@ func Deploy(t *testing.T, blueprint b.Blueprint) *docker.Deployment {
 	if complementBuilder == nil {
 		t.Fatalf("complementBuilder not set, did you forget to call TestMain?")
 	}
-	if err := complementBuilder.ConstructBlueprintsIfNotExist([]b.Blueprint{blueprint}); err != nil {
+	if err := complementBuilder.ConstructBlueprintIfNotExist(blueprint); err != nil {
 		t.Fatalf("Deploy: Failed to construct blueprint: %s", err)
 	}
 	namespace := fmt.Sprintf("%d", atomic.AddUint64(&namespaceCounter, 1))

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -56,7 +56,7 @@ func Deploy(t *testing.T, blueprint b.Blueprint) *docker.Deployment {
 	if complementBuilder == nil {
 		t.Fatalf("complementBuilder not set, did you forget to call TestMain?")
 	}
-	if err := complementBuilder.ConstructBlueprintsIfNotExist([]b.Blueprint{blueprint}); err != nil {
+	if err := complementBuilder.ConstructBlueprintIfNotExist(blueprint); err != nil {
 		t.Fatalf("Deploy: Failed to construct blueprint: %s", err)
 	}
 	namespace := fmt.Sprintf("%d", atomic.AddUint64(&namespaceCounter, 1))


### PR DESCRIPTION
In the early days, Complement would make all known blueprints up front
in `TestMain`, so there was a function called `ConstructBlueprints`.

It soon became obvious that this was inefficient when you wanted to just
run a single test in an IDE, so blueprints became lazily loaded via a new
function `ConstructBlueprintsIfNotExist`. However, we never called this
new function with > 1 blueprint at a time. This PR makes this function
accept a single blueprint.

Whilst debugging flakey Complement deployments, I spotted a logic error
inside `ConstructBlueprints` where it would say that a blueprint was
created if the total number of images matching the complement context
was >= the number of blueprints. This is completely wrong. The blueprint
is only made when the total number of images == the number of _homeservers_
in the specified blueprint. This has now been fixed.

I don't know if this is the cause of some of the flakey Complement woes.
The net result is `ConstructBlueprintIfNotExist` may return _before_ the
blueprint has been created. This could in theory cause blueprints to be
created more than once, which could in theory lead to the HTTP 401 errors
seen, but the precise sequence is unknown.