### PR TITLE
Support host mounts via COMPLEMENT_HOST_MOUNTS

### DIFF
--- a/internal/docker/builder.go
+++ b/internal/docker/builder.go
@@ -252,6 +252,11 @@ func (d *Builder) construct(bprint b.Blueprint) (errs []error) {
 				// something went wrong, but we have a container which may have interesting logs
 				printLogs(d.Docker, res.containerID, res.contextStr)
 			}
+			if delErr := d.Docker.ContainerRemove(context.Background(), res.containerID, types.ContainerRemoveOptions{
+				Force: true,
+			}); delErr != nil {
+				d.log("%s: failed to remove container which failed to deploy: %s", res.contextStr, delErr)
+			}
 		}
 		// kill the container
 		defer func(r result) {
@@ -259,6 +264,7 @@ func (d *Builder) construct(bprint b.Blueprint) (errs []error) {
 			if killErr != nil {
 				d.log("%s : Failed to kill container %s: %s\n", r.contextStr, r.containerID, killErr)
 			}
+
 		}(res)
 		results[i] = res
 	}

--- a/internal/docker/deployer.go
+++ b/internal/docker/deployer.go
@@ -180,6 +180,18 @@ func deployImage(
 		extraHosts = []string{HostnameRunningComplement + ":172.17.0.1"}
 	}
 
+	for _, m := range cfg.HostMounts {
+		mounts = append(mounts, mount.Mount{
+			Source:   m.HostPath,
+			Target:   m.ContainerPath,
+			ReadOnly: m.ReadOnly,
+			Type:     mount.TypeBind,
+		})
+	}
+	if len(mounts) > 0 {
+		log.Printf("Using host mounts: %+v", mounts)
+	}
+
 	env := []string{
 		"SERVER_NAME=" + hsName,
 	}


### PR DESCRIPTION
Usage:
```
COMPLEMENT_HOST_MOUNTS='/my/local/dir:/container/dir;/another/local/dir:/container/dir2:ro'

which is:
  - /my/local/dir:/container/dir
  - /another/local/dir:/container/dir2:ro

which is of the form:
  - HOST:CONTAINER[:ro] where :ro makes the mount read-only.
```

Also fixes #274.