### PR TITLE
Bind HS containers to 127.0.0.1

### DIFF
--- a/internal/docker/builder.go
+++ b/internal/docker/builder.go
@@ -440,12 +440,18 @@ func endpoints(p nat.PortMap, csPort, ssPort int) (baseURL, fedBaseURL string, e
 	if !ok {
 		return "", "", fmt.Errorf("port %s not exposed - exposed ports: %v", csapiPort, p)
 	}
+	if len(csapiPortInfo) == 0 {
+		return "", "", fmt.Errorf("port %s exposed with not mapped port: %+v", csapiPort, p)
+	}
 	baseURL = fmt.Sprintf("http://"+HostnameRunningDocker+":%s", csapiPortInfo[0].HostPort)
 
 	ssapiPort := fmt.Sprintf("%d/tcp", ssPort)
 	ssapiPortInfo, ok := p[nat.Port(ssapiPort)]
 	if !ok {
 		return "", "", fmt.Errorf("port %s not exposed - exposed ports: %v", ssapiPort, p)
+	}
+	if len(ssapiPortInfo) == 0 {
+		return "", "", fmt.Errorf("port %s exposed with not mapped port: %+v", ssapiPort, p)
 	}
 	fedBaseURL = fmt.Sprintf("https://"+HostnameRunningDocker+":%s", ssapiPortInfo[0].HostPort)
 	return


### PR DESCRIPTION
Otherwise on some machines they can bind to both IPv4 and IPv6
addresses which could cause port confusion. Rather than binding
to 0.0.0.0 which we don't need, just bind to 127.0.0.1.