### PR TITLE
Have synapse log to stdout

### DIFF
--- a/dockerfiles/synapse/log_config.yaml
+++ b/dockerfiles/synapse/log_config.yaml
@@ -14,6 +14,8 @@ handlers:
     class: logging.StreamHandler
     formatter: precise
     filters: [context]
+    # log to stdout, for easier use with 'docker logs'
+    stream: 'ext://sys.stdout'
 
 root:
     level: INFO


### PR DESCRIPTION
... which means that `docker logs` also logs to stdout, which is much easier to
tesl with.