### PR TITLE
Support registering as an admin via shared secrets 

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ If you're looking to run against a custom Dockerfile, it must meet the following
 - The homeserver needs to manage its own storage within the image.
 - The homeserver needs to accept the server name given by the environment variable `SERVER_NAME` at runtime.
 - The homeserver needs to assume dockerfile `CMD` or `ENTRYPOINT` instructions will be run multiple times.
+- The homeserver nees to use `complement` as the registration shared secret for `/_synapse/admin/v1/register`, if supported. If this endpoint 404s then these tests are skipped.
 
 
 ### Developing locally

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ If you're looking to run against a custom Dockerfile, it must meet the following
 - The homeserver needs to manage its own storage within the image.
 - The homeserver needs to accept the server name given by the environment variable `SERVER_NAME` at runtime.
 - The homeserver needs to assume dockerfile `CMD` or `ENTRYPOINT` instructions will be run multiple times.
-- The homeserver nees to use `complement` as the registration shared secret for `/_synapse/admin/v1/register`, if supported. If this endpoint 404s then these tests are skipped.
+- The homeserver needs to use `complement` as the registration shared secret for `/_synapse/admin/v1/register`, if supported. If this endpoint 404s then these tests are skipped.
 
 
 ### Developing locally

--- a/dockerfiles/synapse/homeserver.yaml
+++ b/dockerfiles/synapse/homeserver.yaml
@@ -12,6 +12,7 @@ enable_registration: true
 tls_certificate_path: /conf/server.tls.crt
 tls_private_key_path: /conf/server.tls.key
 bcrypt_rounds: 4
+registration_shared_secret: complement
 
 listeners:
   - port: 8448

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -3,7 +3,7 @@ package client
 import (
 	"bytes"
 	"crypto/hmac"
-	"crypto/sha1"
+	"crypto/sha1" // nolint:gosec
 	"encoding/hex"
 	"encoding/json"
 	"fmt"

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -2,6 +2,9 @@ package client
 
 import (
 	"bytes"
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -17,6 +20,11 @@ import (
 	"github.com/tidwall/gjson"
 
 	"github.com/matrix-org/complement/internal/b"
+	"github.com/matrix-org/complement/internal/must"
+)
+
+const (
+	SharedSecret = "complement"
 )
 
 // RequestOpt is a functional option which will modify an outgoing HTTP request.
@@ -311,6 +319,44 @@ func (c *CSAPI) RegisterUser(t *testing.T, localpart, password string) (userID, 
 	userID = gjson.GetBytes(body, "user_id").Str
 	accessToken = gjson.GetBytes(body, "access_token").Str
 	return userID, accessToken
+}
+
+// RegisterSharedSecret registers a new account with a shared secret via HMAC
+// See https://github.com/matrix-org/synapse/blob/e550ab17adc8dd3c48daf7fedcd09418a73f524b/synapse/_scripts/register_new_matrix_user.py#L40
+func (c *CSAPI) RegisterSharedSecret(t *testing.T, user, pass string, isAdmin bool) (userID, password string) {
+	resp := c.DoFunc(t, "GET", []string{"_synapse", "admin", "v1", "register"})
+	if resp.StatusCode != 200 {
+		t.Skipf("Homeserver image does not support shared secret registration, /_synapse/admin/v1/register returned HTTP %d", resp.StatusCode)
+		return
+	}
+	body := must.ParseJSON(t, resp.Body)
+	nonce := gjson.GetBytes(body, "nonce")
+	if !nonce.Exists() {
+		t.Fatalf("Malformed shared secret GET response: %s", string(body))
+	}
+	mac := hmac.New(sha1.New, []byte(SharedSecret))
+	mac.Write([]byte(nonce.Str))
+	mac.Write([]byte("\x00"))
+	mac.Write([]byte(user))
+	mac.Write([]byte("\x00"))
+	mac.Write([]byte(pass))
+	mac.Write([]byte("\x00"))
+	if isAdmin {
+		mac.Write([]byte("notadmin"))
+	} else {
+		mac.Write([]byte("admin"))
+	}
+	sig := mac.Sum(nil)
+	reqBody := map[string]interface{}{
+		"nonce":    nonce.Str,
+		"username": user,
+		"password": pass,
+		"mac":      hex.EncodeToString(sig),
+		"admin":    false,
+	}
+	resp = c.MustDoFunc(t, "POST", []string{"_synapse", "admin", "v1", "register"}, WithJSONBody(t, reqBody))
+	body = must.ParseJSON(t, resp.Body)
+	return gjson.GetBytes(body, "user_id").Str, gjson.GetBytes(body, "access_token").Str
 }
 
 // GetCapbabilities queries the server's capabilities

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -342,9 +342,9 @@ func (c *CSAPI) RegisterSharedSecret(t *testing.T, user, pass string, isAdmin bo
 	mac.Write([]byte(pass))
 	mac.Write([]byte("\x00"))
 	if isAdmin {
-		mac.Write([]byte("notadmin"))
-	} else {
 		mac.Write([]byte("admin"))
+	} else {
+		mac.Write([]byte("notadmin"))
 	}
 	sig := mac.Sum(nil)
 	reqBody := map[string]interface{}{
@@ -352,7 +352,7 @@ func (c *CSAPI) RegisterSharedSecret(t *testing.T, user, pass string, isAdmin bo
 		"username": user,
 		"password": pass,
 		"mac":      hex.EncodeToString(sig),
-		"admin":    false,
+		"admin":    isAdmin,
 	}
 	resp = c.MustDoFunc(t, "POST", []string{"_synapse", "admin", "v1", "register"}, WithJSONBody(t, reqBody))
 	body = must.ParseJSON(t, resp.Body)

--- a/internal/docker/deployment.go
+++ b/internal/docker/deployment.go
@@ -62,7 +62,7 @@ func (d *Deployment) Client(t *testing.T, hsName, userID string) *client.CSAPI {
 }
 
 // RegisterUser within a homeserver and return an authenticatedClient, Fails the test if the hsName is not found.
-func (d *Deployment) RegisterUser(t *testing.T, hsName, localpart, password string) *client.CSAPI {
+func (d *Deployment) RegisterUser(t *testing.T, hsName, localpart, password string, isAdmin bool) *client.CSAPI {
 	t.Helper()
 	dep, ok := d.HS[hsName]
 	if !ok {
@@ -75,7 +75,12 @@ func (d *Deployment) RegisterUser(t *testing.T, hsName, localpart, password stri
 		SyncUntilTimeout: 5 * time.Second,
 		Debug:            d.Deployer.debugLogging,
 	}
-	userID, accessToken := client.RegisterUser(t, localpart, password)
+	var userID, accessToken string
+	if isAdmin {
+		userID, accessToken = client.RegisterSharedSecret(t, localpart, password, isAdmin)
+	} else {
+		userID, accessToken = client.RegisterUser(t, localpart, password)
+	}
 
 	// remember the token so subsequent calls to deployment.Client return the user
 	dep.AccessTokens[userID] = accessToken

--- a/tests/csapi/account_change_password_pushers_test.go
+++ b/tests/csapi/account_change_password_pushers_test.go
@@ -1,3 +1,4 @@
+//go:build !dendrite_blacklist
 // +build !dendrite_blacklist
 
 package csapi_tests
@@ -18,7 +19,7 @@ func TestChangePasswordPushers(t *testing.T) {
 	defer deployment.Destroy(t)
 	password1 := "superuser"
 	password2 := "my_new_password"
-	passwordClient := deployment.RegisterUser(t, "hs1", "test_change_password_pusher_user", password1)
+	passwordClient := deployment.RegisterUser(t, "hs1", "test_change_password_pusher_user", password1, false)
 
 	// sytest: Pushers created with a different access token are deleted on password change
 	t.Run("Pushers created with a different access token are deleted on password change", func(t *testing.T) {

--- a/tests/csapi/account_change_password_test.go
+++ b/tests/csapi/account_change_password_test.go
@@ -18,7 +18,7 @@ func TestChangePassword(t *testing.T) {
 	defer deployment.Destroy(t)
 	password1 := "superuser"
 	password2 := "my_new_password"
-	passwordClient := deployment.RegisterUser(t, "hs1", "test_change_password_user", password1)
+	passwordClient := deployment.RegisterUser(t, "hs1", "test_change_password_user", password1, false)
 	unauthedClient := deployment.Client(t, "hs1", "")
 	sessionTest := createSession(t, deployment, "test_change_password_user", "superuser")
 	// sytest: After changing password, can't log in with old password

--- a/tests/csapi/account_deactivate_test.go
+++ b/tests/csapi/account_deactivate_test.go
@@ -14,7 +14,7 @@ func TestDeactivateAccount(t *testing.T) {
 	deployment := Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 	password := "superuser"
-	authedClient := deployment.RegisterUser(t, "hs1", "test_deactivate_user", password)
+	authedClient := deployment.RegisterUser(t, "hs1", "test_deactivate_user", password, false)
 	unauthedClient := deployment.Client(t, "hs1", "")
 	// sytest: Can't deactivate account with wrong password
 	t.Run("Can't deactivate account with wrong password", func(t *testing.T) {

--- a/tests/csapi/admin_test.go
+++ b/tests/csapi/admin_test.go
@@ -1,0 +1,15 @@
+package csapi_tests
+
+import (
+	"testing"
+
+	"github.com/matrix-org/complement/internal/b"
+)
+
+// Check if this homeserver supports Synapse-style admin registration.
+// Not all images support this currently.
+func TestCanRegisterAdmin(t *testing.T) {
+	deployment := Deploy(t, b.BlueprintAlice)
+	defer deployment.Destroy(t)
+	deployment.RegisterUser(t, "hs1", "admin", "adminpassword", true)
+}

--- a/tests/csapi/apidoc_device_management_test.go
+++ b/tests/csapi/apidoc_device_management_test.go
@@ -15,7 +15,7 @@ func TestDeviceManagement(t *testing.T) {
 	deployment := Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 	unauthedClient := deployment.Client(t, "hs1", "")
-	authedClient := deployment.RegisterUser(t, "hs1", "test_device_management_user", "superuser")
+	authedClient := deployment.RegisterUser(t, "hs1", "test_device_management_user", "superuser", false)
 
 	// sytest: GET /device/{deviceId}
 	t.Run("GET /device/{deviceId}", func(t *testing.T) {

--- a/tests/csapi/apidoc_login_test.go
+++ b/tests/csapi/apidoc_login_test.go
@@ -17,7 +17,7 @@ func TestLogin(t *testing.T) {
 	deployment := Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 	unauthedClient := deployment.Client(t, "hs1", "")
-	_ = deployment.RegisterUser(t, "hs1", "test_login_user", "superuser")
+	_ = deployment.RegisterUser(t, "hs1", "test_login_user", "superuser", false)
 	t.Run("parallel", func(t *testing.T) {
 		// sytest: GET /login yields a set of flows
 		t.Run("GET /login yields a set of flows", func(t *testing.T) {

--- a/tests/csapi/ignored_users_test.go
+++ b/tests/csapi/ignored_users_test.go
@@ -1,3 +1,4 @@
+//go:build !dendrite_blacklist
 // +build !dendrite_blacklist
 
 // Rationale for being included in Dendrite's blacklist: https://github.com/matrix-org/dendrite/issues/600
@@ -26,9 +27,9 @@ import (
 func TestInviteFromIgnoredUsersDoesNotAppearInSync(t *testing.T) {
 	deployment := Deploy(t, b.BlueprintCleanHS)
 	defer deployment.Destroy(t)
-	alice := deployment.RegisterUser(t, "hs1", "alice", "sufficiently_long_password_alice")
-	bob := deployment.RegisterUser(t, "hs1", "bob", "sufficiently_long_password_bob")
-	chris := deployment.RegisterUser(t, "hs1", "chris", "sufficiently_long_password_chris")
+	alice := deployment.RegisterUser(t, "hs1", "alice", "sufficiently_long_password_alice", false)
+	bob := deployment.RegisterUser(t, "hs1", "bob", "sufficiently_long_password_bob", false)
+	chris := deployment.RegisterUser(t, "hs1", "chris", "sufficiently_long_password_chris", false)
 
 	// Alice creates a room for herself.
 	publicRoom := alice.CreateRoom(t, map[string]interface{}{

--- a/tests/csapi/user_directory_display_names_test.go
+++ b/tests/csapi/user_directory_display_names_test.go
@@ -1,3 +1,4 @@
+//go:build !dendrite_blacklist
 // +build !dendrite_blacklist
 
 // Rationale for being included in Dendrite's blacklist: https://github.com/matrix-org/complement/pull/199#issuecomment-904852233
@@ -43,8 +44,8 @@ func setupUsers(t *testing.T) (*client.CSAPI, *client.CSAPI, *client.CSAPI, func
 	}
 
 	alice := deployment.Client(t, "hs1", aliceUserID)
-	bob := deployment.RegisterUser(t, "hs1", "bob", "bob-has-a-very-secret-pw")
-	eve := deployment.RegisterUser(t, "hs1", "eve", "eve-has-a-very-secret-pw")
+	bob := deployment.RegisterUser(t, "hs1", "bob", "bob-has-a-very-secret-pw", false)
+	eve := deployment.RegisterUser(t, "hs1", "eve", "eve-has-a-very-secret-pw", false)
 
 	// Alice sets her profile displayname. This ensures that her
 	// public name, private name and userid localpart are all


### PR DESCRIPTION
Requires homeservers to use 'complement' as the shared secret. This is very similar to sytest which also uses this endpoint to register admins so it can test admin endpoints: https://github.com/matrix-org/sytest/blob/develop/tests/10apidoc/01register.pl#L304

Manually tested on dendrite/synapse and it works, assuming dendrite is running https://github.com/matrix-org/dendrite/pull/2194