### PR TITLE
Fix `Unrecognised appservice access token` errors

### DIFF
--- a/dockerfiles/synapse/start.sh
+++ b/dockerfiles/synapse/start.sh
@@ -5,14 +5,14 @@ set -e
 sed -i "s/SERVER_NAME/${SERVER_NAME}/g" /conf/homeserver.yaml
 
 # Add the application service registration files to the homeserver.yaml config
-for filename in /appservices/*.yaml; do
+for filename in /complement/appservice/*.yaml; do
   [ -f "$filename" ] || break
 
   as_id=$(basename "$filename" .yaml)
 
   # Insert the path to the registration file and the AS_REGISTRATION_FILES marker after 
   # so we can add the next application service in the next iteration of this for loop
-  sed -i "s/AS_REGISTRATION_FILES/  - \/appservices\/${as_id}.yaml\nAS_REGISTRATION_FILES/g" /conf/homeserver.yaml
+  sed -i "s/AS_REGISTRATION_FILES/  - \/complement\/appservice\/${as_id}.yaml\nAS_REGISTRATION_FILES/g" /conf/homeserver.yaml
 done
 # Remove the AS_REGISTRATION_FILES entry
 sed -i "s/AS_REGISTRATION_FILES//g" /conf/homeserver.yaml


### PR DESCRIPTION
Fix `Unrecognised appservice access token` errors

Regressed in https://github.com/matrix-org/complement/commit/7f19337e4af84bad8bc596c048d70fa19c779b95 (https://github.com/matrix-org/complement/pull/304)

In https://github.com/matrix-org/complement/pull/304, the appservice mount path changed from `/appservices/` to `/complement/appservice/` but [`start.sh`](https://github.com/matrix-org/complement/blob/53e90f7502ac3c9f1cce7c057ac65562124031d5/dockerfiles/synapse/start.sh#L8) which loops through every file at that path and adds an entry in `homesever.yaml` was not updated.



## Dev notes

Before run:

```diff
  $ COMPLEMENT_ALWAYS_PRINT_SERVER_LOGS=1 COMPLEMENT_DIR=../complement ./scripts-dev/complement.sh TestImportHistoricalMessages
  [+] Building 0.6s (18/18) FINISHED
   => [internal] load build definition from Dockerfile                                                                                                                                                                   0.0s
   => => transferring dockerfile: 37B                                                                                                                                                                                    0.0s
   => [internal] load .dockerignore                                                                                                                                                                                      0.0s
   => => transferring context: 35B                                                                                                                                                                                       0.0s
   => [internal] load metadata for docker.io/library/python:3.8-slim                                                                                                                                                     0.3s
   => [builder 1/9] FROM docker.io/library/python:3.8-slim@sha256:c5c49edb93bcf487e81c01fd13aba850c996649927d7c42d7367fab05d2d3e7f                                                                                       0.0s
   => [internal] load build context                                                                                                                                                                                      0.1s
   => => transferring context: 62.83kB                                                                                                                                                                                   0.1s
   => CACHED [stage-1 2/5] RUN    --mount=type=cache,target=/var/cache/apt,sharing=locked    --mount=type=cache,target=/var/lib/apt,sharing=locked   apt-get update && apt-get install -y     curl     gosu     libjpeg  0.0s
   => CACHED [builder 2/9] RUN    --mount=type=cache,target=/var/cache/apt,sharing=locked    --mount=type=cache,target=/var/lib/apt,sharing=locked  apt-get update && apt-get install -y     build-essential     libffi  0.0s
   => CACHED [builder 3/9] COPY scripts /synapse/scripts/                                                                                                                                                                0.0s
   => CACHED [builder 4/9] COPY MANIFEST.in README.rst setup.py synctl /synapse/                                                                                                                                         0.0s
   => CACHED [builder 5/9] COPY synapse/__init__.py /synapse/synapse/__init__.py                                                                                                                                         0.0s
   => CACHED [builder 6/9] COPY synapse/python_dependencies.py /synapse/synapse/python_dependencies.py                                                                                                                   0.0s
   => CACHED [builder 7/9] RUN --mount=type=cache,target=/root/.cache/pip   pip install --prefix="/install" --no-warn-script-location     /synapse[all]                                                                  0.0s
   => CACHED [builder 8/9] COPY synapse /synapse/synapse/                                                                                                                                                                0.0s
   => CACHED [builder 9/9] RUN pip install --prefix="/install" --no-deps --no-warn-script-location /synapse                                                                                                              0.0s
   => CACHED [stage-1 3/5] COPY --from=builder /install /usr/local                                                                                                                                                       0.0s
   => CACHED [stage-1 4/5] COPY ./docker/start.py /start.py                                                                                                                                                              0.0s
   => CACHED [stage-1 5/5] COPY ./docker/conf /conf                                                                                                                                                                      0.0s
   => exporting to image                                                                                                                                                                                                 0.0s
   => => exporting layers                                                                                                                                                                                                0.0s
   => => writing image sha256:5e07ebfd161a99dd7846a71f79e7c35956ea0a7b7a72e74c358efe8a71ac74a4                                                                                                                           0.0s
   => => naming to docker.io/matrixdotorg/synapse                                                                                                                                                                        0.0s

  Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
  [+] Building 0.2s (11/11) FINISHED
   => [internal] load build definition from Synapse.Dockerfile                                                                                                                                                           0.0s
   => => transferring dockerfile: 45B                                                                                                                                                                                    0.0s
   => [internal] load .dockerignore                                                                                                                                                                                      0.0s
   => => transferring context: 2B                                                                                                                                                                                        0.0s
   => [internal] load metadata for docker.io/matrixdotorg/synapse:latest                                                                                                                                                 0.0s
   => [1/6] FROM docker.io/matrixdotorg/synapse:latest                                                                                                                                                                   0.0s
   => [internal] load build context                                                                                                                                                                                      0.0s
   => => transferring context: 367B                                                                                                                                                                                      0.0s
   => CACHED [2/6] COPY synapse/* /conf/                                                                                                                                                                                 0.0s
   => CACHED [3/6] COPY keys/* /ca/                                                                                                                                                                                      0.0s
   => CACHED [4/6] RUN openssl genrsa -out /conf/server.tls.key 2048                                                                                                                                                     0.0s
   => CACHED [5/6] RUN generate_signing_key.py -o /conf/server.signing.key                                                                                                                                               0.0s
   => CACHED [6/6] WORKDIR /data                                                                                                                                                                                         0.0s
   => exporting to image                                                                                                                                                                                                 0.0s
   => => exporting layers                                                                                                                                                                                                0.0s
   => => writing image sha256:ebcdb4d11b4bddc0fcd923f5a4dfa39bb00f9133d53789323820075bfba7093d                                                                                                                           0.0s
   => => naming to docker.io/library/complement-synapse                                                                                                                                                                  0.0s

  Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
  Images built; running complement
  2022/02/24 20:09:57 config: &{BaseImageURI:complement-synapse BaseImageArgs:[] DebugLoggingEnabled:false AlwaysPrintServerLogs:true BestEffort:false SpawnHSTimeout:30s KeepBlueprints:[] PackageNamespace:pkg CACertificate:0xc000c82000 CAPrivateKey:0xc0008b0600}
  === RUN   TestImportHistoricalMessages
      msc2716_test.go:63: Deploy times: 6.228565284s blueprints, 2.815885566s containers
      client.go:500: POST hs1/_matrix/client/r0/register => 401 Unauthorized (3.609558ms)
+     msc2716_test.go:1118: msc2716.ensureVirtualUserRegistered failed to register: (M_UNKNOWN_TOKEN) Unrecognised access token
  2022/02/24 20:10:06 ============================================
  ...
+ 2022-02-25 02:10:06,456 - synapse.api.auth - 567 - WARNING - POST-2 - Unrecognised appservice access token.
  ...
  --- FAIL: TestImportHistoricalMessages (9.38s)
  FAIL
  FAIL  github.com/matrix-org/complement/tests  12.275s
  2022/02/24 20:09:55 config: &{BaseImageURI:complement-synapse BaseImageArgs:[] DebugLoggingEnabled:false AlwaysPrintServerLogs:true BestEffort:false SpawnHSTimeout:30s KeepBlueprints:[] PackageNamespace:csapi CACertificate:0xc00012e000 CAPrivateKey:0xc000b3dc20}
  testing: warning: no tests to run
  PASS
  ok    github.com/matrix-org/complement/tests/csapi  1.416s [no tests to run]
  FAIL
```