### PR TITLE
Use MSC2716 room version that exists (revert back to `org.matrix.msc2716v3`)

### DIFF
--- a/tests/msc2716_test.go
+++ b/tests/msc2716_test.go
@@ -50,13 +50,13 @@ var (
 var createPublicRoomOpts = map[string]interface{}{
 	"preset":       "public_chat",
 	"name":         "the hangout spot",
-	"room_version": "org.matrix.msc2716v4",
+	"room_version": "org.matrix.msc2716v3",
 }
 
 var createPrivateRoomOpts = map[string]interface{}{
 	"preset":       "private_chat",
 	"name":         "the hangout spot",
-	"room_version": "org.matrix.msc2716v4",
+	"room_version": "org.matrix.msc2716v3",
 }
 
 func TestImportHistoricalMessages(t *testing.T) {


### PR DESCRIPTION
Use MSC2716 room version that exists (revert back to `org.matrix.msc2716v3`)

During the development of https://github.com/matrix-org/synapse/pull/11243
we added a `org.matrix.msc2716v4` room version but it's no longer necessary
and was removed in https://github.com/matrix-org/synapse/pull/11243/commits/e2928b54a2b4359f6034b6d557c7f36512747ec3


## Dev notes

It's okay that `FAIL: TestImportHistoricalMessages/parallel/Unrecognised_prev_event_ID_will_throw_an_error` is failing. Just haven't decided on what error code is correct for that situation. All the other tests are passing ✅

```
$ COMPLEMENT_ALWAYS_PRINT_SERVER_LOGS=1 COMPLEMENT_DIR=../complement ./scripts-dev/complement.sh TestImportHistoricalMessages
...
--- FAIL: TestImportHistoricalMessages (20.32s)
    --- FAIL: TestImportHistoricalMessages/parallel (7.15s)
        --- SKIP: TestImportHistoricalMessages/parallel/TODO:_Trying_to_send_insertion_event_with_same_`next_batch_id`_will_reject (0.00s)
        --- SKIP: TestImportHistoricalMessages/parallel/TODO:_What_happens_when_you_point_multiple_batches_at_the_same_insertion_event? (0.00s)
        --- PASS: TestImportHistoricalMessages/parallel/Federation (0.00s)
            --- PASS: TestImportHistoricalMessages/parallel/Federation/Historical_messages_are_visible_when_joining_on_federated_server_-_pre-made_insertion_event (4.67s)
            --- PASS: TestImportHistoricalMessages/parallel/Federation/Historical_messages_are_visible_when_joining_on_federated_server_-_auto-generated_base_insertion_event (4.70s)
            --- PASS: TestImportHistoricalMessages/parallel/Federation/When_messages_have_already_been_scrolled_back_through,_new_historical_messages_are_visible_in_next_scroll_back_on_federated_server (5.63s)
            --- PASS: TestImportHistoricalMessages/parallel/Federation/Historical_messages_are_visible_when_already_joined_on_federated_server (6.18s)
        --- PASS: TestImportHistoricalMessages/parallel/Existing_room_versions (0.00s)
            --- PASS: TestImportHistoricalMessages/parallel/Existing_room_versions/Not_allowed_to_redact_MSC2716_insertion,_batch,_marker_events (0.90s)
            --- PASS: TestImportHistoricalMessages/parallel/Existing_room_versions/Room_creator_can_send_MSC2716_events (0.97s)
        --- FAIL: TestImportHistoricalMessages/parallel/Unrecognised_prev_event_ID_will_throw_an_error (1.29s)
        --- PASS: TestImportHistoricalMessages/parallel/Duplicate_next_batch_id_on_insertion_event_will_be_rejected (1.98s)
        --- PASS: TestImportHistoricalMessages/parallel/Normal_users_aren't_allowed_to_batch_send_historical_messages (2.09s)
        --- PASS: TestImportHistoricalMessages/parallel/Unrecognised_batch_id_will_throw_an_error (2.10s)
        --- PASS: TestImportHistoricalMessages/parallel/Batch_send_endpoint_only_returns_state_events_that_we_passed_in_via_state_events_at_start (2.49s)
        --- PASS: TestImportHistoricalMessages/parallel/Should_be_able_to_send_a_batch_without_any_state_events_at_start_-_user_already_joined_in_the_current_room_state (2.69s)
        --- PASS: TestImportHistoricalMessages/parallel/Should_be_able_to_batch_send_historical_messages_into_private_room (2.97s)
        --- PASS: TestImportHistoricalMessages/parallel/Historical_events_from_multiple_users_in_the_same_batch (3.07s)
        --- PASS: TestImportHistoricalMessages/parallel/Historical_events_resolve_in_the_correct_order (3.67s)
        --- PASS: TestImportHistoricalMessages/parallel/should_resolve_member_state_events_for_historical_events (3.70s)
        --- PASS: TestImportHistoricalMessages/parallel/Historical_events_from_batch_send_do_not_come_down_in_an_incremental_sync (3.81s)
FAIL
FAIL	github.com/matrix-org/complement/tests	21.171s
```