### PR TITLE
Update expected response status code when we provide an unrecognised `prev_event` (MSC2716)

### DIFF
--- a/tests/msc2716_test.go
+++ b/tests/msc2716_test.go
@@ -320,10 +320,7 @@ func TestImportHistoricalMessages(t *testing.T) {
 				createJoinStateEventsForBatchSendRequest([]string{virtualUserID}, insertTime),
 				createMessageEventsForBatchSendRequest([]string{virtualUserID}, insertTime, 1),
 				// Status
-				// TODO: Seems like this makes more sense as a 404
-				// But the current Synapse code around unknown prev events will throw ->
-				// `403: No create event in auth events`
-				403,
+				400,
 			)
 		})
 


### PR DESCRIPTION
Update Complement to match the error specified in Synapse, see https://github.com/matrix-org/synapse/blob/54e74cc15f30585f5874780437614c0df6f639d9/synapse/rest/client/room_batch.py#L135-L140

```
SynapseError: 400 - No auth events found for given prev_event query parameter. The prev_event=['$some-non-existant-event-id'] probably does not exist.
```
