### PR TITLE
Update complement to use setuptools entrypoints

### DIFF
--- a/dockerfiles/Synapse.Dockerfile
+++ b/dockerfiles/Synapse.Dockerfile
@@ -24,7 +24,7 @@ COPY keys/* /ca/
 RUN openssl genrsa -out /conf/server.tls.key 2048
 
 # generate a signing key
-RUN generate_signing_key.py -o /conf/server.signing.key
+RUN generate_signing_key -o /conf/server.signing.key
 
 WORKDIR /data
 


### PR DESCRIPTION
Crossref: matrix-org/synapse#12118

I have made this script a proper entry point, so it appears as an suffixless executable.