### PR TITLE
Skip flakey dendrite test

### DIFF
--- a/tests/csapi/room_messages_test.go
+++ b/tests/csapi/room_messages_test.go
@@ -18,6 +18,7 @@ import (
 // sytest: POST /rooms/:room_id/send/:event_type sends a message
 // sytest: GET /rooms/:room_id/messages returns a message
 func TestSendAndFetchMessage(t *testing.T) {
+	runtime.SkipIf(t, runtime.Dendrite) // flakey
 	deployment := Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 


### PR DESCRIPTION
`/messages` flakes on dendrite.