### PR TITLE
Attempt to deflake `TestRoomCreationReportsEventsToMyself`

### DIFF
--- a/tests/csapi/rooms_state_test.go
+++ b/tests/csapi/rooms_state_test.go
@@ -26,35 +26,30 @@ func TestRoomCreationReportsEventsToMyself(t *testing.T) {
 
 	userID := "@alice:hs1"
 	alice := deployment.Client(t, "hs1", userID)
-	roomID := alice.CreateRoom(t, struct{}{})
 
-	t.Run("parallel", func(t *testing.T) {
-		// sytest: Room creation reports m.room.create to myself
-		t.Run("Room creation reports m.room.create to myself", func(t *testing.T) {
-			t.Parallel()
-			alice := deployment.Client(t, "hs1", userID)
-			alice.MustSyncUntil(t, client.SyncReq{}, client.SyncTimelineHas(roomID, func(ev gjson.Result) bool {
-				if ev.Get("type").Str != "m.room.create" {
-					return false
-				}
-				must.EqualStr(t, ev.Get("sender").Str, userID, "wrong sender")
-				must.EqualStr(t, ev.Get("content").Get("creator").Str, userID, "wrong content.creator")
-				return true
-			}))
-		})
-		// sytest: Room creation reports m.room.member to myself
-		t.Run("Room creation reports m.room.member to myself", func(t *testing.T) {
-			t.Parallel()
-			alice := deployment.Client(t, "hs1", userID)
-			alice.MustSyncUntil(t, client.SyncReq{}, client.SyncTimelineHas(roomID, func(ev gjson.Result) bool {
-				if ev.Get("type").Str != "m.room.member" {
-					return false
-				}
-				must.EqualStr(t, ev.Get("sender").Str, userID, "wrong sender")
-				must.EqualStr(t, ev.Get("state_key").Str, userID, "wrong state_key")
-				must.EqualStr(t, ev.Get("content").Get("membership").Str, "join", "wrong content.membership")
-				return true
-			}))
-		})
+	// sytest: Room creation reports m.room.create to myself
+	t.Run("Room creation reports m.room.create to myself", func(t *testing.T) {
+		roomID := alice.CreateRoom(t, struct{}{})
+		alice.MustSyncUntil(t, client.SyncReq{}, client.SyncTimelineHas(roomID, func(ev gjson.Result) bool {
+			if ev.Get("type").Str != "m.room.create" {
+				return false
+			}
+			must.EqualStr(t, ev.Get("sender").Str, userID, "wrong sender")
+			must.EqualStr(t, ev.Get("content").Get("creator").Str, userID, "wrong content.creator")
+			return true
+		}))
+	})
+	// sytest: Room creation reports m.room.member to myself
+	t.Run("Room creation reports m.room.member to myself", func(t *testing.T) {
+		roomID := alice.CreateRoom(t, struct{}{})
+		alice.MustSyncUntil(t, client.SyncReq{}, client.SyncTimelineHas(roomID, func(ev gjson.Result) bool {
+			if ev.Get("type").Str != "m.room.member" {
+				return false
+			}
+			must.EqualStr(t, ev.Get("sender").Str, userID, "wrong sender")
+			must.EqualStr(t, ev.Get("state_key").Str, userID, "wrong state_key")
+			must.EqualStr(t, ev.Get("content").Get("membership").Str, "join", "wrong content.membership")
+			return true
+		}))
 	})
 }


### PR DESCRIPTION
We can't run `/sync` in parallel, as this can result in `Room creation reports m.room.member to myself` consuming events required for `Room creation reports m.room.create to myself` and thus failing the test.