### PR TITLE
Update config in accordance with Synapse #12091

### DIFF
--- a/dockerfiles/synapse/homeserver.yaml
+++ b/dockerfiles/synapse/homeserver.yaml
@@ -6,6 +6,7 @@ report_stats: False
 signing_key_path: /conf/server.signing.key
 trusted_key_servers: []
 enable_registration: true
+enable_registration_without_verification: true
 
 ## Listeners ##
 

--- a/dockerfiles/synapse/workers-shared.yaml
+++ b/dockerfiles/synapse/workers-shared.yaml
@@ -2,6 +2,7 @@
 report_stats: False
 trusted_key_servers: []
 enable_registration: true
+enable_registration_without_verification: true
 bcrypt_rounds: 4
 
 ## Federation ##


### PR DESCRIPTION
Synapse PR matrix-org/synapse#12091, when merged, will cause Synapse to refuse to start if registration is enabled without any verification, unless the new config flag `enable_registration_without_verification` is set. This PR adds that flag to complement's configuration so the homeserver will still start for testing. 