### PR TITLE
Give the CA certificate a "Common Name"

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -166,6 +166,7 @@ func generateCAValues() (*x509.Certificate, *rsa.PrivateKey, error) {
 			Locality:      []string{"London"},
 			StreetAddress: []string{"123 Street"},
 			PostalCode:    []string{"12345"},
+			CommonName:    "Complement Test CA",
 		},
 	}
 


### PR DESCRIPTION
... to help distinguish it from other certs that fly around.