### PR TITLE
Log the body of unexpected HTTP requests

### DIFF
--- a/internal/federation/server.go
+++ b/internal/federation/server.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
+	"io/ioutil"
 	"math/big"
 	"net"
 	"net/http"
@@ -94,7 +95,8 @@ func NewServer(t *testing.T, deployment *docker.Deployment, opts ...func(*Server
 	})
 	srv.mux.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		if srv.UnexpectedRequestsAreErrors {
-			t.Errorf("Server.UnexpectedRequestsAreErrors=true received unexpected request to server: %s %s", req.Method, req.URL.Path)
+			body, _ := ioutil.ReadAll(req.Body)
+			t.Errorf("Server.UnexpectedRequestsAreErrors=true received unexpected request to server: %s %s\n%s", req.Method, req.URL.Path, string(body))
 		} else {
 			t.Logf("Server.UnexpectedRequestsAreErrors=false received unexpected request to server: %s %s", req.Method, req.URL.Path)
 		}


### PR DESCRIPTION
I've observed intermittent test failures due to `/send` requests arriving when
none are expected. To help narrow down what is going on, let's log the content
of any unexpected requests.