### PR TITLE
Gracefully stop blueprint containers before committing them

### DIFF
--- a/internal/docker/builder.go
+++ b/internal/docker/builder.go
@@ -315,7 +315,7 @@ func (d *Builder) construct(bprint b.Blueprint) (errs []error) {
 		// If we don't do this, then e.g. Postgres databases can become corrupt, which
 		// then incurs a slow recovery process when we use the blueprint later.
 		d.log("%s : Stopping container: %s", res.contextStr, res.containerID)
-		timeout := 30 * time.Second
+		timeout := 10 * time.Second
 		d.Docker.ContainerStop(context.Background(), res.containerID, &timeout)
 
 		// commit the container

--- a/internal/docker/builder.go
+++ b/internal/docker/builder.go
@@ -314,9 +314,12 @@ func (d *Builder) construct(bprint b.Blueprint) (errs []error) {
 		// This gives it chance to shut down gracefully.
 		// If we don't do this, then e.g. Postgres databases can become corrupt, which
 		// then incurs a slow recovery process when we use the blueprint later.
-		d.log("%s : Stopping container: %s", res.contextStr, res.containerID)
+		d.log("%s: Stopping container: %s", res.contextStr, res.containerID)
 		timeout := 10 * time.Second
 		d.Docker.ContainerStop(context.Background(), res.containerID, &timeout)
+
+		// Log again so we can see the timings.
+		d.log("%s: Stopped container: %s", res.contextStr, res.containerID)
 
 		// commit the container
 		commit, err := d.Docker.ContainerCommit(context.Background(), res.containerID, types.ContainerCommitOptions{


### PR DESCRIPTION
This PR arises from a conversation with @richvdh, who was presumably working on getting Synapse tested in Complement with Postgres and workers.

The blueprint container gets paused and then committed, which leads to the Postgres database being corrupted in the image that gets created. This then leads to slow startup for that container, since Postgres has to do some kind of recovery process.

It seems like it would be better to gracefully stop the container before committing it, so that Postgres doesn't get corrupted in the process.
Docker stops a container by SIGTERMing it (so the process inside the container can theoretically react to that and shut down gracefully), then SIGKILLing if it didn't stop after a timeout.

This PR will use the equivalent of `docker stop` to shut down the container before committing it. A well-written container could then react to the SIGTERM and shut down the database gracefully.

I'm not sure the container image in question is set up to handle SIGTERM properly, though — the container seems to be taking 30 s (= timeout) to stop so I presume it's still getting killed forcefully.
At least this gives us the option to implement that properly...

I used `COMPLEMENT_DEBUG=1 WORKERS=1 COMPLEMENT_ALWAYS_PRINT_SERVER_LOGS=1 COMPLEMENT_DIR=`pwd`/../complement ./scripts-dev/complement.sh -run TestInboundFederationKeys  2>&1 | tee log` in a Synapse checkout, as Rich suggested.