### PR TITLE
Bump Dendrite version in Dockerfiles README

### DIFF
--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -5,5 +5,5 @@ However, this doesn't work nicely when running Complement with local checkouts, 
 end up copying the Dockerfiles in this directory to their own repository. In an effort to reduce
 duplication, we now point to dockerfiles in respective repositories rather than have them directly here.
 
-- Dendrite: https://github.com/matrix-org/dendrite/blob/v0.6.3/build/scripts/Complement.Dockerfile
+- Dendrite: https://github.com/matrix-org/dendrite/blob/v0.8.2/build/scripts/Complement.Dockerfile
 - Synapse: https://github.com/matrix-org/synapse/blob/develop/docker/complement/Dockerfile


### PR DESCRIPTION
The README points to a very old version which doesn't build with latest Complement anymore.