### PR TITLE
Add test to make sure `/messages` behaves as expected for non-existent `room_id`'s

### DIFF
--- a/tests/csapi/room_messages_test.go
+++ b/tests/csapi/room_messages_test.go
@@ -60,7 +60,7 @@ func TestSendAndFetchMessage(t *testing.T) {
 }
 
 // With a non-existent room_id, GET /rooms/:room_id/messages returns 403
-// forbidden.
+// forbidden ("You aren't a member of the room").
 func TestFetchMessagesFromNonExistentRoom(t *testing.T) {
 	runtime.SkipIf(t, runtime.Dendrite) // flakey
 	deployment := Deploy(t, b.BlueprintAlice)

--- a/tests/csapi/room_messages_test.go
+++ b/tests/csapi/room_messages_test.go
@@ -59,6 +59,25 @@ func TestSendAndFetchMessage(t *testing.T) {
 	})
 }
 
+// With a non-existent room_id, GET /rooms/:room_id/messages returns 403
+// forbidden.
+func TestFetchMessagesFromNonExistentRoom(t *testing.T) {
+	runtime.SkipIf(t, runtime.Dendrite) // flakey
+	deployment := Deploy(t, b.BlueprintAlice)
+	defer deployment.Destroy(t)
+
+	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	roomID := "!does-not-exist:hs1"
+
+	// then request messages from the room
+	queryParams := url.Values{}
+	queryParams.Set("dir", "b")
+	res := alice.DoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "messages"}, client.WithQueries(queryParams))
+	must.MatchResponse(t, res, match.HTTPResponse{
+		StatusCode: http.StatusForbidden,
+	})
+}
+
 // sytest: PUT /rooms/:room_id/send/:event_type/:txn_id sends a message
 // sytest: PUT /rooms/:room_id/send/:event_type/:txn_id deduplicates the same txn id
 func TestSendMessageWithTxn(t *testing.T) {

--- a/tests/csapi/room_messages_test.go
+++ b/tests/csapi/room_messages_test.go
@@ -62,7 +62,6 @@ func TestSendAndFetchMessage(t *testing.T) {
 // With a non-existent room_id, GET /rooms/:room_id/messages returns 403
 // forbidden ("You aren't a member of the room").
 func TestFetchMessagesFromNonExistentRoom(t *testing.T) {
-	runtime.SkipIf(t, runtime.Dendrite) // flakey
 	deployment := Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 


### PR DESCRIPTION
Add test to make sure `/messages` behaves as expected for non-existent `room_id`'s

Tests for Synapse regression fix: https://github.com/matrix-org/synapse/pull/12683
Issue: https://github.com/matrix-org/synapse/issues/12678