### PR TITLE
Marker events as state - MSC2716

### DIFF
--- a/tests/msc2716_test.go
+++ b/tests/msc2716_test.go
@@ -919,101 +919,6 @@ func TestImportHistoricalMessages(t *testing.T) {
 				})
 			})
 
-			t.Run("asdf: why current_state empty when federated re-join", func(t *testing.T) {
-				t.Parallel()
-
-				roomID := as.CreateRoom(t, createPublicRoomOpts)
-				alice.JoinRoom(t, roomID, nil)
-
-				// eventIDsBefore := createMessagesInRoom(t, alice, roomID, 1, "eventIDsBefore")
-				createMessagesInRoom(t, alice, roomID, 1, "eventIDsBefore")
-				// eventIdBefore := eventIDsBefore[0]
-				// timeAfterEventBefore := time.Now()
-
-				// createMessagesInRoom(t, alice, roomID, 3, "eventIDsAfter")
-
-				// Join the room from a remote homeserver before the historical messages were sent
-				remoteCharlie.JoinRoom(t, roomID, []string{"hs1"})
-
-				// Make sure all of the events have been backfilled for the remote user
-				// before we leave the room
-				// fetchUntilMessagesResponseHas(t, remoteCharlie, roomID, func(ev gjson.Result) bool {
-				// 	if ev.Get("event_id").Str == eventIdBefore {
-				// 		return true
-				// 	}
-
-				// 	return false
-				// })
-
-				// Leave before the historical messages are imported
-				remoteCharlie.LeaveRoom(t, roomID)
-
-				// batchSendRes := batchSendHistoricalMessages(
-				// 	t,
-				// 	as,
-				// 	roomID,
-				// 	eventIdBefore,
-				// 	"",
-				// 	createJoinStateEventsForBatchSendRequest([]string{virtualUserID}, timeAfterEventBefore),
-				// 	createMessageEventsForBatchSendRequest([]string{virtualUserID}, timeAfterEventBefore, 2),
-				// 	// Status
-				// 	200,
-				// )
-				// batchSendResBody := client.ParseJSON(t, batchSendRes)
-				// // historicalEventIDs := client.GetJSONFieldStringArray(t, batchSendResBody, "event_ids")
-				// baseInsertionEventID := client.GetJSONFieldStr(t, batchSendResBody, "base_insertion_event_id")
-
-				// Send the marker event which lets remote homeservers know there are
-				// some historical messages back at the given insertion event.
-				// sendMarkerAndEnsureBackfilled(t, as, alice, roomID, baseInsertionEventID)
-				// sendMarkerAndEnsureBackfilled(t, as, alice, roomID, eventIdBefore)
-				// fetchUntilMessagesResponseHas(t, alice, roomID, func(ev gjson.Result) bool {
-				// 	if ev.Get("event_id").Str == eventIdBefore {
-				// 		return true
-				// 	}
-
-				// 	return false
-				// })
-
-				markerEvent := b.Event{
-					Type: markerEventType,
-					Content: map[string]interface{}{
-						markerInsertionContentField: "foo",
-					},
-				}
-				// We can't use as.SendEventSynced(...) because application services can't use the /sync API
-				// markerSendRes := as.MustDoFunc(t, "PUT", []string{"_matrix", "client", "r0", "rooms", roomID, "state", markerEvent.Type}, client.WithJSONBody(t, markerEvent.Content))
-				as.MustDoFunc(t, "PUT", []string{"_matrix", "client", "r0", "rooms", roomID, "state", markerEvent.Type}, client.WithJSONBody(t, markerEvent.Content))
-				// markerSendBody := client.ParseJSON(t, markerSendRes)
-				// markerEventID := client.GetJSONFieldStr(t, markerSendBody, "event_id")
-
-				// alice.MustSyncUntil(t, client.SyncReq{}, client.SyncTimelineHas(roomID, func(ev gjson.Result) bool {
-				// 	return ev.Get("event_id").Str == markerEventID
-				// }))
-
-				// fetchUntilMessagesResponseHas(t, alice, roomID, func(ev gjson.Result) bool {
-				// 	if ev.Get("event_id").Str == eventIdBefore {
-				// 		return true
-				// 	}
-
-				// 	return false
-				// })
-
-				// alice.SendEventSynced(t, roomID, b.Event{
-				// 	Type:     "foostate",
-				// 	StateKey: b.Ptr(""),
-				// 	Content: map[string]interface{}{
-				// 		"foo": "bar",
-				// 	},
-				// })
-
-				// Add some events after the marker so that remoteCharlie doesn't see the marker
-				// createMessagesInRoom(t, alice, roomID, 3, "eventIDFiller")
-
-				// Join the room from a remote homeserver after the historical messages were sent
-				remoteCharlie.JoinRoom(t, roomID, []string{"hs1"})
-			})
-
 			t.Run("Historical messages show up for remote federated homeserver even the homeserver is missing the part of the timeline where the marker was sent and it paginates before it occured", func(t *testing.T) {
 				t.Parallel()
 
@@ -1067,11 +972,6 @@ func TestImportHistoricalMessages(t *testing.T) {
 
 				// Join the room from a remote homeserver after the historical messages were sent
 				remoteCharlie.JoinRoom(t, roomID, []string{"hs1"})
-
-				// TODO: Try wait for the remote join to complete
-				// remoteCharlie.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "context", markerEventId}, client.WithContentType("application/json"), client.WithQueries(url.Values{
-				// 	"limit": []string{"0"},
-				// }))
 
 				// Make a /context request for eventIDAfter to get pagination token before the marker event
 				contextRes := remoteCharlie.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "context", eventIDAfter}, client.WithContentType("application/json"), client.WithQueries(url.Values{

--- a/tests/msc2716_test.go
+++ b/tests/msc2716_test.go
@@ -1240,7 +1240,7 @@ func paginateUntilMessageCheckOff(t *testing.T, c *client.CSAPI, roomID string, 
 	}
 
 	for {
-		if time.Since(start) > 200*c.SyncUntilTimeout {
+		if time.Since(start) > c.SyncUntilTimeout {
 			t.Fatalf(
 				"paginateUntilMessageCheckOff timed out. %s",
 				generateErrorMesssageInfo(),

--- a/tests/msc2716_test.go
+++ b/tests/msc2716_test.go
@@ -1022,8 +1022,7 @@ func TestImportHistoricalMessages(t *testing.T) {
 				testHistoricalMessagesAppearForRemoteHomeserverWhenMissingPartOfTimelineWithMarker(
 					t,
 					// Anything above 1 here should be sufficient to test whether we can
-					// follow the state and previous state all the way up to injest all of
-					// the marker events along the way
+					// process all of the current state to injest all of the marker events
 					2,
 				)
 			})

--- a/tests/msc2716_test.go
+++ b/tests/msc2716_test.go
@@ -1435,8 +1435,10 @@ func sendMarkerAndEnsureBackfilled(t *testing.T, as *client.CSAPI, c *client.CSA
 			markerInsertionContentField: insertionEventID,
 		},
 	}
-	// We can't use as.SendEventSynced(...) because application services can't use the /sync API
-	markerSendRes := as.MustDoFunc(t, "PUT", []string{"_matrix", "client", "r0", "rooms", roomID, "state", markerEvent.Type}, client.WithJSONBody(t, markerEvent.Content))
+	// Marker events should have unique state_key so they all show up in the current state to process.
+	unique_state_key := getTxnID("marker_state_key")
+	// We can't use as.SendEventSynced(...) because application services can't use the /sync API.
+	markerSendRes := as.MustDoFunc(t, "PUT", []string{"_matrix", "client", "r0", "rooms", roomID, "state", markerEvent.Type, unique_state_key}, client.WithJSONBody(t, markerEvent.Content))
 	markerSendBody := client.ParseJSON(t, markerSendRes)
 	markerEventID = client.GetJSONFieldStr(t, markerSendBody, "event_id")
 

--- a/tests/msc2716_test.go
+++ b/tests/msc2716_test.go
@@ -919,6 +919,101 @@ func TestImportHistoricalMessages(t *testing.T) {
 				})
 			})
 
+			t.Run("asdf: why current_state empty when federated re-join", func(t *testing.T) {
+				t.Parallel()
+
+				roomID := as.CreateRoom(t, createPublicRoomOpts)
+				alice.JoinRoom(t, roomID, nil)
+
+				// eventIDsBefore := createMessagesInRoom(t, alice, roomID, 1, "eventIDsBefore")
+				createMessagesInRoom(t, alice, roomID, 1, "eventIDsBefore")
+				// eventIdBefore := eventIDsBefore[0]
+				// timeAfterEventBefore := time.Now()
+
+				// createMessagesInRoom(t, alice, roomID, 3, "eventIDsAfter")
+
+				// Join the room from a remote homeserver before the historical messages were sent
+				remoteCharlie.JoinRoom(t, roomID, []string{"hs1"})
+
+				// Make sure all of the events have been backfilled for the remote user
+				// before we leave the room
+				// fetchUntilMessagesResponseHas(t, remoteCharlie, roomID, func(ev gjson.Result) bool {
+				// 	if ev.Get("event_id").Str == eventIdBefore {
+				// 		return true
+				// 	}
+
+				// 	return false
+				// })
+
+				// Leave before the historical messages are imported
+				remoteCharlie.LeaveRoom(t, roomID)
+
+				// batchSendRes := batchSendHistoricalMessages(
+				// 	t,
+				// 	as,
+				// 	roomID,
+				// 	eventIdBefore,
+				// 	"",
+				// 	createJoinStateEventsForBatchSendRequest([]string{virtualUserID}, timeAfterEventBefore),
+				// 	createMessageEventsForBatchSendRequest([]string{virtualUserID}, timeAfterEventBefore, 2),
+				// 	// Status
+				// 	200,
+				// )
+				// batchSendResBody := client.ParseJSON(t, batchSendRes)
+				// // historicalEventIDs := client.GetJSONFieldStringArray(t, batchSendResBody, "event_ids")
+				// baseInsertionEventID := client.GetJSONFieldStr(t, batchSendResBody, "base_insertion_event_id")
+
+				// Send the marker event which lets remote homeservers know there are
+				// some historical messages back at the given insertion event.
+				// sendMarkerAndEnsureBackfilled(t, as, alice, roomID, baseInsertionEventID)
+				// sendMarkerAndEnsureBackfilled(t, as, alice, roomID, eventIdBefore)
+				// fetchUntilMessagesResponseHas(t, alice, roomID, func(ev gjson.Result) bool {
+				// 	if ev.Get("event_id").Str == eventIdBefore {
+				// 		return true
+				// 	}
+
+				// 	return false
+				// })
+
+				markerEvent := b.Event{
+					Type: markerEventType,
+					Content: map[string]interface{}{
+						markerInsertionContentField: "foo",
+					},
+				}
+				// We can't use as.SendEventSynced(...) because application services can't use the /sync API
+				// markerSendRes := as.MustDoFunc(t, "PUT", []string{"_matrix", "client", "r0", "rooms", roomID, "state", markerEvent.Type}, client.WithJSONBody(t, markerEvent.Content))
+				as.MustDoFunc(t, "PUT", []string{"_matrix", "client", "r0", "rooms", roomID, "state", markerEvent.Type}, client.WithJSONBody(t, markerEvent.Content))
+				// markerSendBody := client.ParseJSON(t, markerSendRes)
+				// markerEventID := client.GetJSONFieldStr(t, markerSendBody, "event_id")
+
+				// alice.MustSyncUntil(t, client.SyncReq{}, client.SyncTimelineHas(roomID, func(ev gjson.Result) bool {
+				// 	return ev.Get("event_id").Str == markerEventID
+				// }))
+
+				// fetchUntilMessagesResponseHas(t, alice, roomID, func(ev gjson.Result) bool {
+				// 	if ev.Get("event_id").Str == eventIdBefore {
+				// 		return true
+				// 	}
+
+				// 	return false
+				// })
+
+				// alice.SendEventSynced(t, roomID, b.Event{
+				// 	Type:     "foostate",
+				// 	StateKey: b.Ptr(""),
+				// 	Content: map[string]interface{}{
+				// 		"foo": "bar",
+				// 	},
+				// })
+
+				// Add some events after the marker so that remoteCharlie doesn't see the marker
+				// createMessagesInRoom(t, alice, roomID, 3, "eventIDFiller")
+
+				// Join the room from a remote homeserver after the historical messages were sent
+				remoteCharlie.JoinRoom(t, roomID, []string{"hs1"})
+			})
+
 			t.Run("Historical messages show up for remote federated homeserver even the homeserver is missing the part of the timeline where the marker was sent and it paginates before it occured", func(t *testing.T) {
 				t.Parallel()
 
@@ -972,6 +1067,11 @@ func TestImportHistoricalMessages(t *testing.T) {
 
 				// Join the room from a remote homeserver after the historical messages were sent
 				remoteCharlie.JoinRoom(t, roomID, []string{"hs1"})
+
+				// TODO: Try wait for the remote join to complete
+				// remoteCharlie.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "context", markerEventId}, client.WithContentType("application/json"), client.WithQueries(url.Values{
+				// 	"limit": []string{"0"},
+				// }))
 
 				// Make a /context request for eventIDAfter to get pagination token before the marker event
 				contextRes := remoteCharlie.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "context", eventIDAfter}, client.WithContentType("application/json"), client.WithQueries(url.Values{


### PR DESCRIPTION
Synapse change: https://github.com/matrix-org/synapse/pull/12718

Part of [MSC2716](https://github.com/matrix-org/matrix-spec-proposals/pull/2716)

We're testing to make sure historical messages show up for a remote federated homeserver even when the homeserver is missing the part of the timeline where the marker events were sent and it paginates before they occured to see if the history is available. Making sure the homeserver processes all of the markers from the current state instead of just when it sees them in the timeline.

Sending marker events as state now so they are always able to be seen by homeservers (not lost in some timeline gap).

Marker events should be sent with a unique `state_key` so that they can all resolve in the current state to easily be discovered.

 - If we re-use the same `state_key` (like `""`), then we would have to fetch previous snapshots of state up through time to find all of the marker events. This way we can avoid all of that.
 - Also avoids state resolution conflicts where only one of the marker events win

As a homeserver, when we see new marker state, we know there is new history imported somewhere back in time and should process it to fetch the insertion event where the historical messages are and set it as an insertion extremity. This way we know where to backfill more messages when someone asks for scrollback.

## Dev notes

```
COMPLEMENT_ALWAYS_PRINT_SERVER_LOGS=1 COMPLEMENT_DIR=../complement ./scripts-dev/complement.sh -run TestImportHistoricalMessages/parallel/Federation/Historical_messages_show_up_for_remote_federated_homeserver_even_when_the_homeserver_is_missing_the_part_of_the_timeline_where_the_marker_was_sent_and_it_paginates_before_it_occured
```

```
COMPLEMENT_ALWAYS_PRINT_SERVER_LOGS=1 COMPLEMENT_DIR=../complement ./scripts-dev/complement.sh -run TestImportHistoricalMessages/parallel/Federation/Historical_messages_show_up_for_remote_federated_homeserver_even_when_the_homeserver_is_missing_the_part_of_the_timeline_where_multiple_marker_events_were_sent_and_it_paginates_before_they_occured
```