### PR TITLE
Enable arbitrary env vars to be propagated to Complement containers

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,14 +22,15 @@ type HostMount struct {
 }
 
 type Complement struct {
-	BaseImageURI          string
-	BaseImageArgs         []string
-	DebugLoggingEnabled   bool
-	AlwaysPrintServerLogs bool
-	BestEffort            bool
-	SpawnHSTimeout        time.Duration
-	KeepBlueprints        []string
-	HostMounts            []HostMount
+	BaseImageURI           string
+	BaseImageArgs          []string
+	DebugLoggingEnabled    bool
+	AlwaysPrintServerLogs  bool
+	BestEffort             bool
+	EnvVarsPropagatePrefix string
+	SpawnHSTimeout         time.Duration
+	KeepBlueprints         []string
+	HostMounts             []HostMount
 	// The namespace for all complement created blueprints and deployments
 	PackageNamespace string
 	// Certificate Authority generated values for this run of complement. Homeservers will use this
@@ -47,6 +48,7 @@ func NewConfigFromEnvVars(pkgNamespace, baseImageURI string) *Complement {
 	cfg.BaseImageArgs = strings.Split(os.Getenv("COMPLEMENT_BASE_IMAGE_ARGS"), " ")
 	cfg.DebugLoggingEnabled = os.Getenv("COMPLEMENT_DEBUG") == "1"
 	cfg.AlwaysPrintServerLogs = os.Getenv("COMPLEMENT_ALWAYS_PRINT_SERVER_LOGS") == "1"
+	cfg.EnvVarsPropagatePrefix = os.Getenv("COMPLEMENT_SHARE_ENV_PREFIX")
 	cfg.SpawnHSTimeout = time.Duration(parseEnvWithDefault("COMPLEMENT_SPAWN_HS_TIMEOUT_SECS", 30)) * time.Second
 	if os.Getenv("COMPLEMENT_VERSION_CHECK_ITERATIONS") != "" {
 		fmt.Fprintln(os.Stderr, "Deprecated: COMPLEMENT_VERSION_CHECK_ITERATIONS will be removed in a later version. Use COMPLEMENT_SPAWN_HS_TIMEOUT_SECS instead which does the same thing and is clearer.")

--- a/internal/docker/deployer.go
+++ b/internal/docker/deployer.go
@@ -22,7 +22,9 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"os"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 
@@ -195,6 +197,14 @@ func deployImage(
 
 	env := []string{
 		"SERVER_NAME=" + hsName,
+	}
+	if cfg.EnvVarsPropagatePrefix != "" {
+		for _, ev := range os.Environ() {
+			if strings.HasPrefix(ev, cfg.EnvVarsPropagatePrefix) {
+				env = append(env, strings.TrimPrefix(ev, cfg.EnvVarsPropagatePrefix))
+			}
+		}
+		log.Printf("Sharing %v host environment variables with container", env)
 	}
 
 	body, err := docker.ContainerCreate(ctx, &container.Config{


### PR DESCRIPTION
Fixes https://github.com/matrix-org/complement/issues/6

This PR adds a new complement env var called `COMPLEMENT_SHARE_ENV_PREFIX`.
This can be set to any string e.g `FOO_`. If it is set, Complement will
look at the host environment for any env var with this prefix. If it finds
it, it will remove the prefix and add it to the Complement container.

For example, with a host env:
```
COMPLEMENT_SHARE_ENV_PREFIX=FOO_
FOO_DENDRITE_TRACE_HTTP=1
```
This will cause `DENDRITE_TRACE_HTTP=1` to be set in the Complement container.

This addresses 2 desires:
 - The ability to ad-hoc set debugging env vars when a test is failing
   e.g to use `os.Setenv("FOO_DENDRITE_TRACE_HTTP", "1")` in a test to get more logging.
 - The ability to pass through arbitrary data to a Synapse container, as requested
   by @reivilibre