### PR TITLE
Update the README for local running.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,20 +88,24 @@ If you're looking to run against a custom Dockerfile, it must meet the following
 
 If you want to write Complement tests _and_ hack on a homeserver implementation at the same time it can be very awkward
 to have to `docker build` the image all the time. To resolve this, Complement support "host mounts" which mount a directory
-from the host to the container. This is set via `COMPLEMENT_HOST_MOUNTS`:
+from the host to the container. This is set via `COMPLEMENT_HOST_MOUNTS`, on the form `HOST:CONTAINER[:ro][;...]` where
+`:ro` makes the mount read-only.
 
+For example, for Dendrite on Linux with the default location of `$GOPATH`, do a one-time setup:
+
+```shellsession
+$ git clone https://github.com/matrix-org/dendrite ../dendrite
+$ (cd ../dendrite && docker build -t complement-dendrite-local -f build/scripts/ComplementLocal.Dockerfile .)
+$ mkdir -p /tmp/complement-$LOGNAME/go-build
+$ export COMPLEMENT_BASE_IMAGE=complement-dendrite-local
+$ export COMPLEMENT_HOST_MOUNTS="$PWD/../dendrite:/dendrite:ro;$HOME/go:/go:ro;/tmp/complement-$LOGNAME/go-build:/root/.cache/go-build"
 ```
-COMPLEMENT_HOST_MOUNTS='/my/local/dir:/container/dir;/another/local/dir:/container/dir2:ro'
 
-which is:
-  - /my/local/dir:/container/dir
-  - /another/local/dir:/container/dir2:ro
+Then simply use `go test` to compile and test your locally checked out Dendrite:
 
-which is of the form:
-  - HOST:CONTAINER[:ro] where :ro makes the mount read-only.
+```shellsession
+$ go test -v ./tests/...
 ```
-
-For example, for Dendrite: `COMPLEMENT_HOST_MOUNTS='/your/local/dendrite:/dendrite:ro;/your/go/path:/go:ro'`.
 
 ### Getting prettier output
 

--- a/tests/csapi/rooms_state_test.go
+++ b/tests/csapi/rooms_state_test.go
@@ -1,4 +1,5 @@
 //go:build !dendrite_blacklist
+// +build !dendrite_blacklist
 
 package csapi_tests
 


### PR DESCRIPTION
By mounting /root/.cache/go-build, we don't need to pre-cache
binaries, and it also helps when large changes are being made to
Dendrite. Without this, the compile cache only remembers the changes
when the ComplementLocal.Dockerfile was last built.

The example is now easier to get started with.

Also fixes a small lint issue for Go 1.16 (which is what Docker images use.)