### PR TITLE
Regression test for /sync returning 404 for redactions

### DIFF
--- a/internal/b/blueprints.go
+++ b/internal/b/blueprints.go
@@ -110,6 +110,9 @@ type Event struct {
 	// The prev events of the event if we want to override or falsify them.
 	// If it is left at nil, MustCreateEvent will populate it automatically based on the forward extremities.
 	PrevEvents interface{}
+
+	// If this is a redaction, the event that it redacts
+	Redacts string
 }
 
 func MustValidate(bp Blueprint) Blueprint {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -248,7 +248,8 @@ func (c *CSAPI) MustSync(t *testing.T, syncReq SyncReq) (gjson.Result, string) {
 // In the unlikely event that you need ordering on your checks, call MustSyncUntil multiple times
 // with a single checker, and reuse the returned since token, as in the "Incremental sync" example.
 //
-// Will time out after CSAPI.SyncUntilTimeout. Returns the latest since token used.
+// Will time out after CSAPI.SyncUntilTimeout. Returns the `next_batch` token from the final
+// response.
 func (c *CSAPI) MustSyncUntil(t *testing.T, syncReq SyncReq, checks ...SyncCheckOpt) string {
 	t.Helper()
 	start := time.Now()

--- a/internal/federation/server.go
+++ b/internal/federation/server.go
@@ -263,6 +263,7 @@ func (s *Server) MustCreateEvent(t *testing.T, room *ServerRoom, ev b.Event) *go
 		PrevEvents: prevEvents,
 		Unsigned:   unsigned,
 		AuthEvents: ev.AuthEvents,
+		Redacts:    ev.Redacts,
 	}
 	if eb.AuthEvents == nil {
 		var stateNeeded gomatrixserverlib.StateNeeded


### PR DESCRIPTION
Lots more detail in the code, but this is a regression test for https://github.com/matrix-org/synapse/issues/12864: Synapse would return a 404 from /sync if given a since token which pointed to a redaction of an unknown event.