### PR TITLE
Use `host-gateway` to ensure servers can reach host

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Complement is a black box integration testing framework for Matrix homeservers.
 
 ## Running
 
-You need to have Go and Docker installed, as well as `libolm3` and `libolm-dev`. Then:
+You need to have Go and Docker >= 20.10 installed, as well as `libolm3` and `libolm-dev`. Then:
 
 ```
 $ COMPLEMENT_BASE_IMAGE=some-matrix/homeserver-impl go test -v ./tests/...

--- a/internal/docker/deployer.go
+++ b/internal/docker/deployer.go
@@ -177,10 +177,11 @@ func deployImage(
 	var err error
 
 	if runtime.GOOS == "linux" {
-		// By default docker for linux does not expose this, so do it now.
-		// When https://github.com/moby/moby/pull/40007 lands in Docker 20, we should
-		// change this to be  `host.docker.internal:host-gateway`
-		extraHosts = []string{HostnameRunningComplement + ":172.17.0.1"}
+		// Ensure that the homservers under test can contact the host, so they can
+		// interact with a complement-controlled test server.
+		// Note: this feature of docker landed in Docker 20.10,
+		// see https://github.com/moby/moby/pull/40007 
+		extraHosts = []string{"host.docker.internal:host-gateway"}
 	}
 
 	for _, m := range cfg.HostMounts {

--- a/internal/docker/deployer.go
+++ b/internal/docker/deployer.go
@@ -177,7 +177,7 @@ func deployImage(
 	var err error
 
 	if runtime.GOOS == "linux" {
-		// Ensure that the homservers under test can contact the host, so they can
+		// Ensure that the homeservers under test can contact the host, so they can
 		// interact with a complement-controlled test server.
 		// Note: this feature of docker landed in Docker 20.10,
 		// see https://github.com/moby/moby/pull/40007 


### PR DESCRIPTION
This fixes [connectivity problems I was having when running complement](https://github.com/matrix-org/complement/issues/370#issuecomment-1147687179). Oddly, noone else seems to have found this issue, and I don't really understand the underlying machinations.

I'm not sure if this will cause complement to fail in environments whose docker versions are older than 20.10.