### PR TITLE
Gracefully shut down container when we want logs

### DIFF
--- a/internal/docker/deployer.go
+++ b/internal/docker/deployer.go
@@ -153,8 +153,8 @@ func (d *Deployer) Destroy(dep *Deployment, printServerLogs bool) {
 		if printServerLogs {
 			// If we want the logs we gracefully stop the containers to allow
 			// the logs to be flushed.
-			x := 1 * time.Second
-			err := d.Docker.ContainerStop(context.Background(), hsDep.ContainerID, &x)
+			timeout := 1 * time.Second
+			err := d.Docker.ContainerStop(context.Background(), hsDep.ContainerID, &timeout)
 			if err != nil {
 				log.Printf("Destroy: Failed to destroy container %s : %s\n", hsDep.ContainerID, err)
 			}


### PR DESCRIPTION
This gives the container a chance to flush out any pending logs, otherwise we can end up with truncated logs.