### PR TITLE
Document the environment variable pass-through prefix option introduced by #382

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ If you're looking to run against a custom Dockerfile, it must meet the following
 - The homeserver needs to assume dockerfile `CMD` or `ENTRYPOINT` instructions will be run multiple times.
 - The homeserver needs to use `complement` as the registration shared secret for `/_synapse/admin/v1/register`, if supported. If this endpoint 404s then these tests are skipped.
 
+If the image needs environment variables to function, you can:
+1. define a pass-through prefix with e.g. `COMPLEMENT_SHARE_ENV_PREFIX=PASS_`; then
+2. prefix the desired environment variables with that prefix; e.g. `PASS_SYNAPSE_COMPLEMENT_USE_WORKERS=true`.
 
 ### Developing locally
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ options will work, so to just run 1 named test and include a timeout for the tes
 $ COMPLEMENT_BASE_IMAGE=complement-dendrite:latest go test -timeout 30s -run '^(TestOutboundFederationSend)$' -v ./tests/...
 ```
 
+If you need to pass environment variables to the image under test, you can:
+1. define a pass-through prefix with e.g. `COMPLEMENT_SHARE_ENV_PREFIX=PASS_`; then
+2. prefix the desired environment variables with that prefix; e.g. `PASS_SYNAPSE_COMPLEMENT_USE_WORKERS=true`.
+
+
 ### Potential conflict with firewall software
 
 The homeserver in the test image needs to be able to make requests to the mock
@@ -98,9 +103,6 @@ If you're looking to run against a custom Dockerfile, it must meet the following
 - The homeserver needs to assume dockerfile `CMD` or `ENTRYPOINT` instructions will be run multiple times.
 - The homeserver needs to use `complement` as the registration shared secret for `/_synapse/admin/v1/register`, if supported. If this endpoint 404s then these tests are skipped.
 
-If the image needs environment variables to function, you can:
-1. define a pass-through prefix with e.g. `COMPLEMENT_SHARE_ENV_PREFIX=PASS_`; then
-2. prefix the desired environment variables with that prefix; e.g. `PASS_SYNAPSE_COMPLEMENT_USE_WORKERS=true`.
 
 ### Developing locally
 


### PR DESCRIPTION
We seem to have forgotten to document this option, so this PR tries to put that right.
