### PR TITLE
Test homeserver restarts during a partial state join

### DIFF
--- a/tests/federation_room_join_partial_state_test.go
+++ b/tests/federation_room_join_partial_state_test.go
@@ -200,7 +200,7 @@ func TestPartialStateJoin(t *testing.T) {
 		psjResult.AwaitStateIdsRequest(t)
 
 		// restart the homeserver
-		err := deployment.Restart()
+		err := deployment.Restart(t)
 		if err != nil {
 			t.Errorf("Failed to restart homeserver: %s", err)
 		}


### PR DESCRIPTION
Tests https://github.com/matrix-org/synapse/issues/12642

Split out from #378.