### PR TITLE
Allow presence transactions during faster room joins tests

### DIFF
--- a/tests/federation_room_join_partial_state_test.go
+++ b/tests/federation_room_join_partial_state_test.go
@@ -478,6 +478,13 @@ func beginPartialStateJoin(t *testing.T, deployment *docker.Deployment, joiningU
 		federation.HandleKeyRequests(),
 		federation.HandlePartialStateMakeSendJoinRequests(),
 		federation.HandleEventRequests(),
+		federation.HandleTransactionRequests(
+			func(e *gomatrixserverlib.Event) {
+				t.Fatalf("Received unexpected PDU: %s", string(e.JSON()))
+			},
+			// the homeserver under test may send us presence when the joining user syncs
+			nil,
+		),
 	)
 	result.cancelListener = result.Server.Listen()
 


### PR DESCRIPTION
When `/sync`ing, the homeserver under test may send presence to the
Complement homeserver. Handle these EDUs by ignoring them.

Blocks CI for https://github.com/matrix-org/synapse/pull/13151