### PR TITLE
Add /health endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ complement
 .idea
 .bin
 .DS_Store
+homerunner

--- a/cmd/homerunner/README.md
+++ b/cmd/homerunner/README.md
@@ -138,3 +138,7 @@ The `complement_blueprint` label is the blueprint name you should use to deploy 
 ### Access tokens
 
 Access tokens are returned when deploying the blueprint but sometimes you want to login as a normal user. The format for passwords for all users created by Complement is [here](https://github.com/matrix-org/complement/blob/fc87b081ac9dd3c8e52bcd2ed155bc8d49ce6d56/internal/instruction/runner.go#L415).
+
+### Health
+
+Homerunner will respond to `GET /health` with a 200 response. You can use this to check if homerunner is ready when running your tests.

--- a/cmd/homerunner/routes.go
+++ b/cmd/homerunner/routes.go
@@ -32,5 +32,10 @@ func Routes(rt *Runtime, cfg *Config) http.Handler {
 			},
 		))),
 	)
+	mux.Path("/health").Methods("GET").HandlerFunc(
+		func(res http.ResponseWriter, req *http.Request) {
+			res.WriteHeader(200)
+		},
+	)
 	return mux
 }


### PR DESCRIPTION
Fixes #398.

This adds a basic /health endpoint to tell us whether the service is up. It doesn't yet perform a readyness check, but that's mostly because the HTTP server is only started *when* homerunner is ready.