### PR TITLE
Ignore presence EDUs during partial state join test

### DIFF
--- a/tests/federation_room_join_test.go
+++ b/tests/federation_room_join_test.go
@@ -459,6 +459,9 @@ func TestSendJoinPartialStateResponse(t *testing.T) {
 
 	srv := federation.NewServer(t, deployment,
 		federation.HandleKeyRequests(),
+
+		// accept incoming presence transactions, etc
+		federation.HandleTransactionRequests(nil, nil),
 	)
 	cancel := srv.Listen()
 	defer cancel()


### PR DESCRIPTION
Hopefully fixes https://github.com/matrix-org/synapse/issues/13256