### PR TITLE
Fix TestContent log argument order.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/tests/csapi/apidoc_content_test.go
+++ b/tests/csapi/apidoc_content_test.go
@@ -23,6 +23,6 @@ func TestContent(t *testing.T) {
 		t.Fatalf("uploaded and downloaded content doesn't match: want %v\ngot\n%v", data.MatrixPng, content)
 	}
 	if contentType != wantContentType {
-		t.Fatalf("expected contentType to be %s, got %s", contentType, wantContentType)
+		t.Fatalf("expected contentType to be %s, got %s", wantContentType, contentType)
 	}
 }


### PR DESCRIPTION
Small fix in TestContent, and added .gitattributes setting so Git doesn't get many modified files when opening the repo in Windows.