### PR TITLE
Use `/v3` URLs instead of `/r0`

### DIFF
--- a/cmd/account-snapshot/internal/sync.go
+++ b/cmd/account-snapshot/internal/sync.go
@@ -33,7 +33,7 @@ func LoadSyncData(hsURL, token, tempFile string) (json.RawMessage, error) {
 		attempts++
 		// Perform the sync
 		log.Println("Performing /sync...")
-		filterReq, err := http.NewRequest("GET", hsURL+"/_matrix/client/r0/sync?filter="+filterStr, nil)
+		filterReq, err := http.NewRequest("GET", hsURL+"/_matrix/client/v3/sync?filter="+filterStr, nil)
 		if err != nil {
 			log.Printf("failed to create sync request: %s\n", err)
 			continue

--- a/cmd/perftest/test.go
+++ b/cmd/perftest/test.go
@@ -164,7 +164,7 @@ func runTest(testName string, builder *docker.Builder, deployer *docker.Deployer
 		syncInstructions[i] = instruction.Instr{
 			UserID:  userID,
 			Method:  "GET",
-			Path:    "/_matrix/client/r0/sync",
+			Path:    "/_matrix/client/v3/sync",
 			Queries: map[string]string{"timeout": "0"},
 			Store: map[string]string{
 				userID: ".next_batch",
@@ -184,7 +184,7 @@ func runTest(testName string, builder *docker.Builder, deployer *docker.Deployer
 		syncInstructions = append(syncInstructions, instruction.Instr{
 			UserID: userID,
 			Method: "PUT",
-			Path:   fmt.Sprintf("/_matrix/client/r0/profile/%s/displayname", url.PathEscape(userID)),
+			Path:   fmt.Sprintf("/_matrix/client/v3/profile/%s/displayname", url.PathEscape(userID)),
 			Body: map[string]interface{}{
 				"displayname": fmt.Sprintf("Updated User %d", i),
 			},
@@ -203,7 +203,7 @@ func runTest(testName string, builder *docker.Builder, deployer *docker.Deployer
 		syncInstructions[i] = instruction.Instr{
 			UserID:  userID,
 			Method:  "GET",
-			Path:    "/_matrix/client/r0/sync",
+			Path:    "/_matrix/client/v3/sync",
 			Queries: map[string]string{"since": runner.GetStoredValue(runOpts, userID)},
 			Store: map[string]string{
 				userID: ".next_batch",

--- a/internal/federation/handle.go
+++ b/internal/federation/handle.go
@@ -366,7 +366,7 @@ func HandleMediaRequests(mediaIds map[string]func(w http.ResponseWriter)) func(*
 			}
 		})
 
-		// Note: The spec says to use r0, but implementations rely on /v1 working for federation requests as a legacy
+		// Note: The spec says to use /v3, but implementations rely on /v1 and /r0 working for federation requests as a legacy
 		// route.
 		mediamux.Handle("/r0/download/{origin}/{mediaId}", downloadFn).Methods("GET")
 		mediamux.Handle("/v1/download/{origin}/{mediaId}", downloadFn).Methods("GET")

--- a/internal/federation/handle.go
+++ b/internal/federation/handle.go
@@ -369,7 +369,7 @@ func HandleMediaRequests(mediaIds map[string]func(w http.ResponseWriter)) func(*
 		// Note: The spec says to use r0, but implementations rely on /v1 working for federation requests as a legacy
 		// route.
 		mediamux.Handle("/v1/download/{origin}/{mediaId}", downloadFn).Methods("GET")
-		mediamux.Handle("/r0/download/{origin}/{mediaId}", downloadFn).Methods("GET")
+		mediamux.Handle("/v3/download/{origin}/{mediaId}", downloadFn).Methods("GET")
 	}
 }
 

--- a/internal/federation/handle.go
+++ b/internal/federation/handle.go
@@ -368,6 +368,7 @@ func HandleMediaRequests(mediaIds map[string]func(w http.ResponseWriter)) func(*
 
 		// Note: The spec says to use r0, but implementations rely on /v1 working for federation requests as a legacy
 		// route.
+		mediamux.Handle("/r0/download/{origin}/{mediaId}", downloadFn).Methods("GET")
 		mediamux.Handle("/v1/download/{origin}/{mediaId}", downloadFn).Methods("GET")
 		mediamux.Handle("/v3/download/{origin}/{mediaId}", downloadFn).Methods("GET")
 	}

--- a/internal/instruction/runner.go
+++ b/internal/instruction/runner.go
@@ -445,7 +445,7 @@ func calculateRoomInstructionSets(r *Runner, hs b.Homeserver) [][]instruction {
 			}
 			instrs = append(instrs, instruction{
 				method:        "POST",
-				path:          "/_matrix/client/r0/createRoom",
+				path:          "/_matrix/client/v3/createRoom",
 				accessToken:   "user_" + room.Creator,
 				body:          room.CreateRoom,
 				storeResponse: storeRes,
@@ -465,10 +465,10 @@ func calculateRoomInstructionSets(r *Runner, hs b.Homeserver) [][]instruction {
 				subs["$roomId"] = fmt.Sprintf(".room_ref_%s", room.Ref)
 			}
 			if event.StateKey != nil {
-				path = "/_matrix/client/r0/rooms/$roomId/state/$eventType/$stateKey"
+				path = "/_matrix/client/v3/rooms/$roomId/state/$eventType/$stateKey"
 				subs["$stateKey"] = *event.StateKey
 			} else {
-				path = "/_matrix/client/r0/rooms/$roomId/send/$eventType/$txnId"
+				path = "/_matrix/client/v3/rooms/$roomId/send/$eventType/$txnId"
 				subs["$txnId"] = fmt.Sprintf("%d", eventIndex)
 			}
 
@@ -479,23 +479,23 @@ func calculateRoomInstructionSets(r *Runner, hs b.Homeserver) [][]instruction {
 				if ok {
 					switch membership {
 					case "join":
-						path = "/_matrix/client/r0/join/$roomId"
+						path = "/_matrix/client/v3/join/$roomId"
 						method = "POST"
 
 						// Set server_name to the homeserver that created the room, as they're a pretty
 						// good candidate to join the room through
 						queryParams["server_name"] = fmt.Sprintf(".room_ref_%s_server_name", room.Ref)
 					case "leave":
-						path = "/_matrix/client/r0/rooms/$roomId/leave"
+						path = "/_matrix/client/v3/rooms/$roomId/leave"
 						method = "POST"
 						if *event.StateKey != event.Sender {
 							// it's a kick
-							path = "/_matrix/client/r0/rooms/$roomId/kick"
+							path = "/_matrix/client/v3/rooms/$roomId/kick"
 							method = "POST"
 							event.Content["user_id"] = *event.StateKey
 						}
 					case "invite":
-						path = "/_matrix/client/r0/rooms/$roomId/invite"
+						path = "/_matrix/client/v3/rooms/$roomId/invite"
 						method = "POST"
 						event.Content["user_id"] = *event.StateKey
 					}
@@ -509,7 +509,7 @@ func calculateRoomInstructionSets(r *Runner, hs b.Homeserver) [][]instruction {
 					ri := roomIndex
 					instrs = append(instrs, instruction{
 						method:        "PUT",
-						path:          "/_matrix/client/r0/directory/room/" + url.PathEscape(alias),
+						path:          "/_matrix/client/v3/directory/room/" + url.PathEscape(alias),
 						accessToken:   fmt.Sprintf("user_%s", event.Sender),
 						substitutions: subs,
 						queryParams:   queryParams,
@@ -552,7 +552,7 @@ func instructionRegister(hs b.Homeserver, user b.User) instruction {
 
 	return instruction{
 		method:      "POST",
-		path:        "/_matrix/client/r0/register",
+		path:        "/_matrix/client/v3/register",
 		accessToken: "",
 		body:        body,
 		storeResponse: map[string]string{
@@ -569,7 +569,7 @@ func instructionDisplayName(hs b.Homeserver, user b.User) instruction {
 	return instruction{
 		method: "PUT",
 		path: fmt.Sprintf(
-			"/_matrix/client/r0/profile/@%s:%s/displayname",
+			"/_matrix/client/v3/profile/@%s:%s/displayname",
 			user.Localpart, hs.Name,
 		),
 		accessToken: fmt.Sprintf("user_@%s:%s", user.Localpart, hs.Name),
@@ -593,7 +593,7 @@ func instructionLogin(hs b.Homeserver, user b.User) instruction {
 
 	return instruction{
 		method:      "POST",
-		path:        "/_matrix/client/r0/login",
+		path:        "/_matrix/client/v3/login",
 		accessToken: "",
 		body:        body,
 		storeResponse: map[string]string{
@@ -653,7 +653,7 @@ func instructionOneTimeKeyUpload(hs b.Homeserver, user b.User) instruction {
 	}
 	return instruction{
 		method:      "POST",
-		path:        "/_matrix/client/r0/keys/upload",
+		path:        "/_matrix/client/v3/keys/upload",
 		accessToken: fmt.Sprintf("user_@%s:%s", user.Localpart, hs.Name),
 		body: map[string]interface{}{
 			"device_keys":   deviceKeys,

--- a/tests/csapi/account_change_password_pushers_test.go
+++ b/tests/csapi/account_change_password_pushers_test.go
@@ -37,13 +37,13 @@ func TestChangePasswordPushers(t *testing.T) {
 			"lang":                "en",
 		})
 
-		_ = sessionOptional.MustDoFunc(t, "POST", []string{"_matrix", "client", "r0", "pushers", "set"}, reqBody)
+		_ = sessionOptional.MustDoFunc(t, "POST", []string{"_matrix", "client", "v3", "pushers", "set"}, reqBody)
 
 		changePassword(t, passwordClient, password1, password2)
 
 		pushersSize := 0
 
-		res := passwordClient.DoFunc(t, "GET", []string{"_matrix", "client", "r0", "pushers"})
+		res := passwordClient.DoFunc(t, "GET", []string{"_matrix", "client", "v3", "pushers"})
 		must.MatchResponse(t, res, match.HTTPResponse{
 			StatusCode: 200,
 			JSON: []match.JSON{
@@ -73,13 +73,13 @@ func TestChangePasswordPushers(t *testing.T) {
 			"lang":                "en",
 		})
 
-		_ = passwordClient.MustDoFunc(t, "POST", []string{"_matrix", "client", "r0", "pushers", "set"}, reqBody)
+		_ = passwordClient.MustDoFunc(t, "POST", []string{"_matrix", "client", "v3", "pushers", "set"}, reqBody)
 
 		changePassword(t, passwordClient, password2, password1)
 
 		pushersSize := 0
 
-		res := passwordClient.DoFunc(t, "GET", []string{"_matrix", "client", "r0", "pushers"})
+		res := passwordClient.DoFunc(t, "GET", []string{"_matrix", "client", "v3", "pushers"})
 		must.MatchResponse(t, res, match.HTTPResponse{
 			StatusCode: 200,
 			JSON: []match.JSON{

--- a/tests/csapi/account_change_password_test.go
+++ b/tests/csapi/account_change_password_test.go
@@ -34,7 +34,7 @@ func TestChangePassword(t *testing.T) {
 			"type":     "m.login.password",
 			"password": password1,
 		})
-		res := unauthedClient.DoFunc(t, "POST", []string{"_matrix", "client", "r0", "login"}, reqBody)
+		res := unauthedClient.DoFunc(t, "POST", []string{"_matrix", "client", "v3", "login"}, reqBody)
 		must.MatchResponse(t, res, match.HTTPResponse{
 			StatusCode: 403,
 			JSON: []match.JSON{
@@ -53,7 +53,7 @@ func TestChangePassword(t *testing.T) {
 			"type":     "m.login.password",
 			"password": password2,
 		})
-		res := unauthedClient.DoFunc(t, "POST", []string{"_matrix", "client", "r0", "login"}, reqBody)
+		res := unauthedClient.DoFunc(t, "POST", []string{"_matrix", "client", "v3", "login"}, reqBody)
 		must.MatchResponse(t, res, match.HTTPResponse{
 			StatusCode: 200,
 			JSON: []match.JSON{
@@ -63,14 +63,14 @@ func TestChangePassword(t *testing.T) {
 	})
 	// sytest: After changing password, existing session still works
 	t.Run("After changing password, existing session still works", func(t *testing.T) {
-		res := passwordClient.DoFunc(t, "GET", []string{"_matrix", "client", "r0", "account", "whoami"})
+		res := passwordClient.DoFunc(t, "GET", []string{"_matrix", "client", "v3", "account", "whoami"})
 		must.MatchResponse(t, res, match.HTTPResponse{
 			StatusCode: 200,
 		})
 	})
 	// sytest: After changing password, a different session no longer works by default
 	t.Run("After changing password, a different session no longer works by default", func(t *testing.T) {
-		res := sessionTest.DoFunc(t, "GET", []string{"_matrix", "client", "r0", "account", "whoami"})
+		res := sessionTest.DoFunc(t, "GET", []string{"_matrix", "client", "v3", "account", "whoami"})
 		must.MatchResponse(t, res, match.HTTPResponse{
 			StatusCode: 401,
 		})
@@ -89,12 +89,12 @@ func TestChangePassword(t *testing.T) {
 			"logout_devices": false,
 		})
 
-		res := passwordClient.DoFunc(t, "POST", []string{"_matrix", "client", "r0", "account", "password"}, reqBody)
+		res := passwordClient.DoFunc(t, "POST", []string{"_matrix", "client", "v3", "account", "password"}, reqBody)
 
 		must.MatchResponse(t, res, match.HTTPResponse{
 			StatusCode: 200,
 		})
-		res = sessionOptional.DoFunc(t, "GET", []string{"_matrix", "client", "r0", "account", "whoami"})
+		res = sessionOptional.DoFunc(t, "GET", []string{"_matrix", "client", "v3", "account", "whoami"})
 
 		must.MatchResponse(t, res, match.HTTPResponse{
 			StatusCode: 200,
@@ -113,7 +113,7 @@ func changePassword(t *testing.T, passwordClient *client.CSAPI, oldPassword stri
 		"new_password": newPassword,
 	})
 
-	res := passwordClient.DoFunc(t, "POST", []string{"_matrix", "client", "r0", "account", "password"}, reqBody)
+	res := passwordClient.DoFunc(t, "POST", []string{"_matrix", "client", "v3", "account", "password"}, reqBody)
 
 	must.MatchResponse(t, res, match.HTTPResponse{
 		StatusCode: 200,
@@ -130,7 +130,7 @@ func createSession(t *testing.T, deployment *docker.Deployment, userID, password
 		"type":     "m.login.password",
 		"password": password,
 	})
-	res := authedClient.DoFunc(t, "POST", []string{"_matrix", "client", "r0", "login"}, reqBody)
+	res := authedClient.DoFunc(t, "POST", []string{"_matrix", "client", "v3", "login"}, reqBody)
 	body, err := ioutil.ReadAll(res.Body)
 	if err != nil {
 		t.Fatalf("unable to read response body: %v", err)

--- a/tests/csapi/account_deactivate_test.go
+++ b/tests/csapi/account_deactivate_test.go
@@ -45,7 +45,7 @@ func TestDeactivateAccount(t *testing.T) {
 			"type":     "m.login.password",
 			"password": password,
 		})
-		res := unauthedClient.DoFunc(t, "POST", []string{"_matrix", "client", "r0", "login"}, reqBody)
+		res := unauthedClient.DoFunc(t, "POST", []string{"_matrix", "client", "v3", "login"}, reqBody)
 		must.MatchResponse(t, res, match.HTTPResponse{
 			StatusCode: 403,
 		})
@@ -62,7 +62,7 @@ func deactivateAccount(t *testing.T, authedClient *client.CSAPI, password string
 		},
 	})
 
-	res := authedClient.DoFunc(t, "POST", []string{"_matrix", "client", "r0", "account", "deactivate"}, reqBody)
+	res := authedClient.DoFunc(t, "POST", []string{"_matrix", "client", "v3", "account", "deactivate"}, reqBody)
 
 	return res
 }

--- a/tests/csapi/admin_test.go
+++ b/tests/csapi/admin_test.go
@@ -56,7 +56,7 @@ func TestServerNotices(t *testing.T) {
 		roomID = syncUntilInvite(t, alice)
 	})
 	t.Run("Alice cannot reject the invite", func(t *testing.T) {
-		res := alice.DoFunc(t, "POST", []string{"_matrix", "client", "r0", "rooms", roomID, "leave"})
+		res := alice.DoFunc(t, "POST", []string{"_matrix", "client", "v3", "rooms", roomID, "leave"})
 		must.MatchResponse(t, res, match.HTTPResponse{
 			StatusCode: http.StatusForbidden,
 			JSON: []match.JSON{
@@ -69,7 +69,7 @@ func TestServerNotices(t *testing.T) {
 		queryParams := url.Values{}
 		queryParams.Set("dir", "b")
 		// check if we received the message
-		res := alice.DoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "messages"}, client.WithQueries(queryParams))
+		res := alice.DoFunc(t, "GET", []string{"_matrix", "client", "v3", "rooms", roomID, "messages"}, client.WithQueries(queryParams))
 		msgRes := &msgResult{}
 		must.MatchResponse(t, res, match.HTTPResponse{
 			StatusCode: http.StatusOK,

--- a/tests/csapi/apidoc_device_management_test.go
+++ b/tests/csapi/apidoc_device_management_test.go
@@ -30,9 +30,9 @@ func TestDeviceManagement(t *testing.T) {
 			"device_id":                   deviceID,
 			"initial_device_display_name": "device display",
 		})
-		_ = unauthedClient.MustDoFunc(t, "POST", []string{"_matrix", "client", "r0", "login"}, reqBody)
+		_ = unauthedClient.MustDoFunc(t, "POST", []string{"_matrix", "client", "v3", "login"}, reqBody)
 
-		res := authedClient.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "devices", deviceID})
+		res := authedClient.MustDoFunc(t, "GET", []string{"_matrix", "client", "v3", "devices", deviceID})
 
 		must.MatchResponse(t, res, match.HTTPResponse{
 			JSON: []match.JSON{
@@ -45,7 +45,7 @@ func TestDeviceManagement(t *testing.T) {
 	// sytest: GET /device/{deviceId} gives a 404 for unknown devices
 	t.Run("GET /device/{deviceId} gives a 404 for unknown devices", func(t *testing.T) {
 
-		res := authedClient.DoFunc(t, "GET", []string{"_matrix", "client", "r0", "devices", "unknown_device"})
+		res := authedClient.DoFunc(t, "GET", []string{"_matrix", "client", "v3", "devices", "unknown_device"})
 
 		must.MatchResponse(t, res, match.HTTPResponse{
 			StatusCode: 404,
@@ -66,13 +66,13 @@ func TestDeviceManagement(t *testing.T) {
 			"device_id":                   deviceIDSecond,
 			"initial_device_display_name": "device display",
 		})
-		_ = unauthedClient.MustDoFunc(t, "POST", []string{"_matrix", "client", "r0", "login"}, reqBody)
+		_ = unauthedClient.MustDoFunc(t, "POST", []string{"_matrix", "client", "v3", "login"}, reqBody)
 
 		wantDeviceIDs := map[string]bool{
 			deviceID:       true,
 			deviceIDSecond: true,
 		}
-		res := authedClient.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "devices"})
+		res := authedClient.MustDoFunc(t, "GET", []string{"_matrix", "client", "v3", "devices"})
 		must.MatchResponse(t, res, match.HTTPResponse{
 			StatusCode: 200,
 			JSON: []match.JSON{
@@ -97,9 +97,9 @@ func TestDeviceManagement(t *testing.T) {
 		reqBody := client.WithJSONBody(t, map[string]interface{}{
 			"display_name": "new device display",
 		})
-		_ = authedClient.MustDoFunc(t, "PUT", []string{"_matrix", "client", "r0", "devices", deviceID}, reqBody)
+		_ = authedClient.MustDoFunc(t, "PUT", []string{"_matrix", "client", "v3", "devices", deviceID}, reqBody)
 
-		res := authedClient.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "devices", deviceID})
+		res := authedClient.MustDoFunc(t, "GET", []string{"_matrix", "client", "v3", "devices", deviceID})
 
 		must.MatchResponse(t, res, match.HTTPResponse{
 			JSON: []match.JSON{
@@ -114,7 +114,7 @@ func TestDeviceManagement(t *testing.T) {
 		reqBody := client.WithJSONBody(t, map[string]interface{}{
 			"display_name": "new device display",
 		})
-		res := authedClient.DoFunc(t, "PUT", []string{"_matrix", "client", "r0", "devices", "unknown_device"}, reqBody)
+		res := authedClient.DoFunc(t, "PUT", []string{"_matrix", "client", "v3", "devices", "unknown_device"}, reqBody)
 
 		must.MatchResponse(t, res, match.HTTPResponse{
 			StatusCode: 404,

--- a/tests/csapi/apidoc_login_test.go
+++ b/tests/csapi/apidoc_login_test.go
@@ -22,7 +22,7 @@ func TestLogin(t *testing.T) {
 		// sytest: GET /login yields a set of flows
 		t.Run("GET /login yields a set of flows", func(t *testing.T) {
 			t.Parallel()
-			res := unauthedClient.DoFunc(t, "GET", []string{"_matrix", "client", "r0", "login"}, client.WithRawBody(json.RawMessage(`{}`)))
+			res := unauthedClient.DoFunc(t, "GET", []string{"_matrix", "client", "v3", "login"}, client.WithRawBody(json.RawMessage(`{}`)))
 			must.MatchResponse(t, res, match.HTTPResponse{
 				Headers: map[string]string{
 					"Content-Type": "application/json",
@@ -43,7 +43,7 @@ func TestLogin(t *testing.T) {
 		// sytest: POST /login can log in as a user
 		t.Run("POST /login can login as user", func(t *testing.T) {
 			t.Parallel()
-			res := unauthedClient.MustDo(t, "POST", []string{"_matrix", "client", "r0", "login"}, json.RawMessage(`{
+			res := unauthedClient.MustDo(t, "POST", []string{"_matrix", "client", "v3", "login"}, json.RawMessage(`{
 				"type": "m.login.password",
 				"identifier": {
 					"type": "m.id.user",
@@ -63,7 +63,7 @@ func TestLogin(t *testing.T) {
 		t.Run("POST /login returns the same device_id as that in the request", func(t *testing.T) {
 			t.Parallel()
 			deviceID := "test_device_id"
-			res := unauthedClient.MustDo(t, "POST", []string{"_matrix", "client", "r0", "login"}, json.RawMessage(`{
+			res := unauthedClient.MustDo(t, "POST", []string{"_matrix", "client", "v3", "login"}, json.RawMessage(`{
 				"type": "m.login.password",
 				"identifier": {
 					"type": "m.id.user",
@@ -84,7 +84,7 @@ func TestLogin(t *testing.T) {
 		t.Run("POST /login can log in as a user with just the local part of the id", func(t *testing.T) {
 			t.Parallel()
 
-			res := unauthedClient.MustDo(t, "POST", []string{"_matrix", "client", "r0", "login"}, json.RawMessage(`{
+			res := unauthedClient.MustDo(t, "POST", []string{"_matrix", "client", "v3", "login"}, json.RawMessage(`{
 				"type": "m.login.password",
 				"identifier": {
 					"type": "m.id.user",
@@ -103,7 +103,7 @@ func TestLogin(t *testing.T) {
 		// sytest: POST /login as non-existing user is rejected
 		t.Run("POST /login as non-existing user is rejected", func(t *testing.T) {
 			t.Parallel()
-			res := unauthedClient.DoFunc(t, "POST", []string{"_matrix", "client", "r0", "login"}, client.WithRawBody(json.RawMessage(`{
+			res := unauthedClient.DoFunc(t, "POST", []string{"_matrix", "client", "v3", "login"}, client.WithRawBody(json.RawMessage(`{
 				"type": "m.login.password",
 				"identifier": {
 					"type": "m.id.user",
@@ -118,7 +118,7 @@ func TestLogin(t *testing.T) {
 		// sytest: POST /login wrong password is rejected
 		t.Run("POST /login wrong password is rejected", func(t *testing.T) {
 			t.Parallel()
-			res := unauthedClient.DoFunc(t, "POST", []string{"_matrix", "client", "r0", "login"}, client.WithRawBody(json.RawMessage(`{
+			res := unauthedClient.DoFunc(t, "POST", []string{"_matrix", "client", "v3", "login"}, client.WithRawBody(json.RawMessage(`{
 				"type": "m.login.password",
 				"identifier": {
 					"type": "m.id.user",
@@ -138,7 +138,7 @@ func TestLogin(t *testing.T) {
 		t.Run("Login with uppercase username works and GET /whoami afterwards also", func(t *testing.T) {
 			t.Parallel()
 			// login should be possible with uppercase username
-			res := unauthedClient.MustDoFunc(t, "POST", []string{"_matrix", "client", "r0", "login"}, client.WithRawBody(json.RawMessage(`{
+			res := unauthedClient.MustDoFunc(t, "POST", []string{"_matrix", "client", "v3", "login"}, client.WithRawBody(json.RawMessage(`{
 				"type": "m.login.password",
 				"identifier": {
 					"type": "m.id.user",
@@ -153,7 +153,7 @@ func TestLogin(t *testing.T) {
 			unauthedClient.UserID = js.Get("user_id").Str
 			unauthedClient.AccessToken = js.Get("access_token").Str
 			// check that we can successfully query /whoami
-			unauthedClient.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "account", "whoami"})
+			unauthedClient.MustDoFunc(t, "GET", []string{"_matrix", "client", "v3", "account", "whoami"})
 		})
 	})
 }

--- a/tests/csapi/apidoc_presence_test.go
+++ b/tests/csapi/apidoc_presence_test.go
@@ -20,7 +20,7 @@ func TestPresence(t *testing.T) {
 	authedClient := deployment.Client(t, "hs1", "@alice:hs1")
 	// sytest: GET /presence/:user_id/status fetches initial status
 	t.Run("GET /presence/:user_id/status fetches initial status", func(t *testing.T) {
-		res := authedClient.DoFunc(t, "GET", []string{"_matrix", "client", "r0", "presence", "@alice:hs1", "status"})
+		res := authedClient.DoFunc(t, "GET", []string{"_matrix", "client", "v3", "presence", "@alice:hs1", "status"})
 		must.MatchResponse(t, res, match.HTTPResponse{
 			JSON: []match.JSON{
 				match.JSONKeyPresent("presence"),
@@ -34,11 +34,11 @@ func TestPresence(t *testing.T) {
 			"status_msg": statusMsg,
 			"presence":   "online",
 		})
-		res := authedClient.DoFunc(t, "PUT", []string{"_matrix", "client", "r0", "presence", "@alice:hs1", "status"}, reqBody)
+		res := authedClient.DoFunc(t, "PUT", []string{"_matrix", "client", "v3", "presence", "@alice:hs1", "status"}, reqBody)
 		must.MatchResponse(t, res, match.HTTPResponse{
 			StatusCode: 200,
 		})
-		res = authedClient.DoFunc(t, "GET", []string{"_matrix", "client", "r0", "presence", "@alice:hs1", "status"})
+		res = authedClient.DoFunc(t, "GET", []string{"_matrix", "client", "v3", "presence", "@alice:hs1", "status"})
 		must.MatchResponse(t, res, match.HTTPResponse{
 			JSON: []match.JSON{
 				match.JSONKeyPresent("presence"),

--- a/tests/csapi/apidoc_profile_avatar_url_test.go
+++ b/tests/csapi/apidoc_profile_avatar_url_test.go
@@ -20,7 +20,7 @@ func TestProfileAvatarURL(t *testing.T) {
 		reqBody := client.WithJSONBody(t, map[string]interface{}{
 			"avatar_url": avatarURL,
 		})
-		res := authedClient.MustDoFunc(t, "PUT", []string{"_matrix", "client", "r0", "profile", authedClient.UserID, "avatar_url"}, reqBody)
+		res := authedClient.MustDoFunc(t, "PUT", []string{"_matrix", "client", "v3", "profile", authedClient.UserID, "avatar_url"}, reqBody)
 
 		must.MatchResponse(t, res, match.HTTPResponse{
 			StatusCode: 200,
@@ -29,7 +29,7 @@ func TestProfileAvatarURL(t *testing.T) {
 
 	// sytest: GET /profile/:user_id/avatar_url publicly accessible
 	t.Run("GET /profile/:user_id/avatar_url publicly accessible", func(t *testing.T) {
-		res := unauthedClient.DoFunc(t, "GET", []string{"_matrix", "client", "r0", "profile", authedClient.UserID, "avatar_url"})
+		res := unauthedClient.DoFunc(t, "GET", []string{"_matrix", "client", "v3", "profile", authedClient.UserID, "avatar_url"})
 
 		must.MatchResponse(t, res, match.HTTPResponse{
 			StatusCode: 200,

--- a/tests/csapi/apidoc_profile_displayname_test.go
+++ b/tests/csapi/apidoc_profile_displayname_test.go
@@ -20,11 +20,11 @@ func TestProfileDisplayName(t *testing.T) {
 		reqBody := client.WithJSONBody(t, map[string]interface{}{
 			"displayname": displayName,
 		})
-		_ = authedClient.MustDoFunc(t, "PUT", []string{"_matrix", "client", "r0", "profile", authedClient.UserID, "displayname"}, reqBody)
+		_ = authedClient.MustDoFunc(t, "PUT", []string{"_matrix", "client", "v3", "profile", authedClient.UserID, "displayname"}, reqBody)
 	})
 	// sytest: GET /profile/:user_id/displayname publicly accessible
 	t.Run("GET /profile/:user_id/displayname publicly accessible", func(t *testing.T) {
-		res := unauthedClient.DoFunc(t, "GET", []string{"_matrix", "client", "r0", "profile", authedClient.UserID, "displayname"})
+		res := unauthedClient.DoFunc(t, "GET", []string{"_matrix", "client", "v3", "profile", authedClient.UserID, "displayname"})
 		must.MatchResponse(t, res, match.HTTPResponse{
 			StatusCode: 200,
 			JSON: []match.JSON{

--- a/tests/csapi/apidoc_register_test.go
+++ b/tests/csapi/apidoc_register_test.go
@@ -41,7 +41,7 @@ func TestRegistration(t *testing.T) {
 		// The name in Sytest is different, the test is actually doing a POST request.
 		t.Run("POST {} returns a set of flows", func(t *testing.T) {
 			t.Parallel()
-			res := unauthedClient.DoFunc(t, "POST", []string{"_matrix", "client", "r0", "register"}, client.WithRawBody(json.RawMessage(`{}`)))
+			res := unauthedClient.DoFunc(t, "POST", []string{"_matrix", "client", "v3", "register"}, client.WithRawBody(json.RawMessage(`{}`)))
 			must.MatchResponse(t, res, match.HTTPResponse{
 				StatusCode: 401,
 				Headers: map[string]string{
@@ -60,7 +60,7 @@ func TestRegistration(t *testing.T) {
 		// sytest: POST /register can create a user
 		t.Run("POST /register can create a user", func(t *testing.T) {
 			t.Parallel()
-			res := unauthedClient.DoFunc(t, "POST", []string{"_matrix", "client", "r0", "register"}, client.WithRawBody(json.RawMessage(`{
+			res := unauthedClient.DoFunc(t, "POST", []string{"_matrix", "client", "v3", "register"}, client.WithRawBody(json.RawMessage(`{
 				"auth": {
 					"type": "m.login.dummy"
 				},
@@ -77,7 +77,7 @@ func TestRegistration(t *testing.T) {
 		// sytest: POST /register downcases capitals in usernames
 		t.Run("POST /register downcases capitals in usernames", func(t *testing.T) {
 			t.Parallel()
-			res := unauthedClient.DoFunc(t, "POST", []string{"_matrix", "client", "r0", "register"}, client.WithRawBody(json.RawMessage(`{
+			res := unauthedClient.DoFunc(t, "POST", []string{"_matrix", "client", "v3", "register"}, client.WithRawBody(json.RawMessage(`{
 				"auth": {
 					"type": "m.login.dummy"
 				},
@@ -95,7 +95,7 @@ func TestRegistration(t *testing.T) {
 		t.Run("POST /register returns the same device_id as that in the request", func(t *testing.T) {
 			t.Parallel()
 			deviceID := "my_device_id"
-			res := unauthedClient.DoFunc(t, "POST", []string{"_matrix", "client", "r0", "register"}, client.WithRawBody(json.RawMessage(`{
+			res := unauthedClient.DoFunc(t, "POST", []string{"_matrix", "client", "v3", "register"}, client.WithRawBody(json.RawMessage(`{
 				"auth": {
 					"type": "m.login.dummy"
 				},
@@ -131,7 +131,7 @@ func TestRegistration(t *testing.T) {
 				`'`,
 			}
 			for _, ch := range specialChars {
-				res := unauthedClient.DoFunc(t, "POST", []string{"_matrix", "client", "r0", "register"},
+				res := unauthedClient.DoFunc(t, "POST", []string{"_matrix", "client", "v3", "register"},
 					client.WithJSONBody(t, map[string]interface{}{
 						"auth": map[string]string{
 							"type": "m.login.dummy",
@@ -149,7 +149,7 @@ func TestRegistration(t *testing.T) {
 		})
 		t.Run("POST /register rejects if user already exists", func(t *testing.T) {
 			t.Parallel()
-			res := unauthedClient.DoFunc(t, "POST", []string{"_matrix", "client", "r0", "register"}, client.WithRawBody(json.RawMessage(`{
+			res := unauthedClient.DoFunc(t, "POST", []string{"_matrix", "client", "v3", "register"}, client.WithRawBody(json.RawMessage(`{
 				"auth": {
 					"type": "m.login.dummy"
 				},
@@ -162,7 +162,7 @@ func TestRegistration(t *testing.T) {
 					match.JSONKeyTypeEqual("user_id", gjson.String),
 				},
 			})
-			res = unauthedClient.DoFunc(t, "POST", []string{"_matrix", "client", "r0", "register"}, client.WithRawBody(json.RawMessage(`{
+			res = unauthedClient.DoFunc(t, "POST", []string{"_matrix", "client", "v3", "register"}, client.WithRawBody(json.RawMessage(`{
 				"auth": {
 					"type": "m.login.dummy"
 				},
@@ -231,7 +231,7 @@ func TestRegistration(t *testing.T) {
 				"password":                    "übers3kr1t",
 				"device_id":                   "xyzzy",
 				"initial_device_display_name": "display_name"}
-			resp := unauthedClient.DoFunc(t, "POST", []string{"_matrix", "client", "r0", "register"}, client.WithJSONBody(t, reqJson))
+			resp := unauthedClient.DoFunc(t, "POST", []string{"_matrix", "client", "v3", "register"}, client.WithJSONBody(t, reqJson))
 			body, err := ioutil.ReadAll(resp.Body)
 			session := gjson.GetBytes(body, "session")
 			if err != nil {
@@ -249,7 +249,7 @@ func TestRegistration(t *testing.T) {
 				"initial_device_display_name": "display_name",
 				"auth":                        auth,
 			}
-			resp2 := unauthedClient.DoFunc(t, "POST", []string{"_matrix", "client", "r0", "register"}, client.WithJSONBody(t, reqBody))
+			resp2 := unauthedClient.DoFunc(t, "POST", []string{"_matrix", "client", "v3", "register"}, client.WithJSONBody(t, reqBody))
 			must.MatchResponse(t, resp2, match.HTTPResponse{JSON: []match.JSON{
 				match.JSONKeyPresent("access_token"),
 			}})

--- a/tests/csapi/apidoc_request_encoding_test.go
+++ b/tests/csapi/apidoc_request_encoding_test.go
@@ -18,7 +18,7 @@ func TestRequestEncodingFails(t *testing.T) {
 	testString := `{ "test":"a` + "\x81" + `" }`
 	// sytest: POST rejects invalid utf-8 in JSON
 	t.Run("POST rejects invalid utf-8 in JSON", func(t *testing.T) {
-		res := unauthedClient.DoFunc(t, "POST", []string{"_matrix", "client", "r0", "register"}, client.WithRawBody(json.RawMessage(testString)))
+		res := unauthedClient.DoFunc(t, "POST", []string{"_matrix", "client", "v3", "register"}, client.WithRawBody(json.RawMessage(testString)))
 		must.MatchResponse(t, res, match.HTTPResponse{
 			StatusCode: 400,
 			JSON: []match.JSON{

--- a/tests/csapi/apidoc_room_alias_test.go
+++ b/tests/csapi/apidoc_room_alias_test.go
@@ -11,21 +11,21 @@ import (
 )
 
 func setRoomAliasResp(t *testing.T, c *client.CSAPI, roomID, roomAlias string) *http.Response {
-	return c.DoFunc(t, "PUT", []string{"_matrix", "client", "r0", "directory", "room", roomAlias}, client.WithJSONBody(t, map[string]interface{}{
+	return c.DoFunc(t, "PUT", []string{"_matrix", "client", "v3", "directory", "room", roomAlias}, client.WithJSONBody(t, map[string]interface{}{
 		"room_id": roomID,
 	}))
 }
 
 func getRoomAliasResp(t *testing.T, c *client.CSAPI, roomAlias string) *http.Response {
-	return c.DoFunc(t, "GET", []string{"_matrix", "client", "r0", "directory", "room", roomAlias})
+	return c.DoFunc(t, "GET", []string{"_matrix", "client", "v3", "directory", "room", roomAlias})
 }
 
 func deleteRoomAliasResp(t *testing.T, c *client.CSAPI, roomAlias string) *http.Response {
-	return c.DoFunc(t, "DELETE", []string{"_matrix", "client", "r0", "directory", "room", roomAlias})
+	return c.DoFunc(t, "DELETE", []string{"_matrix", "client", "v3", "directory", "room", roomAlias})
 }
 
 func listRoomAliasesResp(t *testing.T, c *client.CSAPI, roomID string) *http.Response {
-	return c.DoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "aliases"})
+	return c.DoFunc(t, "GET", []string{"_matrix", "client", "v3", "rooms", roomID, "aliases"})
 }
 
 func setCanonicalAlias(t *testing.T, c *client.CSAPI, roomID string, roomAlias string, altAliases *[]string) *http.Response {
@@ -36,7 +36,7 @@ func setCanonicalAlias(t *testing.T, c *client.CSAPI, roomID string, roomAlias s
 		content["alt_aliases"] = altAliases
 	}
 
-	return c.DoFunc(t, "PUT", []string{"_matrix", "client", "r0", "rooms", roomID, "state", "m.room.canonical_alias"}, client.WithJSONBody(t, content))
+	return c.DoFunc(t, "PUT", []string{"_matrix", "client", "v3", "rooms", roomID, "state", "m.room.canonical_alias"}, client.WithJSONBody(t, content))
 }
 
 func TestRoomAlias(t *testing.T) {

--- a/tests/csapi/apidoc_room_create_test.go
+++ b/tests/csapi/apidoc_room_create_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func doCreateRoom(t *testing.T, c *client.CSAPI, json map[string]interface{}, match match.HTTPResponse) {
-	res := c.DoFunc(t, "POST", []string{"_matrix", "client", "r0", "createRoom"}, client.WithJSONBody(t, json))
+	res := c.DoFunc(t, "POST", []string{"_matrix", "client", "v3", "createRoom"}, client.WithJSONBody(t, json))
 	must.MatchResponse(t, res, match)
 }
 
@@ -62,7 +62,7 @@ func TestRoomCreate(t *testing.T) {
 				"topic":  "Test Room",
 				"preset": "public_chat",
 			})
-			res := alice.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "state", "m.room.topic"})
+			res := alice.MustDoFunc(t, "GET", []string{"_matrix", "client", "v3", "rooms", roomID, "state", "m.room.topic"})
 			must.MatchResponse(t, res, match.HTTPResponse{
 				StatusCode: 200,
 				JSON: []match.JSON{
@@ -77,7 +77,7 @@ func TestRoomCreate(t *testing.T) {
 				"name":   "Test Room",
 				"preset": "public_chat",
 			})
-			res := alice.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "state", "m.room.name"})
+			res := alice.MustDoFunc(t, "GET", []string{"_matrix", "client", "v3", "rooms", roomID, "state", "m.room.name"})
 			must.MatchResponse(t, res, match.HTTPResponse{
 				StatusCode: 200,
 				JSON: []match.JSON{
@@ -92,7 +92,7 @@ func TestRoomCreate(t *testing.T) {
 				"room_version": "2",
 				"preset":       "public_chat",
 			})
-			res := alice.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "state", "m.room.create"})
+			res := alice.MustDoFunc(t, "GET", []string{"_matrix", "client", "v3", "rooms", roomID, "state", "m.room.create"})
 			must.MatchResponse(t, res, match.HTTPResponse{
 				StatusCode: 200,
 				JSON: []match.JSON{

--- a/tests/csapi/apidoc_room_forget_test.go
+++ b/tests/csapi/apidoc_room_forget_test.go
@@ -25,7 +25,7 @@ func TestRoomForget(t *testing.T) {
 		t.Run("Can't forget room you're still in", func(t *testing.T) {
 			t.Parallel()
 			roomID := alice.CreateRoom(t, map[string]interface{}{"preset": "private_chat"})
-			res := alice.DoFunc(t, "POST", []string{"_matrix", "client", "r0", "rooms", roomID, "forget"})
+			res := alice.DoFunc(t, "POST", []string{"_matrix", "client", "v3", "rooms", roomID, "forget"})
 			must.MatchResponse(t, res, match.HTTPResponse{
 				StatusCode: http.StatusBadRequest,
 				JSON: []match.JSON{
@@ -46,8 +46,8 @@ func TestRoomForget(t *testing.T) {
 				},
 			})
 			alice.LeaveRoom(t, roomID)
-			alice.MustDoFunc(t, "POST", []string{"_matrix", "client", "r0", "rooms", roomID, "forget"})
-			res := alice.DoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "messages"})
+			alice.MustDoFunc(t, "POST", []string{"_matrix", "client", "v3", "rooms", roomID, "forget"})
+			res := alice.DoFunc(t, "GET", []string{"_matrix", "client", "v3", "rooms", roomID, "messages"})
 			must.MatchResponse(t, res, match.HTTPResponse{
 				StatusCode: http.StatusForbidden,
 				JSON: []match.JSON{
@@ -70,7 +70,7 @@ func TestRoomForget(t *testing.T) {
 			alice.LeaveRoom(t, roomID)
 			// Ensure Alice left the room
 			bob.MustSyncUntil(t, client.SyncReq{}, client.SyncLeftFrom(alice.UserID, roomID))
-			alice.MustDoFunc(t, "POST", []string{"_matrix", "client", "r0", "rooms", roomID, "forget"})
+			alice.MustDoFunc(t, "POST", []string{"_matrix", "client", "v3", "rooms", roomID, "forget"})
 			bob.SendEventSynced(t, roomID, b.Event{
 				Type: "m.room.message",
 				Content: map[string]interface{}{
@@ -102,7 +102,7 @@ func TestRoomForget(t *testing.T) {
 				},
 			})
 			// Kick Bob
-			alice.MustDoFunc(t, "POST", []string{"_matrix", "client", "r0", "rooms", roomID, "kick"},
+			alice.MustDoFunc(t, "POST", []string{"_matrix", "client", "v3", "rooms", roomID, "kick"},
 				client.WithJSONBody(t, map[string]interface{}{
 					"user_id": bob.UserID,
 				}),
@@ -147,9 +147,9 @@ func TestRoomForget(t *testing.T) {
 			bob.LeaveRoom(t, roomID)
 			// Ensure Bob has really left the room
 			alice.MustSyncUntil(t, client.SyncReq{}, client.SyncLeftFrom(bob.UserID, roomID))
-			bob.MustDoFunc(t, "POST", []string{"_matrix", "client", "r0", "rooms", roomID, "forget"})
+			bob.MustDoFunc(t, "POST", []string{"_matrix", "client", "v3", "rooms", roomID, "forget"})
 			// Try to re-join
-			joinRes := bob.DoFunc(t, "POST", []string{"_matrix", "client", "r0", "join", roomID})
+			joinRes := bob.DoFunc(t, "POST", []string{"_matrix", "client", "v3", "join", roomID})
 			must.MatchResponse(t, joinRes, match.HTTPResponse{
 				StatusCode: http.StatusForbidden,
 				JSON: []match.JSON{
@@ -164,7 +164,7 @@ func TestRoomForget(t *testing.T) {
 			queryParams.Set("dir", "b")
 			queryParams.Set("limit", "100")
 			// Check if we can see Bobs previous message
-			res := bob.DoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "messages"}, client.WithQueries(queryParams))
+			res := bob.DoFunc(t, "GET", []string{"_matrix", "client", "v3", "rooms", roomID, "messages"}, client.WithQueries(queryParams))
 			msgRes := &msgResult{}
 			must.MatchResponse(t, res, match.HTTPResponse{
 				StatusCode: http.StatusOK,
@@ -184,7 +184,7 @@ func TestRoomForget(t *testing.T) {
 			msgRes.found = false
 			// We should now be able to see the new message
 			queryParams.Set("limit", "1")
-			res = bob.DoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "messages"}, client.WithQueries(queryParams))
+			res = bob.DoFunc(t, "GET", []string{"_matrix", "client", "v3", "rooms", roomID, "messages"}, client.WithQueries(queryParams))
 			must.MatchResponse(t, res, match.HTTPResponse{
 				StatusCode: http.StatusOK,
 				JSON:       []match.JSON{findMessageId(messageID, msgRes)},
@@ -201,11 +201,11 @@ func TestRoomForget(t *testing.T) {
 			// Bob rejects the invite
 			bob.LeaveRoom(t, roomID)
 			// Bob tries to forget about this room
-			bob.MustDoFunc(t, "POST", []string{"_matrix", "client", "r0", "rooms", roomID, "forget"})
+			bob.MustDoFunc(t, "POST", []string{"_matrix", "client", "v3", "rooms", roomID, "forget"})
 			// Alice also leaves the room
 			alice.LeaveRoom(t, roomID)
 			// Alice tries to forget about this room
-			alice.MustDoFunc(t, "POST", []string{"_matrix", "client", "r0", "rooms", roomID, "forget"})
+			alice.MustDoFunc(t, "POST", []string{"_matrix", "client", "v3", "rooms", roomID, "forget"})
 		})
 	})
 }

--- a/tests/csapi/apidoc_room_history_visibility_test.go
+++ b/tests/csapi/apidoc_room_history_visibility_test.go
@@ -16,7 +16,7 @@ import (
 // TODO most of this can be refactored into data-driven tests
 
 func fetchEvent(t *testing.T, c *client.CSAPI, roomId, eventId string) *http.Response {
-	return c.DoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomId, "event", eventId})
+	return c.DoFunc(t, "GET", []string{"_matrix", "client", "v3", "rooms", roomId, "event", eventId})
 }
 
 func createRoomWithVisibility(t *testing.T, c *client.CSAPI, visibility string) string {

--- a/tests/csapi/apidoc_room_members_test.go
+++ b/tests/csapi/apidoc_room_members_test.go
@@ -25,7 +25,7 @@ func TestRoomMembers(t *testing.T) {
 				"preset":     "public_chat",
 			})
 
-			res := bob.MustDoFunc(t, "POST", []string{"_matrix", "client", "r0", "rooms", roomID, "join"})
+			res := bob.MustDoFunc(t, "POST", []string{"_matrix", "client", "v3", "rooms", roomID, "join"})
 
 			must.MatchResponse(t, res, match.HTTPResponse{
 				JSON: []match.JSON{
@@ -46,7 +46,7 @@ func TestRoomMembers(t *testing.T) {
 				"room_alias_name": "room_alias_random",
 			})
 
-			res := bob.MustDoFunc(t, "POST", []string{"_matrix", "client", "r0", "join", "#room_alias_random:hs1"})
+			res := bob.MustDoFunc(t, "POST", []string{"_matrix", "client", "v3", "join", "#room_alias_random:hs1"})
 
 			must.MatchResponse(t, res, match.HTTPResponse{
 				JSON: []match.JSON{
@@ -66,7 +66,7 @@ func TestRoomMembers(t *testing.T) {
 				"preset":     "public_chat",
 			})
 
-			res := bob.MustDoFunc(t, "POST", []string{"_matrix", "client", "r0", "join", roomID})
+			res := bob.MustDoFunc(t, "POST", []string{"_matrix", "client", "v3", "join", roomID})
 
 			must.MatchResponse(t, res, match.HTTPResponse{
 				JSON: []match.JSON{
@@ -173,7 +173,7 @@ func TestRoomMembers(t *testing.T) {
 				"room_alias_name": "room_alias_random2",
 			})
 			joinBody := client.WithJSONBody(t, map[string]string{"foo": "bar"})
-			res := bob.MustDoFunc(t, "POST", []string{"_matrix", "client", "r0", "join", "#room_alias_random2:hs1"}, joinBody)
+			res := bob.MustDoFunc(t, "POST", []string{"_matrix", "client", "v3", "join", "#room_alias_random2:hs1"}, joinBody)
 
 			must.MatchResponse(t, res, match.HTTPResponse{
 				JSON: []match.JSON{

--- a/tests/csapi/apidoc_room_state_test.go
+++ b/tests/csapi/apidoc_room_state_test.go
@@ -24,7 +24,7 @@ func TestRoomState(t *testing.T) {
 				"visibility": "public",
 				"preset":     "public_chat",
 			})
-			res := authedClient.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "state", "m.room.member", authedClient.UserID})
+			res := authedClient.MustDoFunc(t, "GET", []string{"_matrix", "client", "v3", "rooms", roomID, "state", "m.room.member", authedClient.UserID})
 			must.MatchResponse(t, res, match.HTTPResponse{
 				JSON: []match.JSON{
 					match.JSONKeyPresent("membership"),
@@ -42,7 +42,7 @@ func TestRoomState(t *testing.T) {
 				"visibility": "public",
 				"preset":     "public_chat",
 			})
-			res := authedClient.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "state", "m.room.member", authedClient.UserID}, client.WithQueries(queryParams))
+			res := authedClient.MustDoFunc(t, "GET", []string{"_matrix", "client", "v3", "rooms", roomID, "state", "m.room.member", authedClient.UserID}, client.WithQueries(queryParams))
 			must.MatchResponse(t, res, match.HTTPResponse{
 				JSON: []match.JSON{
 					match.JSONKeyPresent("sender"),
@@ -63,7 +63,7 @@ func TestRoomState(t *testing.T) {
 				"preset":          "public_chat",
 				"room_alias_name": "room_alias",
 			})
-			res := authedClient.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "state", "m.room.power_levels"})
+			res := authedClient.MustDoFunc(t, "GET", []string{"_matrix", "client", "v3", "rooms", roomID, "state", "m.room.power_levels"})
 
 			must.MatchResponse(t, res, match.HTTPResponse{
 				JSON: []match.JSON{
@@ -86,7 +86,7 @@ func TestRoomState(t *testing.T) {
 				"preset":     "public_chat",
 			})
 
-			res := authedClient.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "joined_members"})
+			res := authedClient.MustDoFunc(t, "GET", []string{"_matrix", "client", "v3", "rooms", roomID, "joined_members"})
 			must.MatchResponse(t, res, match.HTTPResponse{
 				JSON: []match.JSON{
 					match.JSONKeyPresent("joined"),
@@ -104,7 +104,7 @@ func TestRoomState(t *testing.T) {
 				"preset":     "public_chat",
 			})
 
-			res := authedClient.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "publicRooms"})
+			res := authedClient.MustDoFunc(t, "GET", []string{"_matrix", "client", "v3", "publicRooms"})
 			foundRoom := false
 
 			must.MatchResponse(t, res, match.HTTPResponse{
@@ -135,7 +135,7 @@ func TestRoomState(t *testing.T) {
 				"room_alias_name": "room_new",
 			})
 
-			res := authedClient.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "directory", "room", "#room_new:hs1"})
+			res := authedClient.MustDoFunc(t, "GET", []string{"_matrix", "client", "v3", "directory", "room", "#room_new:hs1"})
 
 			must.MatchResponse(t, res, match.HTTPResponse{
 				JSON: []match.JSON{
@@ -154,7 +154,7 @@ func TestRoomState(t *testing.T) {
 				"visibility": "public",
 				"preset":     "public_chat",
 			})
-			res := authedClient.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "joined_rooms"})
+			res := authedClient.MustDoFunc(t, "GET", []string{"_matrix", "client", "v3", "joined_rooms"})
 
 			foundRoom := false
 
@@ -186,7 +186,7 @@ func TestRoomState(t *testing.T) {
 				"name":       "room_name_test",
 			})
 
-			res := authedClient.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "state", "m.room.name"})
+			res := authedClient.MustDoFunc(t, "GET", []string{"_matrix", "client", "v3", "rooms", roomID, "state", "m.room.name"})
 
 			must.MatchResponse(t, res, match.HTTPResponse{
 				JSON: []match.JSON{
@@ -208,9 +208,9 @@ func TestRoomState(t *testing.T) {
 				"name": "room_test_name",
 			})
 
-			_ = authedClient.MustDoFunc(t, "PUT", []string{"_matrix", "client", "r0", "rooms", roomID, "state", "m.room.name"}, reqBody)
+			_ = authedClient.MustDoFunc(t, "PUT", []string{"_matrix", "client", "v3", "rooms", roomID, "state", "m.room.name"}, reqBody)
 
-			res := authedClient.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "state", "m.room.name"})
+			res := authedClient.MustDoFunc(t, "GET", []string{"_matrix", "client", "v3", "rooms", roomID, "state", "m.room.name"})
 
 			must.MatchResponse(t, res, match.HTTPResponse{
 				JSON: []match.JSON{
@@ -229,7 +229,7 @@ func TestRoomState(t *testing.T) {
 				"topic":      "room_topic_test",
 			})
 
-			res := authedClient.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "state", "m.room.topic"})
+			res := authedClient.MustDoFunc(t, "GET", []string{"_matrix", "client", "v3", "rooms", roomID, "state", "m.room.topic"})
 
 			must.MatchResponse(t, res, match.HTTPResponse{
 				JSON: []match.JSON{
@@ -251,9 +251,9 @@ func TestRoomState(t *testing.T) {
 				"topic": "room_test_topic",
 			})
 
-			_ = authedClient.MustDoFunc(t, "PUT", []string{"_matrix", "client", "r0", "rooms", roomID, "state", "m.room.topic"}, reqBody)
+			_ = authedClient.MustDoFunc(t, "PUT", []string{"_matrix", "client", "v3", "rooms", roomID, "state", "m.room.topic"}, reqBody)
 
-			res := authedClient.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "state", "m.room.topic"})
+			res := authedClient.MustDoFunc(t, "GET", []string{"_matrix", "client", "v3", "rooms", roomID, "state", "m.room.topic"})
 
 			must.MatchResponse(t, res, match.HTTPResponse{
 				JSON: []match.JSON{
@@ -281,7 +281,7 @@ func TestRoomState(t *testing.T) {
 				"m.room.topic":        true,
 			}
 
-			res := authedClient.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "state"})
+			res := authedClient.MustDoFunc(t, "GET", []string{"_matrix", "client", "v3", "rooms", roomID, "state"})
 
 			must.MatchResponse(t, res, match.HTTPResponse{
 				JSON: []match.JSON{
@@ -311,7 +311,7 @@ func TestRoomState(t *testing.T) {
 				},
 			})
 
-			res := authedClient.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "state", "m.room.create"})
+			res := authedClient.MustDoFunc(t, "GET", []string{"_matrix", "client", "v3", "rooms", roomID, "state", "m.room.create"})
 
 			must.MatchResponse(t, res, match.HTTPResponse{
 				JSON: []match.JSON{

--- a/tests/csapi/e2e_key_backup_test.go
+++ b/tests/csapi/e2e_key_backup_test.go
@@ -32,7 +32,7 @@ func TestE2EKeyBackupReplaceRoomKeyRules(t *testing.T) {
 	alice := deployment.Client(t, "hs1", userID)
 
 	// make a new key backup
-	res := alice.MustDoFunc(t, "POST", []string{"_matrix", "client", "r0", "room_keys", "version"}, client.WithJSONBody(t, map[string]interface{}{
+	res := alice.MustDoFunc(t, "POST", []string{"_matrix", "client", "v3", "room_keys", "version"}, client.WithJSONBody(t, map[string]interface{}{
 		"algorithm": "m.megolm_backup.v1",
 		"auth_data": map[string]interface{}{
 			"foo": "bar",
@@ -123,7 +123,7 @@ func TestE2EKeyBackupReplaceRoomKeyRules(t *testing.T) {
 			t.Run(fmt.Sprintf("%+v", tc.input), func(t *testing.T) {
 				t.Parallel()
 				// insert the key that will be tested against
-				alice.MustDoFunc(t, "PUT", []string{"_matrix", "client", "r0", "room_keys", "keys", roomID, tc.sessionID},
+				alice.MustDoFunc(t, "PUT", []string{"_matrix", "client", "v3", "room_keys", "keys", roomID, tc.sessionID},
 					client.WithQueries(map[string][]string{"version": {backupVersion}}), client.WithJSONBody(t, map[string]interface{}{
 						"first_message_index": tc.input.firstMessageIndex,
 						"forwarded_count":     tc.input.forwardedCount,
@@ -133,7 +133,7 @@ func TestE2EKeyBackupReplaceRoomKeyRules(t *testing.T) {
 				)
 				// now check that each key in keysThatDontReplace do not replace this key
 				for _, testKey := range tc.keysThatDontReplace {
-					alice.MustDoFunc(t, "PUT", []string{"_matrix", "client", "r0", "room_keys", "keys", roomID, tc.sessionID},
+					alice.MustDoFunc(t, "PUT", []string{"_matrix", "client", "v3", "room_keys", "keys", roomID, tc.sessionID},
 						client.WithQueries(map[string][]string{"version": {backupVersion}}), client.WithJSONBody(t, map[string]interface{}{
 							"first_message_index": testKey.firstMessageIndex,
 							"forwarded_count":     testKey.forwardedCount,
@@ -141,7 +141,7 @@ func TestE2EKeyBackupReplaceRoomKeyRules(t *testing.T) {
 							"session_data":        map[string]interface{}{"a": "b"},
 						}),
 					)
-					checkResp := alice.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "room_keys", "keys", roomID, tc.sessionID},
+					checkResp := alice.MustDoFunc(t, "GET", []string{"_matrix", "client", "v3", "room_keys", "keys", roomID, tc.sessionID},
 						client.WithQueries(map[string][]string{"version": {backupVersion}}),
 					)
 					must.MatchResponse(t, checkResp, match.HTTPResponse{

--- a/tests/csapi/ignored_users_test.go
+++ b/tests/csapi/ignored_users_test.go
@@ -43,7 +43,7 @@ func TestInviteFromIgnoredUsersDoesNotAppearInSync(t *testing.T) {
 	alice.MustDoFunc(
 		t,
 		"PUT",
-		[]string{"_matrix", "client", "r0", "user", alice.UserID, "account_data", "m.ignored_user_list"},
+		[]string{"_matrix", "client", "v3", "user", alice.UserID, "account_data", "m.ignored_user_list"},
 		client.WithJSONBody(t, map[string]interface{}{
 			"ignored_users": map[string]interface{}{
 				bob.UserID: map[string]interface{}{},
@@ -85,7 +85,7 @@ func TestInviteFromIgnoredUsersDoesNotAppearInSync(t *testing.T) {
 	response := alice.MustDoFunc(
 		t,
 		"GET",
-		[]string{"_matrix", "client", "r0", "sync"},
+		[]string{"_matrix", "client", "v3", "sync"},
 		client.WithQueries(queryParams),
 	)
 	bobRoomPath := "rooms.invite." + client.GjsonEscape(bobRoom)

--- a/tests/csapi/invalid_test.go
+++ b/tests/csapi/invalid_test.go
@@ -34,7 +34,7 @@ func TestJson(t *testing.T) {
 			}
 
 			for _, testCase := range testCases {
-				res := alice.DoFunc(t, "POST", []string{"_matrix", "client", "r0", "rooms", roomID, "send", "complement.dummy"}, client.WithJSONBody(t, testCase))
+				res := alice.DoFunc(t, "POST", []string{"_matrix", "client", "v3", "rooms", roomID, "send", "complement.dummy"}, client.WithJSONBody(t, testCase))
 
 				must.MatchResponse(t, res, match.HTTPResponse{
 					StatusCode: 400,
@@ -56,7 +56,7 @@ func TestJson(t *testing.T) {
 			}
 
 			for _, testCase := range testCases {
-				res := alice.DoFunc(t, "POST", []string{"_matrix", "client", "r0", "rooms", roomID, "send", "complement.dummy"}, client.WithJSONBody(t, testCase))
+				res := alice.DoFunc(t, "POST", []string{"_matrix", "client", "v3", "rooms", roomID, "send", "complement.dummy"}, client.WithJSONBody(t, testCase))
 
 				must.MatchResponse(t, res, match.HTTPResponse{
 					StatusCode: 400,
@@ -177,7 +177,7 @@ func TestFilter(t *testing.T) {
 	filters := getFilters()
 
 	for _, filter := range filters {
-		res := alice.DoFunc(t, "POST", []string{"_matrix", "client", "r0", "user", alice.UserID, "filter"}, client.WithJSONBody(t, filter))
+		res := alice.DoFunc(t, "POST", []string{"_matrix", "client", "v3", "user", alice.UserID, "filter"}, client.WithJSONBody(t, filter))
 
 		if res.StatusCode >= 500 || res.StatusCode < 400 {
 			t.Errorf("Expected 4XX status code, got %d for testing filter %s", res.StatusCode, filter)
@@ -205,7 +205,7 @@ func TestEvent(t *testing.T) {
 				"body":    strings.Repeat("and they dont stop coming ", 2700), // 2700 * 26 == 70200
 			}
 
-			res := alice.DoFunc(t, "PUT", []string{"_matrix", "client", "r0", "rooms", roomID, "send", "m.room.message", "1"}, client.WithJSONBody(t, event))
+			res := alice.DoFunc(t, "PUT", []string{"_matrix", "client", "v3", "rooms", roomID, "send", "m.room.message", "1"}, client.WithJSONBody(t, event))
 
 			must.MatchResponse(t, res, match.HTTPResponse{
 				StatusCode: 413,
@@ -219,7 +219,7 @@ func TestEvent(t *testing.T) {
 				"body": strings.Repeat("Dormammu, I've Come To Bargain.\n", 2200), // 2200 * 32 == 70400
 			}
 
-			res := alice.DoFunc(t, "PUT", []string{"_matrix", "client", "r0", "rooms", roomID, "state", "marvel.universe.fate"}, client.WithJSONBody(t, stateEvent))
+			res := alice.DoFunc(t, "PUT", []string{"_matrix", "client", "v3", "rooms", roomID, "state", "marvel.universe.fate"}, client.WithJSONBody(t, stateEvent))
 
 			must.MatchResponse(t, res, match.HTTPResponse{
 				StatusCode: 413,

--- a/tests/csapi/media_misc_test.go
+++ b/tests/csapi/media_misc_test.go
@@ -45,7 +45,7 @@ func TestRoomImageRoundtrip(t *testing.T) {
 		},
 	})
 
-	messages := alice.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomId, "messages"}, client.WithQueries(url.Values{
+	messages := alice.MustDoFunc(t, "GET", []string{"_matrix", "client", "v3", "rooms", roomId, "messages"}, client.WithQueries(url.Values{
 		"filter": []string{`{"contains_url":true}`},
 		"dir":    []string{"b"},
 	}))
@@ -66,7 +66,7 @@ func TestMediaConfig(t *testing.T) {
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
 
-	res := alice.MustDoFunc(t, "GET", []string{"_matrix", "media", "r0", "config"})
+	res := alice.MustDoFunc(t, "GET", []string{"_matrix", "media", "v3", "config"})
 
 	must.MatchResponse(t, res, match.HTTPResponse{
 		JSON: []match.JSON{

--- a/tests/csapi/push_test.go
+++ b/tests/csapi/push_test.go
@@ -20,12 +20,12 @@ func TestPushRuleCacheHealth(t *testing.T) {
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
 
-	alice.MustDoFunc(t, "PUT", []string{"_matrix", "client", "r0", "pushrules", "global", "sender", alice.UserID}, client.WithJSONBody(t, map[string]interface{}{
+	alice.MustDoFunc(t, "PUT", []string{"_matrix", "client", "v3", "pushrules", "global", "sender", alice.UserID}, client.WithJSONBody(t, map[string]interface{}{
 		"actions": []string{"dont_notify"},
 	}))
 
 	// the extra "" is to make sure the submitted URL ends with a trailing slash
-	res := alice.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "pushrules", ""})
+	res := alice.MustDoFunc(t, "GET", []string{"_matrix", "client", "v3", "pushrules", ""})
 
 	must.MatchResponse(t, res, match.HTTPResponse{
 		JSON: []match.JSON{
@@ -33,7 +33,7 @@ func TestPushRuleCacheHealth(t *testing.T) {
 		},
 	})
 
-	res = alice.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "pushrules", ""})
+	res = alice.MustDoFunc(t, "GET", []string{"_matrix", "client", "v3", "pushrules", ""})
 
 	must.MatchResponse(t, res, match.HTTPResponse{
 		JSON: []match.JSON{

--- a/tests/csapi/room_ban_test.go
+++ b/tests/csapi/room_ban_test.go
@@ -59,7 +59,7 @@ func TestNotPresentUserCannotBanOthers(t *testing.T) {
 
 	bob.MustSyncUntil(t, client.SyncReq{}, client.SyncJoinedTo(bob.UserID, roomID))
 
-	res := charlie.DoFunc(t, "POST", []string{"_matrix", "client", "r0", "rooms", roomID, "ban"}, client.WithJSONBody(t, map[string]interface{}{
+	res := charlie.DoFunc(t, "POST", []string{"_matrix", "client", "v3", "rooms", roomID, "ban"}, client.WithJSONBody(t, map[string]interface{}{
 		"user_id": bob.UserID,
 		"reason":  "testing",
 	}))

--- a/tests/csapi/room_messages_test.go
+++ b/tests/csapi/room_messages_test.go
@@ -31,7 +31,7 @@ func TestSendAndFetchMessage(t *testing.T) {
 	_, token := alice.MustSync(t, client.SyncReq{})
 
 	// first use the non-txn endpoint
-	alice.MustDoFunc(t, "POST", []string{"_matrix", "client", "r0", "rooms", roomID, "send", "m.room.message"}, client.WithJSONBody(t, map[string]interface{}{
+	alice.MustDoFunc(t, "POST", []string{"_matrix", "client", "v3", "rooms", roomID, "send", "m.room.message"}, client.WithJSONBody(t, map[string]interface{}{
 		"msgtype": "m.text",
 		"body":    testMessage,
 	}))
@@ -45,7 +45,7 @@ func TestSendAndFetchMessage(t *testing.T) {
 	queryParams := url.Values{}
 	queryParams.Set("dir", "f")
 	queryParams.Set("from", token)
-	res := alice.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "messages"}, client.WithQueries(queryParams))
+	res := alice.MustDoFunc(t, "GET", []string{"_matrix", "client", "v3", "rooms", roomID, "messages"}, client.WithQueries(queryParams))
 	must.MatchResponse(t, res, match.HTTPResponse{
 		StatusCode: http.StatusOK,
 		JSON: []match.JSON{
@@ -71,7 +71,7 @@ func TestFetchMessagesFromNonExistentRoom(t *testing.T) {
 	// then request messages from the room
 	queryParams := url.Values{}
 	queryParams.Set("dir", "b")
-	res := alice.DoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "messages"}, client.WithQueries(queryParams))
+	res := alice.DoFunc(t, "GET", []string{"_matrix", "client", "v3", "rooms", roomID, "messages"}, client.WithQueries(queryParams))
 	must.MatchResponse(t, res, match.HTTPResponse{
 		StatusCode: http.StatusForbidden,
 	})
@@ -89,13 +89,13 @@ func TestSendMessageWithTxn(t *testing.T) {
 
 	const txnID = "lorem"
 
-	res := alice.MustDoFunc(t, "PUT", []string{"_matrix", "client", "r0", "rooms", roomID, "send", "m.room.message", txnID}, client.WithJSONBody(t, map[string]interface{}{
+	res := alice.MustDoFunc(t, "PUT", []string{"_matrix", "client", "v3", "rooms", roomID, "send", "m.room.message", txnID}, client.WithJSONBody(t, map[string]interface{}{
 		"msgtype": "m.text",
 		"body":    "test",
 	}))
 	eventID := client.GetJSONFieldStr(t, client.ParseJSON(t, res), "event_id")
 
-	res = alice.MustDoFunc(t, "PUT", []string{"_matrix", "client", "r0", "rooms", roomID, "send", "m.room.message", txnID}, client.WithJSONBody(t, map[string]interface{}{
+	res = alice.MustDoFunc(t, "PUT", []string{"_matrix", "client", "v3", "rooms", roomID, "send", "m.room.message", txnID}, client.WithJSONBody(t, map[string]interface{}{
 		"msgtype": "m.text",
 		"body":    "test",
 	}))
@@ -166,7 +166,7 @@ func TestRoomMessagesLazyLoading(t *testing.T) {
 	queryParams.Set("filter", `{ "lazy_load_members" : true }`)
 	queryParams.Set("from", beforeToken)
 	queryParams.Set("to", afterToken)
-	res := alice.DoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "messages"}, client.WithQueries(queryParams))
+	res := alice.DoFunc(t, "GET", []string{"_matrix", "client", "v3", "rooms", roomID, "messages"}, client.WithQueries(queryParams))
 	must.MatchResponse(t, res, match.HTTPResponse{
 		StatusCode: http.StatusOK,
 		JSON: []match.JSON{
@@ -217,7 +217,7 @@ func TestRoomMessagesLazyLoadingLocalUser(t *testing.T) {
 	queryParams.Set("dir", "b")
 	queryParams.Set("filter", `{ "lazy_load_members" : true }`)
 	queryParams.Set("from", token)
-	res := alice.DoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "messages"}, client.WithQueries(queryParams))
+	res := alice.DoFunc(t, "GET", []string{"_matrix", "client", "v3", "rooms", roomID, "messages"}, client.WithQueries(queryParams))
 	must.MatchResponse(t, res, match.HTTPResponse{
 		StatusCode: http.StatusOK,
 		JSON: []match.JSON{

--- a/tests/csapi/room_typing_test.go
+++ b/tests/csapi/room_typing_test.go
@@ -24,7 +24,7 @@ func TestTyping(t *testing.T) {
 
 	token := bob.MustSyncUntil(t, client.SyncReq{}, client.SyncJoinedTo(bob.UserID, roomID))
 
-	alice.MustDoFunc(t, "PUT", []string{"_matrix", "client", "r0", "rooms", roomID, "typing", alice.UserID}, client.WithJSONBody(t, map[string]interface{}{
+	alice.MustDoFunc(t, "PUT", []string{"_matrix", "client", "v3", "rooms", roomID, "typing", alice.UserID}, client.WithJSONBody(t, map[string]interface{}{
 		"typing":  true,
 		"timeout": 10000,
 	}))

--- a/tests/csapi/rooms_invite_test.go
+++ b/tests/csapi/rooms_invite_test.go
@@ -88,7 +88,7 @@ func TestRoomsInvite(t *testing.T) {
 			body := client.WithJSONBody(t, map[string]interface{}{
 				"user_id": alice.UserID,
 			})
-			res := alice.DoFunc(t, "POST", []string{"_matrix", "client", "r0", "rooms", roomID, "invite"}, body)
+			res := alice.DoFunc(t, "POST", []string{"_matrix", "client", "v3", "rooms", roomID, "invite"}, body)
 			must.MatchResponse(t, res, match.HTTPResponse{
 				StatusCode: http.StatusForbidden,
 			})
@@ -109,7 +109,7 @@ func TestRoomsInvite(t *testing.T) {
 			body := client.WithJSONBody(t, map[string]interface{}{
 				"user_id": bob.UserID,
 			})
-			res := alice.DoFunc(t, "POST", []string{"_matrix", "client", "r0", "rooms", roomID, "invite"}, body)
+			res := alice.DoFunc(t, "POST", []string{"_matrix", "client", "v3", "rooms", roomID, "invite"}, body)
 			must.MatchResponse(t, res, match.HTTPResponse{
 				StatusCode: http.StatusForbidden,
 			})

--- a/tests/csapi/sync_filter_test.go
+++ b/tests/csapi/sync_filter_test.go
@@ -44,7 +44,7 @@ func TestSyncFilter(t *testing.T) {
 			t.Fatalf("failed to marshal JSON request body: %s", err)
 		}
 		filterID := createFilter(t, authedClient, reqBody, "@alice:hs1")
-		res := authedClient.MustDo(t, "GET", []string{"_matrix", "client", "r0", "user", "@alice:hs1", "filter", filterID}, nil)
+		res := authedClient.MustDo(t, "GET", []string{"_matrix", "client", "v3", "user", "@alice:hs1", "filter", filterID}, nil)
 		must.MatchResponse(t, res, match.HTTPResponse{
 			JSON: []match.JSON{
 				match.JSONKeyPresent("room"),
@@ -57,7 +57,7 @@ func TestSyncFilter(t *testing.T) {
 
 func createFilter(t *testing.T, authedClient *client.CSAPI, reqBody []byte, userID string) string {
 	t.Helper()
-	res := authedClient.MustDo(t, "POST", []string{"_matrix", "client", "r0", "user", userID, "filter"}, json.RawMessage(reqBody))
+	res := authedClient.MustDo(t, "POST", []string{"_matrix", "client", "v3", "user", userID, "filter"}, json.RawMessage(reqBody))
 	if res.StatusCode != 200 {
 		t.Fatalf("MatchResponse got status %d want 200", res.StatusCode)
 	}

--- a/tests/csapi/user_directory_display_names_test.go
+++ b/tests/csapi/user_directory_display_names_test.go
@@ -53,7 +53,7 @@ func setupUsers(t *testing.T) (*client.CSAPI, *client.CSAPI, *client.CSAPI, func
 	alice.MustDoFunc(
 		t,
 		"PUT",
-		[]string{"_matrix", "client", "r0", "profile", alice.UserID, "displayname"},
+		[]string{"_matrix", "client", "v3", "profile", alice.UserID, "displayname"},
 		client.WithJSONBody(t, map[string]interface{}{
 			"displayname": alicePublicName,
 		}),
@@ -69,7 +69,7 @@ func checkExpectations(t *testing.T, bob, eve *client.CSAPI) {
 		res := eve.MustDoFunc(
 			t,
 			"POST",
-			[]string{"_matrix", "client", "r0", "user_directory", "search"},
+			[]string{"_matrix", "client", "v3", "user_directory", "search"},
 			client.WithJSONBody(t, map[string]interface{}{
 				"search_term": alicePublicName,
 			}),
@@ -81,7 +81,7 @@ func checkExpectations(t *testing.T, bob, eve *client.CSAPI) {
 		res := eve.MustDoFunc(
 			t,
 			"POST",
-			[]string{"_matrix", "client", "r0", "user_directory", "search"},
+			[]string{"_matrix", "client", "v3", "user_directory", "search"},
 			client.WithJSONBody(t, map[string]interface{}{
 				"search_term": aliceUserID,
 			}),
@@ -93,7 +93,7 @@ func checkExpectations(t *testing.T, bob, eve *client.CSAPI) {
 		res := eve.MustDoFunc(
 			t,
 			"POST",
-			[]string{"_matrix", "client", "r0", "user_directory", "search"},
+			[]string{"_matrix", "client", "v3", "user_directory", "search"},
 			client.WithJSONBody(t, map[string]interface{}{
 				"search_term": alicePrivateName,
 			}),
@@ -105,7 +105,7 @@ func checkExpectations(t *testing.T, bob, eve *client.CSAPI) {
 		res := bob.MustDoFunc(
 			t,
 			"POST",
-			[]string{"_matrix", "client", "r0", "user_directory", "search"},
+			[]string{"_matrix", "client", "v3", "user_directory", "search"},
 			client.WithJSONBody(t, map[string]interface{}{
 				"search_term": alicePublicName,
 			}),
@@ -119,7 +119,7 @@ func checkExpectations(t *testing.T, bob, eve *client.CSAPI) {
 		res := bob.MustDoFunc(
 			t,
 			"POST",
-			[]string{"_matrix", "client", "r0", "user_directory", "search"},
+			[]string{"_matrix", "client", "v3", "user_directory", "search"},
 			client.WithJSONBody(t, map[string]interface{}{
 				"search_term": aliceUserID,
 			}),
@@ -148,7 +148,7 @@ func TestRoomSpecificUsernameChange(t *testing.T) {
 	alice.MustDoFunc(
 		t,
 		"PUT",
-		[]string{"_matrix", "client", "r0", "rooms", privateRoom, "state", "m.room.member", alice.UserID},
+		[]string{"_matrix", "client", "v3", "rooms", privateRoom, "state", "m.room.member", alice.UserID},
 		client.WithJSONBody(t, map[string]interface{}{
 			"displayname": alicePrivateName,
 			"membership":  "join",
@@ -177,7 +177,7 @@ func TestRoomSpecificUsernameAtJoin(t *testing.T) {
 	alice.MustDoFunc(
 		t,
 		"PUT",
-		[]string{"_matrix", "client", "r0", "rooms", privateRoom, "state", "m.room.member", alice.UserID},
+		[]string{"_matrix", "client", "v3", "rooms", privateRoom, "state", "m.room.member", alice.UserID},
 		client.WithJSONBody(t, map[string]interface{}{
 			"displayname": alicePrivateName,
 			"membership":  "join",

--- a/tests/csapi/user_query_keys_test.go
+++ b/tests/csapi/user_query_keys_test.go
@@ -20,7 +20,7 @@ func TestKeysQueryWithDeviceIDAsObjectFails(t *testing.T) {
 
 	userID := "@alice:hs1"
 	alice := deployment.Client(t, "hs1", userID)
-	res := alice.DoFunc(t, "POST", []string{"_matrix", "client", "r0", "keys", "query"},
+	res := alice.DoFunc(t, "POST", []string{"_matrix", "client", "v3", "keys", "query"},
 		client.WithJSONBody(t, map[string]interface{}{
 			"device_keys": map[string]interface{}{
 				"@bob:hs1": map[string]bool{

--- a/tests/federation_query_profile_test.go
+++ b/tests/federation_query_profile_test.go
@@ -55,7 +55,7 @@ func TestOutboundFederationProfile(t *testing.T) {
 
 		// query the display name which should do an outbound federation hit
 		unauthedClient := deployment.Client(t, "hs1", "")
-		res := unauthedClient.MustDo(t, "GET", []string{"_matrix", "client", "r0", "profile", remoteUserID, "displayname"}, nil)
+		res := unauthedClient.MustDo(t, "GET", []string{"_matrix", "client", "v3", "profile", remoteUserID, "displayname"}, nil)
 		must.MatchResponse(t, res, match.HTTPResponse{
 			JSON: []match.JSON{
 				match.JSONKeyEqual("displayname", remoteDisplayName),

--- a/tests/federation_room_ban_test.go
+++ b/tests/federation_room_ban_test.go
@@ -25,13 +25,13 @@ func TestUnbanViaInvite(t *testing.T) {
 	alice.JoinRoom(t, roomID, []string{"hs2"})
 
 	// Ban Alice
-	bob.MustDoFunc(t, "POST", []string{"_matrix", "client", "r0", "rooms", roomID, "ban"}, client.WithJSONBody(t, map[string]interface{}{
+	bob.MustDoFunc(t, "POST", []string{"_matrix", "client", "v3", "rooms", roomID, "ban"}, client.WithJSONBody(t, map[string]interface{}{
 		"user_id": alice.UserID,
 	}))
 	alice.MustSyncUntil(t, client.SyncReq{}, client.SyncLeftFrom(alice.UserID, roomID))
 
 	// Unban Alice
-	bob.MustDoFunc(t, "POST", []string{"_matrix", "client", "r0", "rooms", roomID, "unban"}, client.WithJSONBody(t, map[string]interface{}{
+	bob.MustDoFunc(t, "POST", []string{"_matrix", "client", "v3", "rooms", roomID, "unban"}, client.WithJSONBody(t, map[string]interface{}{
 		"user_id": alice.UserID,
 	}))
 	bob.MustSyncUntil(t, client.SyncReq{}, client.SyncLeftFrom(alice.UserID, roomID))

--- a/tests/federation_room_event_auth_test.go
+++ b/tests/federation_room_event_auth_test.go
@@ -219,7 +219,7 @@ func TestInboundFederationRejectsEventsWithRejectedAuthEvents(t *testing.T) {
 
 	// now inspect the results. Each of the rejected events should give a 404 for /event
 	t.Run("Outlier should be rejected", func(t *testing.T) {
-		res := alice.DoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", room.RoomID, "event", outlierEvent.EventID()})
+		res := alice.DoFunc(t, "GET", []string{"_matrix", "client", "v3", "rooms", room.RoomID, "event", outlierEvent.EventID()})
 		defer res.Body.Close()
 		if res.StatusCode != 404 {
 			t.Errorf("Expected a 404 when fetching outlier event, but got %d", res.StatusCode)
@@ -227,7 +227,7 @@ func TestInboundFederationRejectsEventsWithRejectedAuthEvents(t *testing.T) {
 	})
 
 	t.Run("sent event 1 should be rejected", func(t *testing.T) {
-		res := alice.DoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", room.RoomID, "event", sentEvent1.EventID()})
+		res := alice.DoFunc(t, "GET", []string{"_matrix", "client", "v3", "rooms", room.RoomID, "event", sentEvent1.EventID()})
 		defer res.Body.Close()
 		if res.StatusCode != 404 {
 			t.Errorf("Expected a 404 when fetching sent event 1, but got %d", res.StatusCode)
@@ -235,7 +235,7 @@ func TestInboundFederationRejectsEventsWithRejectedAuthEvents(t *testing.T) {
 	})
 
 	t.Run("sent event 2 should be rejected", func(t *testing.T) {
-		res := alice.DoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", room.RoomID, "event", sentEvent2.EventID()})
+		res := alice.DoFunc(t, "GET", []string{"_matrix", "client", "v3", "rooms", room.RoomID, "event", sentEvent2.EventID()})
 		defer res.Body.Close()
 		if res.StatusCode != 404 {
 			t.Errorf("Expected a 404 when fetching sent event 2, but got %d", res.StatusCode)

--- a/tests/federation_room_join_partial_state_test.go
+++ b/tests/federation_room_join_partial_state_test.go
@@ -118,7 +118,7 @@ func TestPartialStateJoin(t *testing.T) {
 		defer psjResult.Destroy()
 
 		alice.Client.Timeout = 2 * time.Second
-		paths := []string{"_matrix", "client", "r0", "rooms", psjResult.ServerRoom.RoomID, "send", "m.room.message", "0"}
+		paths := []string{"_matrix", "client", "v3", "rooms", psjResult.ServerRoom.RoomID, "send", "m.room.message", "0"}
 		res := alice.MustDoFunc(t, "PUT", paths, client.WithJSONBody(t, map[string]interface{}{
 			"msgtype": "m.text",
 			"body":    "Hello world!",
@@ -156,7 +156,7 @@ func TestPartialStateJoin(t *testing.T) {
 			clientMembersRequestResponseChan <- alice.MustDoFunc(
 				t,
 				"GET",
-				[]string{"_matrix", "client", "r0", "rooms", psjResult.ServerRoom.RoomID, "members"},
+				[]string{"_matrix", "client", "v3", "rooms", psjResult.ServerRoom.RoomID, "members"},
 				client.WithQueries(queryParams),
 			)
 		}()

--- a/tests/federation_room_join_test.go
+++ b/tests/federation_room_join_test.go
@@ -80,7 +80,7 @@ func TestJoinViaRoomIDAndServerName(t *testing.T) {
 
 	queryParams := url.Values{}
 	queryParams.Set("server_name", "hs1")
-	res := bob.DoFunc(t, "POST", []string{"_matrix", "client", "r0", "join", serverRoom.RoomID}, client.WithQueries(queryParams))
+	res := bob.DoFunc(t, "POST", []string{"_matrix", "client", "v3", "join", serverRoom.RoomID}, client.WithQueries(queryParams))
 	must.MatchResponse(t, res, match.HTTPResponse{
 		StatusCode: 200,
 		JSON: []match.JSON{
@@ -317,7 +317,7 @@ func TestBannedUserCannotSendJoin(t *testing.T) {
 	res := alice.MustDoFunc(
 		t,
 		"GET",
-		[]string{"_matrix", "client", "r0", "rooms", roomID, "state", "m.room.member", charlie},
+		[]string{"_matrix", "client", "v3", "rooms", roomID, "state", "m.room.member", charlie},
 	)
 	stateResp := client.ParseJSON(t, res)
 	membership := must.GetJSONFieldStr(t, stateResp, "membership")

--- a/tests/knocking_test.go
+++ b/tests/knocking_test.go
@@ -123,7 +123,7 @@ func knockingBetweenTwoUsersTest(t *testing.T, roomID string, inRoomUser, knocki
 		res := knockingUser.DoFunc(
 			t,
 			"POST",
-			[]string{"_matrix", "client", "r0", "join", roomID},
+			[]string{"_matrix", "client", "v3", "join", roomID},
 			client.WithQueries(query),
 			client.WithRawBody([]byte(`{}`)),
 		)
@@ -175,7 +175,7 @@ func knockingBetweenTwoUsersTest(t *testing.T, roomID string, inRoomUser, knocki
 			knockingUser.MustDo(
 				t,
 				"POST",
-				[]string{"_matrix", "client", "r0", "rooms", roomID, "leave"},
+				[]string{"_matrix", "client", "v3", "rooms", roomID, "leave"},
 				struct {
 					Reason string `json:"reason"`
 				}{
@@ -214,7 +214,7 @@ func knockingBetweenTwoUsersTest(t *testing.T, roomID string, inRoomUser, knocki
 		inRoomUser.MustDo(
 			t,
 			"POST",
-			[]string{"_matrix", "client", "r0", "rooms", roomID, "kick"},
+			[]string{"_matrix", "client", "v3", "rooms", roomID, "kick"},
 			struct {
 				UserID string `json:"user_id"`
 				Reason string `json:"reason"`
@@ -240,7 +240,7 @@ func knockingBetweenTwoUsersTest(t *testing.T, roomID string, inRoomUser, knocki
 		inRoomUser.MustDo(
 			t,
 			"POST",
-			[]string{"_matrix", "client", "r0", "rooms", roomID, "kick"},
+			[]string{"_matrix", "client", "v3", "rooms", roomID, "kick"},
 			struct {
 				UserID string `json:"user_id"`
 				Reason string `json:"reason"`
@@ -258,7 +258,7 @@ func knockingBetweenTwoUsersTest(t *testing.T, roomID string, inRoomUser, knocki
 		inRoomUser.MustDo(
 			t,
 			"POST",
-			[]string{"_matrix", "client", "r0", "rooms", roomID, "invite"},
+			[]string{"_matrix", "client", "v3", "rooms", roomID, "invite"},
 			struct {
 				UserID string `json:"user_id"`
 				Reason string `json:"reason"`
@@ -290,7 +290,7 @@ func knockingBetweenTwoUsersTest(t *testing.T, roomID string, inRoomUser, knocki
 		inRoomUser.MustDo(
 			t,
 			"POST",
-			[]string{"_matrix", "client", "r0", "rooms", roomID, "ban"},
+			[]string{"_matrix", "client", "v3", "rooms", roomID, "ban"},
 			struct {
 				UserID string `json:"user_id"`
 				Reason string `json:"reason"`
@@ -357,7 +357,7 @@ func knockOnRoomWithStatus(t *testing.T, c *client.CSAPI, roomID, reason string,
 	res := c.DoFunc(
 		t,
 		"POST",
-		[]string{"_matrix", "client", "r0", "knock", roomID},
+		[]string{"_matrix", "client", "v3", "knock", roomID},
 		client.WithQueries(query),
 		client.WithRawBody(b),
 	)
@@ -424,7 +424,7 @@ func publishAndCheckRoomJoinRule(t *testing.T, c *client.CSAPI, roomID, expected
 	c.MustDo(
 		t,
 		"PUT",
-		[]string{"_matrix", "client", "r0", "directory", "list", "room", roomID},
+		[]string{"_matrix", "client", "v3", "directory", "list", "room", roomID},
 		struct {
 			Visibility string `json:"visibility"`
 		}{
@@ -436,7 +436,7 @@ func publishAndCheckRoomJoinRule(t *testing.T, c *client.CSAPI, roomID, expected
 	res := c.MustDo(
 		t,
 		"GET",
-		[]string{"_matrix", "client", "r0", "publicRooms"},
+		[]string{"_matrix", "client", "v3", "publicRooms"},
 		nil,
 	)
 

--- a/tests/media_filename_test.go
+++ b/tests/media_filename_test.go
@@ -127,9 +127,9 @@ func downloadForFilename(t *testing.T, c *client.CSAPI, mxcUri string, diffName 
 	var path []string
 
 	if diffName != "" {
-		path = []string{"_matrix", "media", "r0", "download", origin, mediaId, diffName}
+		path = []string{"_matrix", "media", "v3", "download", origin, mediaId, diffName}
 	} else {
-		path = []string{"_matrix", "media", "r0", "download", origin, mediaId}
+		path = []string{"_matrix", "media", "v3", "download", origin, mediaId}
 	}
 
 	res := c.MustDoFunc(t, "GET", path)

--- a/tests/media_thumbnail_test.go
+++ b/tests/media_thumbnail_test.go
@@ -52,7 +52,7 @@ func fetchAndValidateThumbnail(t *testing.T, c *client.CSAPI, mxcUri string) {
 
 	origin, mediaId := client.SplitMxc(mxcUri)
 
-	res := c.MustDoFunc(t, "GET", []string{"_matrix", "media", "r0", "thumbnail", origin, mediaId}, client.WithQueries(url.Values{
+	res := c.MustDoFunc(t, "GET", []string{"_matrix", "media", "v3", "thumbnail", origin, mediaId}, client.WithQueries(url.Values{
 		"width":  []string{"32"},
 		"height": []string{"32"},
 		"method": []string{"scale"},

--- a/tests/msc2716_test.go
+++ b/tests/msc2716_test.go
@@ -172,7 +172,7 @@ func TestImportHistoricalMessages(t *testing.T) {
 				t.Fatalf("Expected eventID list should be length 15 but saw %d: %s", len(expectedEventIDOrder), expectedEventIDOrder)
 			}
 
-			messagesRes := alice.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "messages"}, client.WithContentType("application/json"), client.WithQueries(url.Values{
+			messagesRes := alice.MustDoFunc(t, "GET", []string{"_matrix", "client", "v3", "rooms", roomID, "messages"}, client.WithContentType("application/json"), client.WithQueries(url.Values{
 				"dir":   []string{"b"},
 				"limit": []string{"100"},
 			}))
@@ -408,7 +408,7 @@ func TestImportHistoricalMessages(t *testing.T) {
 			})
 
 			txnId := getTxnID("duplicateinsertion-txn")
-			res := alice.DoFunc(t, "PUT", []string{"_matrix", "client", "r0", "rooms", roomID, "send", insertionEventType, txnId}, client.WithJSONBody(t, map[string]interface{}{
+			res := alice.DoFunc(t, "PUT", []string{"_matrix", "client", "v3", "rooms", roomID, "send", insertionEventType, txnId}, client.WithJSONBody(t, map[string]interface{}{
 				nextBatchIDContentField: "same",
 				historicalContentField:  true,
 			}))
@@ -637,7 +637,7 @@ func TestImportHistoricalMessages(t *testing.T) {
 				// order isn't quite perfect when a remote federated homeserver gets
 				// backfilled.
 				// validateBatchSendRes(t, remoteCharlie, roomID, batchSendRes, false)
-				messagesRes := remoteCharlie.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "messages"}, client.WithContentType("application/json"), client.WithQueries(url.Values{
+				messagesRes := remoteCharlie.MustDoFunc(t, "GET", []string{"_matrix", "client", "v3", "rooms", roomID, "messages"}, client.WithContentType("application/json"), client.WithQueries(url.Values{
 					"dir":   []string{"b"},
 					"limit": []string{"100"},
 				}))
@@ -672,7 +672,7 @@ func TestImportHistoricalMessages(t *testing.T) {
 				}
 				// We can't use as.SendEventSynced(...) because application services can't use the /sync API
 				txnId := getTxnID("sendInsertionAndEnsureBackfilled-txn")
-				insertionSendRes := as.MustDoFunc(t, "PUT", []string{"_matrix", "client", "r0", "rooms", roomID, "send", insertionEvent.Type, txnId}, client.WithJSONBody(t, insertionEvent.Content))
+				insertionSendRes := as.MustDoFunc(t, "PUT", []string{"_matrix", "client", "v3", "rooms", roomID, "send", insertionEvent.Type, txnId}, client.WithJSONBody(t, insertionEvent.Content))
 				insertionSendBody := client.ParseJSON(t, insertionSendRes)
 				insertionEventID := client.GetJSONFieldStr(t, insertionSendBody, "event_id")
 				// Make sure the insertion event has reached the homeserver
@@ -718,7 +718,7 @@ func TestImportHistoricalMessages(t *testing.T) {
 				// order isn't quite perfect when a remote federated homeserver gets
 				// backfilled.
 				// validateBatchSendRes(t, remoteCharlie, roomID, batchSendRes, false)
-				messagesRes := remoteCharlie.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "messages"}, client.WithContentType("application/json"), client.WithQueries(url.Values{
+				messagesRes := remoteCharlie.MustDoFunc(t, "GET", []string{"_matrix", "client", "v3", "rooms", roomID, "messages"}, client.WithContentType("application/json"), client.WithQueries(url.Values{
 					"dir":   []string{"b"},
 					"limit": []string{"100"},
 				}))
@@ -748,7 +748,7 @@ func TestImportHistoricalMessages(t *testing.T) {
 				createMessagesInRoom(t, alice, roomID, 10, "eventIDsAfter")
 
 				// Mimic scrollback just through the latest messages
-				remoteCharlie.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "messages"}, client.WithContentType("application/json"), client.WithQueries(url.Values{
+				remoteCharlie.MustDoFunc(t, "GET", []string{"_matrix", "client", "v3", "rooms", roomID, "messages"}, client.WithContentType("application/json"), client.WithQueries(url.Values{
 					"dir": []string{"b"},
 					// Limited so we can only see a portion of the latest messages
 					"limit": []string{"5"},
@@ -774,7 +774,7 @@ func TestImportHistoricalMessages(t *testing.T) {
 					t.Fatalf("Expected %d event_ids in the response that correspond to the %d events we sent in the request but saw %d: %s", numMessagesSent, numMessagesSent, len(historicalEventIDs), historicalEventIDs)
 				}
 
-				beforeMarkerMessagesRes := remoteCharlie.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "messages"}, client.WithContentType("application/json"), client.WithQueries(url.Values{
+				beforeMarkerMessagesRes := remoteCharlie.MustDoFunc(t, "GET", []string{"_matrix", "client", "v3", "rooms", roomID, "messages"}, client.WithContentType("application/json"), client.WithQueries(url.Values{
 					"dir":   []string{"b"},
 					"limit": []string{"100"},
 				}))
@@ -811,7 +811,7 @@ func TestImportHistoricalMessages(t *testing.T) {
 				// order isn't quite perfect when a remote federated homeserver gets
 				// backfilled.
 				// validateBatchSendRes(t, remoteCharlie, roomID, batchSendRes, false)
-				remoteMessagesRes := remoteCharlie.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "messages"}, client.WithContentType("application/json"), client.WithQueries(url.Values{
+				remoteMessagesRes := remoteCharlie.MustDoFunc(t, "GET", []string{"_matrix", "client", "v3", "rooms", roomID, "messages"}, client.WithContentType("application/json"), client.WithQueries(url.Values{
 					"dir":   []string{"b"},
 					"limit": []string{"100"},
 				}))
@@ -843,7 +843,7 @@ func TestImportHistoricalMessages(t *testing.T) {
 
 				// Mimic scrollback to all of the messages
 				// scrollbackMessagesRes
-				remoteCharlie.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "messages"}, client.WithContentType("application/json"), client.WithQueries(url.Values{
+				remoteCharlie.MustDoFunc(t, "GET", []string{"_matrix", "client", "v3", "rooms", roomID, "messages"}, client.WithContentType("application/json"), client.WithQueries(url.Values{
 					"dir":   []string{"b"},
 					"limit": []string{"100"},
 				}))
@@ -869,7 +869,7 @@ func TestImportHistoricalMessages(t *testing.T) {
 					t.Fatalf("Expected %d event_ids in the response that correspond to the %d events we sent in the request but saw %d: %s", numMessagesSent, numMessagesSent, len(historicalEventIDs), historicalEventIDs)
 				}
 
-				beforeMarkerMessagesRes := remoteCharlie.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "messages"}, client.WithContentType("application/json"), client.WithQueries(url.Values{
+				beforeMarkerMessagesRes := remoteCharlie.MustDoFunc(t, "GET", []string{"_matrix", "client", "v3", "rooms", roomID, "messages"}, client.WithContentType("application/json"), client.WithQueries(url.Values{
 					"dir":   []string{"b"},
 					"limit": []string{"100"},
 				}))
@@ -904,7 +904,7 @@ func TestImportHistoricalMessages(t *testing.T) {
 				// order isn't quite perfect when a remote federated homeserver gets
 				// backfilled.
 				// validateBatchSendRes(t, remoteCharlie, roomID, batchSendRes, false)
-				remoteMessagesRes := remoteCharlie.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "messages"}, client.WithContentType("application/json"), client.WithQueries(url.Values{
+				remoteMessagesRes := remoteCharlie.MustDoFunc(t, "GET", []string{"_matrix", "client", "v3", "rooms", roomID, "messages"}, client.WithContentType("application/json"), client.WithQueries(url.Values{
 					"dir":   []string{"b"},
 					"limit": []string{"100"},
 				}))
@@ -991,7 +991,7 @@ func TestImportHistoricalMessages(t *testing.T) {
 
 				// From the remote user, make a /context request for eventIDAfter to get
 				// pagination token before the marker event
-				contextRes := remoteCharlie.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "context", eventIDAfter}, client.WithContentType("application/json"), client.WithQueries(url.Values{
+				contextRes := remoteCharlie.MustDoFunc(t, "GET", []string{"_matrix", "client", "v3", "rooms", roomID, "context", eventIDAfter}, client.WithContentType("application/json"), client.WithQueries(url.Values{
 					"limit": []string{"0"},
 				}))
 				contextResResBody := client.ParseJSON(t, contextRes)
@@ -1173,7 +1173,7 @@ func fetchUntilMessagesResponseHas(t *testing.T, c *client.CSAPI, roomID string,
 			t.Fatalf("fetchUntilMessagesResponseHas timed out. Called check function %d times", checkCounter)
 		}
 
-		messagesRes := c.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "messages"}, client.WithContentType("application/json"), client.WithQueries(url.Values{
+		messagesRes := c.MustDoFunc(t, "GET", []string{"_matrix", "client", "v3", "rooms", roomID, "messages"}, client.WithContentType("application/json"), client.WithQueries(url.Values{
 			"dir":   []string{"b"},
 			"limit": []string{"100"},
 		}))
@@ -1247,7 +1247,7 @@ func paginateUntilMessageCheckOff(t *testing.T, c *client.CSAPI, roomID string, 
 			)
 		}
 
-		messagesRes := c.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "messages"}, client.WithContentType("application/json"), client.WithQueries(url.Values{
+		messagesRes := c.MustDoFunc(t, "GET", []string{"_matrix", "client", "v3", "rooms", roomID, "messages"}, client.WithContentType("application/json"), client.WithQueries(url.Values{
 			"dir":   []string{"b"},
 			"limit": []string{"100"},
 			"from":  []string{messageResEnd},
@@ -1343,7 +1343,7 @@ func ensureVirtualUserRegistered(t *testing.T, c *client.CSAPI, virtualUserLocal
 	res := c.DoFunc(
 		t,
 		"POST",
-		[]string{"_matrix", "client", "r0", "register"},
+		[]string{"_matrix", "client", "v3", "register"},
 		client.WithJSONBody(t, map[string]interface{}{"type": "m.login.application_service", "username": virtualUserLocalpart}),
 		client.WithContentType("application/json"),
 	)
@@ -1377,7 +1377,7 @@ func sendMarkerAndEnsureBackfilled(t *testing.T, as *client.CSAPI, c *client.CSA
 	// Marker events should have unique state_key so they all show up in the current state to process.
 	unique_state_key := getTxnID("marker_state_key")
 	// We can't use as.SendEventSynced(...) because application services can't use the /sync API.
-	markerSendRes := as.MustDoFunc(t, "PUT", []string{"_matrix", "client", "r0", "rooms", roomID, "state", markerEvent.Type, unique_state_key}, client.WithJSONBody(t, markerEvent.Content))
+	markerSendRes := as.MustDoFunc(t, "PUT", []string{"_matrix", "client", "v3", "rooms", roomID, "state", markerEvent.Type, unique_state_key}, client.WithJSONBody(t, markerEvent.Content))
 	markerSendBody := client.ParseJSON(t, markerSendRes)
 	markerEventID = client.GetJSONFieldStr(t, markerSendBody, "event_id")
 
@@ -1505,7 +1505,7 @@ func redactEventID(t *testing.T, c *client.CSAPI, roomID, eventID string, expect
 	redactionRes := c.DoFunc(
 		t,
 		"PUT",
-		[]string{"_matrix", "client", "r0", "rooms", roomID, "redact", eventID, txnID},
+		[]string{"_matrix", "client", "v3", "rooms", roomID, "redact", eventID, txnID},
 		client.WithJSONBody(t, map[string]interface{}{"reason": "chaos"}),
 		client.WithContentType("application/json"),
 	)
@@ -1591,7 +1591,7 @@ func validateBatchSendRes(t *testing.T, c *client.CSAPI, roomID string, batchSen
 
 	// Make sure the historical events appear in scrollback without jumping back
 	// in time specifically.
-	fullMessagesRes := c.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "messages"}, client.WithContentType("application/json"), client.WithQueries(url.Values{
+	fullMessagesRes := c.MustDoFunc(t, "GET", []string{"_matrix", "client", "v3", "rooms", roomID, "messages"}, client.WithContentType("application/json"), client.WithQueries(url.Values{
 		"dir":   []string{"b"},
 		"limit": []string{"100"},
 	}))
@@ -1607,7 +1607,7 @@ func validateBatchSendRes(t *testing.T, c *client.CSAPI, roomID string, batchSen
 	// Validate state after we paginate `/messages` to avoid any potential 404 if
 	// the server hasn't backfilled here yet
 	if validateState {
-		contextRes := c.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "context", expectedEventIDOrder[0]}, client.WithContentType("application/json"), client.WithQueries(url.Values{
+		contextRes := c.MustDoFunc(t, "GET", []string{"_matrix", "client", "v3", "rooms", roomID, "context", expectedEventIDOrder[0]}, client.WithContentType("application/json"), client.WithQueries(url.Values{
 			"limit": []string{"0"},
 		}))
 

--- a/tests/msc3030_test.go
+++ b/tests/msc3030_test.go
@@ -147,7 +147,7 @@ func TestJumpToDateEndpoint(t *testing.T) {
 				importTimestamp := makeTimestampFromTime(importTime)
 				timestampString := strconv.FormatInt(importTimestamp, 10)
 				// We can't use as.SendEventSynced(...) because application services can't use the /sync API
-				sendRes := as.DoFunc(t, "PUT", []string{"_matrix", "client", "r0", "rooms", roomID, "send", "m.room.message", getTxnID("findEventBeforeCreation-txn")}, client.WithContentType("application/json"), client.WithJSONBody(t, map[string]interface{}{
+				sendRes := as.DoFunc(t, "PUT", []string{"_matrix", "client", "v3", "rooms", roomID, "send", "m.room.message", getTxnID("findEventBeforeCreation-txn")}, client.WithContentType("application/json"), client.WithJSONBody(t, map[string]interface{}{
 					"body":    "old imported event",
 					"msgtype": "m.text",
 				}), client.WithQueries(url.Values{
@@ -241,7 +241,7 @@ func mustCheckEventisReturnedForTime(t *testing.T, c *client.CSAPI, roomID strin
 func getDebugMessageListFromMessagesResponse(t *testing.T, c *client.CSAPI, roomID string, expectedEventId string, actualEventId string, givenTimestamp int64) string {
 	t.Helper()
 
-	messagesRes := c.MustDoFunc(t, "GET", []string{"_matrix", "client", "r0", "rooms", roomID, "messages"}, client.WithContentType("application/json"), client.WithQueries(url.Values{
+	messagesRes := c.MustDoFunc(t, "GET", []string{"_matrix", "client", "v3", "rooms", roomID, "messages"}, client.WithContentType("application/json"), client.WithQueries(url.Values{
 		// The events returned will be from the newest -> oldest since we're going backwards
 		"dir":   []string{"b"},
 		"limit": []string{"100"},

--- a/tests/restricted_rooms_test.go
+++ b/tests/restricted_rooms_test.go
@@ -25,7 +25,7 @@ func failJoinRoom(t *testing.T, c *client.CSAPI, roomIDOrAlias string, serverNam
 	res := c.DoFunc(
 		t,
 		"POST",
-		[]string{"_matrix", "client", "r0", "join", roomIDOrAlias},
+		[]string{"_matrix", "client", "v3", "join", roomIDOrAlias},
 		client.WithQueries(query),
 	)
 	must.MatchFailure(t, res)
@@ -254,7 +254,7 @@ func doTestRestrictedRoomsRemoteJoinLocalUser(t *testing.T, roomVersion string, 
 	res := alice.DoFunc(
 		t,
 		"POST",
-		[]string{"_matrix", "client", "r0", "rooms", room, "invite"},
+		[]string{"_matrix", "client", "v3", "rooms", room, "invite"},
 		client.WithJSONBody(t, body),
 	)
 	must.MatchResponse(t, res, match.HTTPResponse{


### PR DESCRIPTION
We had quite a lot of tests still using `/r0` URLs.