### PR TITLE
Retry /publicRooms a few times to allow for propagation delay before a new room appears in the room directory

### DIFF
--- a/tests/csapi/apidoc_room_state_test.go
+++ b/tests/csapi/apidoc_room_state_test.go
@@ -3,6 +3,7 @@ package csapi_tests
 import (
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/tidwall/gjson"
 
@@ -10,6 +11,8 @@ import (
 	"github.com/matrix-org/complement/internal/client"
 	"github.com/matrix-org/complement/internal/match"
 	"github.com/matrix-org/complement/internal/must"
+
+	"net/http"
 )
 
 func TestRoomState(t *testing.T) {
@@ -104,26 +107,31 @@ func TestRoomState(t *testing.T) {
 				"preset":     "public_chat",
 			})
 
-			res := authedClient.MustDoFunc(t, "GET", []string{"_matrix", "client", "v3", "publicRooms"})
-			foundRoom := false
+			authedClient.MustDoFunc(t, "GET", []string{"_matrix", "client", "v3", "publicRooms"},
+				client.WithRetryUntil(time.Second, func(res *http.Response) bool {
+					foundRoom := false
 
-			must.MatchResponse(t, res, match.HTTPResponse{
-				JSON: []match.JSON{
-					match.JSONKeyPresent("chunk"),
-					match.JSONArrayEach("chunk", func(val gjson.Result) error {
-						gotRoomID := val.Get("room_id").Str
-						if gotRoomID == roomID {
-							foundRoom = true
-							return nil
-						}
-						return nil
-					}),
-				},
-			})
+					must.MatchResponse(t, res, match.HTTPResponse{
+						JSON: []match.JSON{
+							match.JSONKeyPresent("chunk"),
+							match.JSONArrayEach("chunk", func(val gjson.Result) error {
+								gotRoomID := val.Get("room_id").Str
+								if gotRoomID == roomID {
+									foundRoom = true
+									return nil
+								}
+								return nil
+							}),
+						},
+					})
 
-			if !foundRoom {
-				t.Errorf("failed to find room with id: %s", roomID)
-			}
+					if !foundRoom {
+						t.Logf("failed to find room with id: %s", roomID)
+					}
+
+					return foundRoom
+				}),
+			)
 		})
 		// sytest: GET /directory/room/:room_alias yields room ID
 		t.Run("GET /directory/room/:room_alias yields room ID", func(t *testing.T) {


### PR DESCRIPTION
This is needed in Synapse because the room directory is updated in the background. Part of https://github.com/matrix-org/synapse/issues/13161.
It's particularly worse when using workers, because the room directory is updated in a different process and CPU contention increases the likelihood of hitting the race.
