### PR TITLE
Add more tests for receiving events while resyncing for a partial join

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "go.testEnvVars": {
-        "COMPLEMENT_BASE_IMAGE": "complement-synapse"
-    }
-}

--- a/internal/federation/server.go
+++ b/internal/federation/server.go
@@ -213,7 +213,7 @@ func (s *Server) MustSendTransaction(t *testing.T, deployment *docker.Deployment
 // SendFederationRequest signs and sends an arbitrary federation request from this server.
 //
 // The requests will be routed according to the deployment map in `deployment`.
-func (s *Server) SendFederationRequest(deployment *docker.Deployment, req gomatrixserverlib.FederationRequest, resBody interface{}) error {
+func (s *Server) SendFederationRequest(ctx context.Context, deployment *docker.Deployment, req gomatrixserverlib.FederationRequest, resBody interface{}) error {
 	if err := req.Sign(gomatrixserverlib.ServerName(s.serverName), s.KeyID, s.Priv); err != nil {
 		return err
 	}
@@ -224,7 +224,7 @@ func (s *Server) SendFederationRequest(deployment *docker.Deployment, req gomatr
 	}
 
 	httpClient := gomatrixserverlib.NewClient(gomatrixserverlib.WithTransport(&docker.RoundTripper{Deployment: deployment}))
-	return httpClient.DoRequestAndParseResponse(context.Background(), httpReq, resBody)
+	return httpClient.DoRequestAndParseResponse(ctx, httpReq, resBody)
 }
 
 // MustCreateEvent will create and sign a new latest event for the given room.

--- a/tests/federation_room_join_partial_state_test.go
+++ b/tests/federation_room_join_partial_state_test.go
@@ -632,6 +632,8 @@ func testReceiveEventDuringPartialStateJoin(
 	select {
 	case <-time.After(1 * time.Second):
 		t.Logf("/state_ids request for event %s blocked as expected", event.EventID())
+		// read from the channel and discard the result, so that the goroutine above doesn't block
+		// indefinitely on the send
 		defer func() { <-stateIdsResultChan }()
 		break
 	case stateIDsResult := <-stateIdsResultChan:

--- a/tests/federation_room_join_partial_state_test.go
+++ b/tests/federation_room_join_partial_state_test.go
@@ -592,6 +592,8 @@ type partialStateJoinResult struct {
 	ServerRoom                       *federation.ServerRoom
 	fedStateIdsRequestReceivedWaiter *Waiter
 	fedStateIdsSendResponseWaiter    *Waiter
+	// the set of events for which we will not block `/state` or `/state_ids` requests.
+	fedStateIdsAllowedEvents map[string]bool
 }
 
 // beginPartialStateJoin spins up a room on a complement server,
@@ -627,6 +629,7 @@ func beginPartialStateJoin(t *testing.T, deployment *docker.Deployment, joiningU
 	// some things for orchestration
 	result.fedStateIdsRequestReceivedWaiter = NewWaiter()
 	result.fedStateIdsSendResponseWaiter = NewWaiter()
+	result.fedStateIdsAllowedEvents = make(map[string]bool)
 
 	// create the room on the complement server, with charlie and derek as members
 	roomVer := joiningUser.GetDefaultRoomVersion(t)
@@ -642,10 +645,17 @@ func beginPartialStateJoin(t *testing.T, deployment *docker.Deployment, joiningU
 
 	// register a handler for /state_ids requests, which finishes fedStateIdsRequestReceivedWaiter, then
 	// waits for fedStateIdsSendResponseWaiter and sends a reply
-	handleStateIdsRequests(t, result.Server, result.ServerRoom, result.fedStateIdsRequestReceivedWaiter, result.fedStateIdsSendResponseWaiter)
+	handleStateIdsRequests(
+		t,
+		result.Server,
+		result.ServerRoom,
+		result.fedStateIdsRequestReceivedWaiter,
+		result.fedStateIdsSendResponseWaiter,
+		result.fedStateIdsAllowedEvents,
+	)
 
 	// a handler for /state requests, which sends a sensible response
-	handleStateRequests(t, result.Server, result.ServerRoom, nil, nil)
+	handleStateRequests(t, result.Server, result.ServerRoom, nil, nil, nil)
 
 	// have joiningUser join the room by room ID.
 	joiningUser.JoinRoom(t, result.ServerRoom.RoomID, []string{result.Server.ServerName()})
@@ -693,6 +703,12 @@ func (psj *partialStateJoinResult) CreateMessageEvent(t *testing.T, senderLocalp
 	return event
 }
 
+// allow a /state_ids request for a given event to complete before FinishStateRequest has been called.
+// only applies to new incoming requests, and not any currently blocked ones.
+func (psj *partialStateJoinResult) AllowStateRequestForEvent(eventID string) {
+	psj.fedStateIdsAllowedEvents[eventID] = true
+}
+
 // wait for a /state_ids request for the test room to arrive
 func (psj *partialStateJoinResult) AwaitStateIdsRequest(t *testing.T) {
 	psj.fedStateIdsRequestReceivedWaiter.Waitf(t, 5*time.Second, "Waiting for /state_ids request")
@@ -709,7 +725,7 @@ func (psj *partialStateJoinResult) FinishStateRequest() {
 // if sendResponseWaiter is not nil, we will Wait() for it to finish before sending the response.
 func handleStateIdsRequests(
 	t *testing.T, srv *federation.Server, serverRoom *federation.ServerRoom,
-	requestReceivedWaiter *Waiter, sendResponseWaiter *Waiter,
+	requestReceivedWaiter *Waiter, sendResponseWaiter *Waiter, allowedEvents map[string]bool,
 ) {
 	srv.Mux().Handle(
 		fmt.Sprintf("/_matrix/federation/v1/state_ids/%s", serverRoom.RoomID),
@@ -719,7 +735,8 @@ func handleStateIdsRequests(
 			if requestReceivedWaiter != nil {
 				requestReceivedWaiter.Finish()
 			}
-			if sendResponseWaiter != nil {
+			if !allowedEvents[queryParams["event_id"][0]] &&
+				sendResponseWaiter != nil {
 				sendResponseWaiter.Waitf(t, 60*time.Second, "Waiting for /state_ids request")
 			}
 			t.Logf("Replying to /state_ids request")
@@ -744,7 +761,7 @@ func handleStateIdsRequests(
 // if sendResponseWaiter is not nil, we will Wait() for it to finish before sending the response.
 func handleStateRequests(
 	t *testing.T, srv *federation.Server, serverRoom *federation.ServerRoom,
-	requestReceivedWaiter *Waiter, sendResponseWaiter *Waiter,
+	requestReceivedWaiter *Waiter, sendResponseWaiter *Waiter, allowedEvents map[string]bool,
 ) {
 	srv.Mux().Handle(
 		fmt.Sprintf("/_matrix/federation/v1/state/%s", serverRoom.RoomID),
@@ -754,7 +771,8 @@ func handleStateRequests(
 			if requestReceivedWaiter != nil {
 				requestReceivedWaiter.Finish()
 			}
-			if sendResponseWaiter != nil {
+			if !allowedEvents[queryParams["event_id"][0]] &&
+				sendResponseWaiter != nil {
 				sendResponseWaiter.Waitf(t, 60*time.Second, "Waiting for /state request")
 			}
 			res := gomatrixserverlib.RespState{

--- a/tests/federation_room_join_partial_state_test.go
+++ b/tests/federation_room_join_partial_state_test.go
@@ -151,6 +151,40 @@ func TestPartialStateJoin(t *testing.T) {
 		testReceiveEventDuringPartialStateJoin(t, deployment, alice, psjResult, event)
 	})
 
+	// we should be able to receive events with missing prevs over federation during the resync
+	t.Run("CanReceiveEventsWithMissingPrevDuringPartialStateJoin", func(t *testing.T) {
+		deployment := Deploy(t, b.BlueprintAlice)
+		defer deployment.Destroy(t)
+		alice := deployment.Client(t, "hs1", "@alice:hs1")
+
+		psjResult := beginPartialStateJoin(t, deployment, alice)
+		defer psjResult.Destroy()
+
+		// we construct the following event graph:
+		// ... <-- M <-- A <-- B
+		//
+		// M is @alice:hs1's join event.
+		// A and B are regular m.room.messsage events sent by @derek from Complement.
+		//
+		// initially, hs1 only knows about event M.
+		// we send only event B to hs1.
+		eventM := psjResult.ServerRoom.CurrentState("m.room.member", alice.UserID)
+		eventA := psjResult.CreateMessageEvent(t, "derek", []string{eventM.EventID()})
+		eventB := psjResult.CreateMessageEvent(t, "derek", []string{eventA.EventID()})
+		t.Logf("%s's m.room.member event is %s", *eventM.StateKey(), eventM.EventID())
+		t.Logf("Derek sent event A with ID %s", eventA.EventID())
+		t.Logf("Derek sent event B with ID %s", eventB.EventID())
+
+		// the HS will make an /event_auth request for event A
+		federation.HandleEventAuthRequests()(psjResult.Server)
+
+		// the HS will make a /get_missing_events request for the missing prev events of event B
+		handleGetMissingEventsRequests(t, psjResult.Server, psjResult.ServerRoom, []*gomatrixserverlib.Event{eventA})
+
+		// send event B to hs1
+		testReceiveEventDuringPartialStateJoin(t, deployment, alice, psjResult, eventB)
+	})
+
 	// a request to (client-side) /members?at= should block until the (federation) /state request completes
 	// TODO(faster_joins): also need to test /state, and /members without an `at`, which follow a different path
 	t.Run("MembersRequestBlocksDuringPartialStateJoin", func(t *testing.T) {

--- a/tests/federation_room_join_partial_state_test.go
+++ b/tests/federation_room_join_partial_state_test.go
@@ -854,7 +854,7 @@ func handleStateIdsRequests(
 			if sendResponseWaiter != nil {
 				sendResponseWaiter.Waitf(t, 60*time.Second, "Waiting for /state_ids request")
 			}
-			t.Logf("Replying to /state_ids request")
+			t.Logf("Replying to /state_ids request for event %s", queryParams["event_id"])
 
 			res := gomatrixserverlib.RespStateIDs{
 				AuthEventIDs:  eventIDsFromEvents(serverRoom.AuthChainForEvents(roomState)),

--- a/tests/federation_room_join_partial_state_test.go
+++ b/tests/federation_room_join_partial_state_test.go
@@ -606,7 +606,8 @@ func testReceiveEventDuringPartialStateJoin(
 	//   * or 403 because the homeserver does not have full state yet and does not consider the
 	//     Complement homeserver to be in the room
 	// Synapse's behaviour will likely change once https://github.com/matrix-org/synapse/issues/13288
-	// is resolved.
+	// is resolved. For now, we use this to check whether Synapse has calculated the partial state
+	// flag for the last event correctly.
 
 	stateReq := gomatrixserverlib.NewFederationRequest("GET", "hs1",
 		fmt.Sprintf("/_matrix/federation/v1/state_ids/%s?event_id=%s",

--- a/tests/federation_room_join_partial_state_test.go
+++ b/tests/federation_room_join_partial_state_test.go
@@ -607,6 +607,8 @@ func testReceiveEventDuringPartialStateJoin(
 	//   * block because the homeserver does not have full state at the last event
 	//   * or 403 because the homeserver does not have full state yet and does not consider the
 	//     Complement homeserver to be in the room
+	// Synapse's behaviour will likely change once https://github.com/matrix-org/synapse/issues/13288
+	// is resolved.
 
 	type StateIDsResult struct {
 		RespStateIDs gomatrixserverlib.RespStateIDs

--- a/tests/federation_room_join_partial_state_test.go
+++ b/tests/federation_room_join_partial_state_test.go
@@ -145,9 +145,10 @@ func TestPartialStateJoin(t *testing.T) {
 		// the HS will make an /event_auth request for the event
 		federation.HandleEventAuthRequests()(psjResult.Server)
 
-		// derek sends an event in the room
 		event := psjResult.CreateMessageEvent(t, "derek", nil)
-		t.Logf("Derek sent event event ID %s", event.EventID())
+		t.Logf("Derek created event with ID %s", event.EventID())
+
+		// derek sends an event in the room
 		testReceiveEventDuringPartialStateJoin(t, deployment, alice, psjResult, event)
 	})
 
@@ -164,7 +165,7 @@ func TestPartialStateJoin(t *testing.T) {
 		// ... <-- M <-- A <-- B
 		//
 		// M is @alice:hs1's join event.
-		// A and B are regular m.room.messsage events sent by @derek from Complement.
+		// A and B are regular m.room.messsage events created by @derek on the Complement homeserver.
 		//
 		// initially, hs1 only knows about event M.
 		// we send only event B to hs1.
@@ -172,8 +173,8 @@ func TestPartialStateJoin(t *testing.T) {
 		eventA := psjResult.CreateMessageEvent(t, "derek", []string{eventM.EventID()})
 		eventB := psjResult.CreateMessageEvent(t, "derek", []string{eventA.EventID()})
 		t.Logf("%s's m.room.member event is %s", *eventM.StateKey(), eventM.EventID())
-		t.Logf("Derek sent event A with ID %s", eventA.EventID())
-		t.Logf("Derek sent event B with ID %s", eventB.EventID())
+		t.Logf("Derek created event A with ID %s", eventA.EventID())
+		t.Logf("Derek created event B with ID %s", eventB.EventID())
 
 		// the HS will make an /event_auth request for event A
 		federation.HandleEventAuthRequests()(psjResult.Server)
@@ -200,7 +201,7 @@ func TestPartialStateJoin(t *testing.T) {
 		// ... <-- M <-- A <-- B
 		//
 		// M is @alice:hs1's join event.
-		// A and B are regular m.room.messsage events sent by @derek from Complement.
+		// A and B are regular m.room.messsage events created by @derek on the Complement homeserver.
 		//
 		// initially, hs1 only knows about event M.
 		// we send only event B to hs1.
@@ -208,8 +209,8 @@ func TestPartialStateJoin(t *testing.T) {
 		eventA := psjResult.CreateMessageEvent(t, "derek", []string{eventM.EventID()})
 		eventB := psjResult.CreateMessageEvent(t, "derek", []string{eventA.EventID(), eventM.EventID()})
 		t.Logf("%s's m.room.member event is %s", *eventM.StateKey(), eventM.EventID())
-		t.Logf("Derek sent event A with ID %s", eventA.EventID())
-		t.Logf("Derek sent event B with ID %s", eventB.EventID())
+		t.Logf("Derek created event A with ID %s", eventA.EventID())
+		t.Logf("Derek created event B with ID %s", eventB.EventID())
 
 		// the HS will make an /event_auth request for event A
 		federation.HandleEventAuthRequests()(psjResult.Server)
@@ -236,7 +237,7 @@ func TestPartialStateJoin(t *testing.T) {
 		// ... <-- M <-- A <-- B <-- C
 		//
 		// M is @alice:hs1's join event.
-		// A, B and C are regular m.room.messsage events sent by @derek from Complement.
+		// A, B and C are regular m.room.messsage events created by @derek on the Complement homeserver.
 		//
 		// initially, hs1 only knows about event M.
 		// we send only event C to hs1.
@@ -245,9 +246,9 @@ func TestPartialStateJoin(t *testing.T) {
 		eventB := psjResult.CreateMessageEvent(t, "derek", []string{eventA.EventID(), eventM.EventID()})
 		eventC := psjResult.CreateMessageEvent(t, "derek", []string{eventB.EventID()})
 		t.Logf("%s's m.room.member event is %s", *eventM.StateKey(), eventM.EventID())
-		t.Logf("Derek sent event A with ID %s", eventA.EventID())
-		t.Logf("Derek sent event B with ID %s", eventB.EventID())
-		t.Logf("Derek sent event C with ID %s", eventC.EventID())
+		t.Logf("Derek created event A with ID %s", eventA.EventID())
+		t.Logf("Derek created event B with ID %s", eventB.EventID())
+		t.Logf("Derek created event C with ID %s", eventC.EventID())
 		psjResult.AllowStateRequestForEvent(eventA.EventID())
 
 		// the HS will make a /get_missing_events request for the missing prev event of event C,

--- a/tests/federation_room_join_partial_state_test.go
+++ b/tests/federation_room_join_partial_state_test.go
@@ -152,8 +152,8 @@ func TestPartialStateJoin(t *testing.T) {
 		testReceiveEventDuringPartialStateJoin(t, deployment, alice, psjResult, event)
 	})
 
-	// we should be able to receive events with missing prevs over federation during the resync
-	t.Run("CanReceiveEventsWithMissingPrevDuringPartialStateJoin", func(t *testing.T) {
+	// we should be able to receive events with a missing prev event over federation during the resync
+	t.Run("CanReceiveEventsWithMissingParentsDuringPartialStateJoin", func(t *testing.T) {
 		deployment := Deploy(t, b.BlueprintAlice)
 		defer deployment.Destroy(t)
 		alice := deployment.Client(t, "hs1", "@alice:hs1")
@@ -186,8 +186,8 @@ func TestPartialStateJoin(t *testing.T) {
 		testReceiveEventDuringPartialStateJoin(t, deployment, alice, psjResult, eventB)
 	})
 
-	// we should be able to receive events with partially missing prevs over federation during the resync
-	t.Run("CanReceiveEventsWithHalfMissingPrevsDuringPartialStateJoin", func(t *testing.T) {
+	// we should be able to receive events with partially missing prev events over federation during the resync
+	t.Run("CanReceiveEventsWithHalfMissingParentsDuringPartialStateJoin", func(t *testing.T) {
 		deployment := Deploy(t, b.BlueprintAlice)
 		defer deployment.Destroy(t)
 		alice := deployment.Client(t, "hs1", "@alice:hs1")
@@ -222,8 +222,9 @@ func TestPartialStateJoin(t *testing.T) {
 		testReceiveEventDuringPartialStateJoin(t, deployment, alice, psjResult, eventB)
 	})
 
-	// we should be able to receive events with missing prevs over federation during the resync
-	t.Run("CanReceiveEventsWithMissingPrevWithHalfMissingPrevsDuringPartialStateJoin", func(t *testing.T) {
+	// we should be able to receive events with a missing prev event, with half missing prev events,
+	// over federation during the resync
+	t.Run("CanReceiveEventsWithHalfMissingGrandparentsDuringPartialStateJoin", func(t *testing.T) {
 		deployment := Deploy(t, b.BlueprintAlice)
 		defer deployment.Destroy(t)
 		alice := deployment.Client(t, "hs1", "@alice:hs1")

--- a/tests/federation_room_join_partial_state_test.go
+++ b/tests/federation_room_join_partial_state_test.go
@@ -250,11 +250,14 @@ func TestPartialStateJoin(t *testing.T) {
 		t.Logf("Derek created event A with ID %s", eventA.EventID())
 		t.Logf("Derek created event B with ID %s", eventB.EventID())
 		t.Logf("Derek created event C with ID %s", eventC.EventID())
-		psjResult.AllowStateRequestForEvent(eventA.EventID())
 
 		// the HS will make a /get_missing_events request for the missing prev event of event C,
 		// to which we respond with event B only.
 		handleGetMissingEventsRequests(t, psjResult.Server, psjResult.ServerRoom, []*gomatrixserverlib.Event{eventB})
+
+		// dedicated state_ids and state handlers for event A
+		handleStateIdsRequests(t, psjResult.Server, psjResult.ServerRoom, eventA.EventID(), psjResult.ServerRoom.AllCurrentState(), nil, nil)
+		handleStateRequests(t, psjResult.Server, psjResult.ServerRoom, eventA.EventID(), psjResult.ServerRoom.AllCurrentState(), nil, nil)
 
 		// send event C to hs1
 		testReceiveEventDuringPartialStateJoin(t, deployment, alice, psjResult, eventC)

--- a/tests/federation_room_join_partial_state_test.go
+++ b/tests/federation_room_join_partial_state_test.go
@@ -185,6 +185,42 @@ func TestPartialStateJoin(t *testing.T) {
 		testReceiveEventDuringPartialStateJoin(t, deployment, alice, psjResult, eventB)
 	})
 
+	// we should be able to receive events with partially missing prevs over federation during the resync
+	t.Run("CanReceiveEventsWithHalfMissingPrevsDuringPartialStateJoin", func(t *testing.T) {
+		deployment := Deploy(t, b.BlueprintAlice)
+		defer deployment.Destroy(t)
+		alice := deployment.Client(t, "hs1", "@alice:hs1")
+
+		psjResult := beginPartialStateJoin(t, deployment, alice)
+		defer psjResult.Destroy()
+
+		// we construct the following event graph:
+		//         +---------+
+		//         v          \
+		// ... <-- M <-- A <-- B
+		//
+		// M is @alice:hs1's join event.
+		// A and B are regular m.room.messsage events sent by @derek from Complement.
+		//
+		// initially, hs1 only knows about event M.
+		// we send only event B to hs1.
+		eventM := psjResult.ServerRoom.CurrentState("m.room.member", alice.UserID)
+		eventA := psjResult.CreateMessageEvent(t, "derek", []string{eventM.EventID()})
+		eventB := psjResult.CreateMessageEvent(t, "derek", []string{eventA.EventID(), eventM.EventID()})
+		t.Logf("%s's m.room.member event is %s", *eventM.StateKey(), eventM.EventID())
+		t.Logf("Derek sent event A with ID %s", eventA.EventID())
+		t.Logf("Derek sent event B with ID %s", eventB.EventID())
+
+		// the HS will make an /event_auth request for event A
+		federation.HandleEventAuthRequests()(psjResult.Server)
+
+		// the HS will make a /get_missing_events request for the missing prev event of event B
+		handleGetMissingEventsRequests(t, psjResult.Server, psjResult.ServerRoom, []*gomatrixserverlib.Event{eventA})
+
+		// send event B to hs1
+		testReceiveEventDuringPartialStateJoin(t, deployment, alice, psjResult, eventB)
+	})
+
 	// a request to (client-side) /members?at= should block until the (federation) /state request completes
 	// TODO(faster_joins): also need to test /state, and /members without an `at`, which follow a different path
 	t.Run("MembersRequestBlocksDuringPartialStateJoin", func(t *testing.T) {

--- a/tests/federation_room_join_partial_state_test.go
+++ b/tests/federation_room_join_partial_state_test.go
@@ -754,12 +754,23 @@ func beginPartialStateJoin(t *testing.T, deployment *docker.Deployment, joiningU
 		},
 	}))
 
-	// register a handler for /state_ids requests, which finishes fedStateIdsRequestReceivedWaiter, then
+	// register a handler for /state_ids requests for the most recent event,
+	// which finishes fedStateIdsRequestReceivedWaiter, then
 	// waits for fedStateIdsSendResponseWaiter and sends a reply
-	handleStateIdsRequests(t, result.Server, result.ServerRoom, result.fedStateIdsRequestReceivedWaiter, result.fedStateIdsSendResponseWaiter)
+	lastEvent := result.ServerRoom.Timeline[len(result.ServerRoom.Timeline)-1]
+	currentState := result.ServerRoom.AllCurrentState()
+	handleStateIdsRequests(
+		t, result.Server, result.ServerRoom,
+		lastEvent.EventID(), currentState,
+		result.fedStateIdsRequestReceivedWaiter, result.fedStateIdsSendResponseWaiter,
+	)
 
 	// a handler for /state requests, which sends a sensible response
-	handleStateRequests(t, result.Server, result.ServerRoom, nil, nil)
+	handleStateRequests(
+		t, result.Server, result.ServerRoom,
+		lastEvent.EventID(), currentState,
+		nil, nil,
+	)
 
 	// have joiningUser join the room by room ID.
 	joiningUser.JoinRoom(t, result.ServerRoom.RoomID, []string{result.Server.ServerName()})
@@ -817,16 +828,20 @@ func (psj *partialStateJoinResult) FinishStateRequest() {
 	psj.fedStateIdsSendResponseWaiter.Finish()
 }
 
-// handleStateIdsRequests registers a handler for /state_ids requests for serverRoom.
+// handleStateIdsRequests registers a handler for /state_ids requests for 'eventID'
+//
+// the returned state is as passed in 'roomState'
 //
 // if requestReceivedWaiter is not nil, it will be Finish()ed when the request arrives.
 // if sendResponseWaiter is not nil, we will Wait() for it to finish before sending the response.
 func handleStateIdsRequests(
 	t *testing.T, srv *federation.Server, serverRoom *federation.ServerRoom,
+	eventID string, roomState []*gomatrixserverlib.Event,
 	requestReceivedWaiter *Waiter, sendResponseWaiter *Waiter,
 ) {
-	srv.Mux().Handle(
+	srv.Mux().NewRoute().Methods("GET").Path(
 		fmt.Sprintf("/_matrix/federation/v1/state_ids/%s", serverRoom.RoomID),
+	).Queries("event_id", eventID).Handler(
 		http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			queryParams := req.URL.Query()
 			t.Logf("Incoming state_ids request for event %s in room %s", queryParams["event_id"], serverRoom.RoomID)
@@ -839,8 +854,8 @@ func handleStateIdsRequests(
 			t.Logf("Replying to /state_ids request")
 
 			res := gomatrixserverlib.RespStateIDs{
-				AuthEventIDs:  eventIDsFromEvents(serverRoom.AuthChain()),
-				StateEventIDs: eventIDsFromEvents(serverRoom.AllCurrentState()),
+				AuthEventIDs:  eventIDsFromEvents(serverRoom.AuthChainForEvents(roomState)),
+				StateEventIDs: eventIDsFromEvents(roomState),
 			}
 			w.WriteHeader(200)
 			jsonb, _ := json.Marshal(res)
@@ -849,19 +864,24 @@ func handleStateIdsRequests(
 				t.Errorf("Error writing to request: %v", err)
 			}
 		}),
-	).Methods("GET")
+	)
+	t.Logf("Registered state_ids handler for event %s", eventID)
 }
 
-// makeStateHandler returns a handler for /state requests for serverRoom.
+// makeStateHandler returns a handler for /state requests for 'eventID'
+//
+// the returned state is as passed in 'roomState'
 //
 // if requestReceivedWaiter is not nil, it will be Finish()ed when the request arrives.
 // if sendResponseWaiter is not nil, we will Wait() for it to finish before sending the response.
 func handleStateRequests(
 	t *testing.T, srv *federation.Server, serverRoom *federation.ServerRoom,
+	eventID string, roomState []*gomatrixserverlib.Event,
 	requestReceivedWaiter *Waiter, sendResponseWaiter *Waiter,
 ) {
-	srv.Mux().Handle(
+	srv.Mux().NewRoute().Methods("GET").Path(
 		fmt.Sprintf("/_matrix/federation/v1/state/%s", serverRoom.RoomID),
+	).Queries("event_id", eventID).Handler(
 		http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			queryParams := req.URL.Query()
 			t.Logf("Incoming state request for event %s in room %s", queryParams["event_id"], serverRoom.RoomID)
@@ -872,8 +892,8 @@ func handleStateRequests(
 				sendResponseWaiter.Waitf(t, 60*time.Second, "Waiting for /state request")
 			}
 			res := gomatrixserverlib.RespState{
-				AuthEvents:  gomatrixserverlib.NewEventJSONsFromEvents(serverRoom.AuthChain()),
-				StateEvents: gomatrixserverlib.NewEventJSONsFromEvents(serverRoom.AllCurrentState()),
+				AuthEvents:  gomatrixserverlib.NewEventJSONsFromEvents(serverRoom.AuthChainForEvents(roomState)),
+				StateEvents: gomatrixserverlib.NewEventJSONsFromEvents(roomState),
 			}
 			w.WriteHeader(200)
 			jsonb, _ := json.Marshal(res)
@@ -882,7 +902,7 @@ func handleStateRequests(
 				t.Errorf("Error writing to request: %v", err)
 			}
 		}),
-	).Methods("GET")
+	)
 }
 
 // register a handler for `/get_missing_events` requests

--- a/tests/federation_room_join_test.go
+++ b/tests/federation_room_join_test.go
@@ -385,7 +385,7 @@ func testValidationForSendMembershipEndpoint(t *testing.T, baseApiPath, expected
 		}
 
 		var res interface{}
-		err := srv.SendFederationRequest(deployment, req, &res)
+		err := srv.SendFederationRequest(context.Background(), deployment, req, &res)
 		if err == nil {
 			t.Errorf("send request returned 200")
 			return


### PR DESCRIPTION
Add tests for three cases where a homeserver receives a latest event with missing prev events while it is still resyncing state after a partial join.

Namely:
```
... <-- M <-- A <-- B
```
```
        +---------+
        v          \
... <-- M <-- A <-- B
```
and
```
        +---------+
        v          \
... <-- M <-- A <-- B <-- C
```
where event M is the last event the homeserver knows about and the rightmost event is the one it receives.

The last case tests the code path mentioned in https://github.com/matrix-org/synapse/issues/13002

Best reviewed commit by commit. 