### PR TITLE
Raise the timeout for Synapse CI to 12 minutes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,10 +40,12 @@ jobs:
           - homeserver: Synapse
             tags: synapse_blacklist msc3083 msc3787 faster_joins
             env: "COMPLEMENT_SHARE_ENV_PREFIX=PASS_ PASS_SYNAPSE_COMPLEMENT_DATABASE=sqlite"
+            timeout: 12m
 
           - homeserver: Dendrite
             tags: msc2836 dendrite_blacklist
             env: ""
+            timeout: 10m
 
     steps:
       - uses: actions/checkout@v2 # Checkout complement
@@ -111,7 +113,7 @@ jobs:
 
       - run: |
           set -o pipefail &&
-          ${{ matrix.env }} go test -v -json -tags "${{ matrix.tags }}" ./tests/... 2>&1 | gotestfmt
+          ${{ matrix.env }} go test -v -json -tags "${{ matrix.tags }}" -timeout "${{ matrix.timeout }}" ./tests/... 2>&1 | gotestfmt
         shell: bash # required for pipefail to be A Thing. pipefail is required to stop gotestfmt swallowing non-zero exit codes
         name: Run Complement Tests
         env:


### PR DESCRIPTION
The default 10 minute timeout is no longer sufficient to run all of the
Synapse tests and is now being hit randomly.

---

CI is currently failing on `main`: https://github.com/matrix-org/complement/runs/7499686661?check_suite_focus=true because of the timeout.