### PR TITLE
Fix an out of bounds error in TestSync 'sync should succeed even if the sync token points to a redaction of an unknown event'

### DIFF
--- a/tests/csapi/sync_test.go
+++ b/tests/csapi/sync_test.go
@@ -354,16 +354,22 @@ func TestSync(t *testing.T) {
 				numResponsesReturned += 1
 				timeline := syncResponse.Get("rooms.join." + client.GjsonEscape(redactionRoomID) + ".timeline")
 				timelineEvents := timeline.Get("events").Array()
-				lastEventIdInSync := timelineEvents[len(timelineEvents)-1].Get("event_id").String()
 
-				t.Logf("Iteration %d: /sync returned %d events, with final event %s", numResponsesReturned, len(timelineEvents), lastEventIdInSync)
-				if lastEventIdInSync == lastSentEventId {
-					// check we actually got a gappy sync - else this test isn't testing the right thing
-					if !timeline.Get("limited").Bool() {
-						t.Fatalf("Not a gappy sync after redaction")
+				if len(timelineEvents) > 0 {
+					lastEventIdInSync := timelineEvents[len(timelineEvents)-1].Get("event_id").String()
+					t.Logf("Iteration %d: /sync returned %d events, with final event %s", numResponsesReturned, len(timelineEvents), lastEventIdInSync)
+
+					if lastEventIdInSync == lastSentEventId {
+						// check we actually got a gappy sync - else this test isn't testing the right thing
+						if !timeline.Get("limited").Bool() {
+							t.Fatalf("Not a gappy sync after redaction")
+						}
+						break
 					}
-					break
+				} else {
+					t.Logf("Iteration %d: /sync returned %d events", numResponsesReturned, len(timelineEvents))
 				}
+
 			}
 
 			// that's it - we successfully did a gappy sync.

--- a/tests/csapi/sync_test.go
+++ b/tests/csapi/sync_test.go
@@ -316,6 +316,7 @@ func TestSync(t *testing.T) {
 				Content: map[string]interface{}{"body": "1234"},
 			})
 			sentinelRoom.AddEvent(sentinelEvent)
+			t.Logf("Created sentinel event %s", sentinelEvent.EventID())
 			srv.MustSendTransaction(t, deployment, "hs1", []json.RawMessage{redactionEvent.JSON(), sentinelEvent.JSON()}, nil)
 
 			// wait for the sentinel to arrive
@@ -343,6 +344,7 @@ func TestSync(t *testing.T) {
 			// keep the same ?since each time, instead of incrementally syncing on each pass.
 			numResponsesReturned := 0
 			start := time.Now()
+			t.Logf("Will sync with since=%s", nextBatch)
 			for {
 				if time.Since(start) > alice.SyncUntilTimeout {
 					t.Fatalf("%s: timed out after %v. Seen %d /sync responses", alice.UserID, time.Since(start), numResponsesReturned)


### PR DESCRIPTION
When no events are received in the sync window, it tries to access index `-1` and panics.

This mitigates that and also adds some log lines which might be useful in tracking down another flake that occurs rarely.