### PR TITLE
partial state tests: factor out room creation

### DIFF
--- a/tests/federation_room_join_partial_state_test.go
+++ b/tests/federation_room_join_partial_state_test.go
@@ -461,18 +461,7 @@ func TestPartialStateJoin(t *testing.T) {
 		})
 
 		// create the complement homeserver
-		server := federation.NewServer(t, deployment,
-			federation.HandleKeyRequests(),
-			federation.HandlePartialStateMakeSendJoinRequests(),
-			federation.HandleEventRequests(),
-			federation.HandleTransactionRequests(
-				func(e *gomatrixserverlib.Event) {
-					t.Fatalf("Received unexpected PDU: %s", string(e.JSON()))
-				},
-				// hs1 may send us presence when alice syncs
-				nil,
-			),
-		)
+		server := createTestServer(t, deployment)
 		cancelListener := server.Listen()
 		defer cancelListener()
 


### PR DESCRIPTION
Factor the creation of the server and the room from `beginPartialStateJoin`. It was handy there, but is too restrictive for tests that need to mess about with the room before the join.

~~Based on #418~~