### PR TITLE
Bump up the timeout for 'sync should succeed even if the sync token points to a redaction of an unknown event'

### DIFF
--- a/tests/csapi/sync_test.go
+++ b/tests/csapi/sync_test.go
@@ -345,6 +345,11 @@ func TestSync(t *testing.T) {
 			numResponsesReturned := 0
 			start := time.Now()
 			t.Logf("Will sync with since=%s", nextBatch)
+
+			// This part of the test is flaky for workerised Synapse with the default 5 second timeout,
+			// so bump it up to 10 seconds.
+			alice.SyncUntilTimeout = 10 * time.Second
+
 			for {
 				if time.Since(start) > alice.SyncUntilTimeout {
 					t.Fatalf("%s: timed out after %v. Seen %d /sync responses", alice.UserID, time.Since(start), numResponsesReturned)


### PR DESCRIPTION
This test is fairly frequently timing out when running Synapse with workers in GHA (who knew things slow down if you run 14 workers per homeserver on a 2-core machine, plus there are two test runs in parallel?).
I don't really have any smart ideas to avoid this being so slow, so reluctantly I propose we increase the timeout.

Example fail:
https://github.com/matrix-org/synapse/runs/7578791006?check_suite_focus=true