### PR TITLE
Extend Blueprints to permit baseImageURI to be optionally overridden for each Homeserver

### DIFF
--- a/internal/b/blueprints.go
+++ b/internal/b/blueprints.go
@@ -54,6 +54,8 @@ type Homeserver struct {
 	Rooms []Room
 	// The list of application services to create on the homeserver
 	ApplicationServices []ApplicationService
+	// Optionally override the baseImageURI for blueprint creation
+	BaseImageURI *string
 }
 
 type User struct {

--- a/internal/docker/builder.go
+++ b/internal/docker/builder.go
@@ -181,7 +181,10 @@ func (d *Builder) ConstructBlueprintIfNotExist(bprint b.Blueprint) error {
 		return fmt.Errorf("ConstructBlueprintIfNotExist(%s): failed to ImageList: %w", bprint.Name, err)
 	}
 	if len(images) == 0 {
-		d.ConstructBlueprint(bprint)
+		err = d.ConstructBlueprint(bprint)
+		if err != nil {
+			return fmt.Errorf("ConstructBlueprintIfNotExist(%s): failed to ConstructBlueprint: %w", bprint.Name, err)
+		}
 	}
 	return nil
 }

--- a/internal/docker/builder.go
+++ b/internal/docker/builder.go
@@ -380,9 +380,15 @@ func (d *Builder) constructHomeserver(blueprintName string, runner *instruction.
 // deployBaseImage runs the base image and returns the baseURL, containerID or an error.
 func (d *Builder) deployBaseImage(blueprintName string, hs b.Homeserver, contextStr, networkID string) (*HomeserverDeployment, error) {
 	asIDToRegistrationMap := asIDToRegistrationFromLabels(labelsForApplicationServices(hs))
+	var baseImageURI string
+	if hs.BaseImageURI == nil {
+		baseImageURI = d.Config.BaseImageURI
+	} else {
+		baseImageURI = *hs.BaseImageURI
+	}
 
 	return deployImage(
-		d.Docker, d.Config.BaseImageURI, fmt.Sprintf("complement_%s", contextStr),
+		d.Docker, baseImageURI, fmt.Sprintf("complement_%s", contextStr),
 		d.Config.PackageNamespace, blueprintName, hs.Name, asIDToRegistrationMap, contextStr,
 		networkID, d.Config,
 	)


### PR DESCRIPTION
Fixes matrix-org/complement#435

Includes an error handling change to be able to see what's going on when base images aren't available. Before the error handling change, the requests below would have both reported the error:
`{"message":"failed to create deployment: CreateDeployment: Deploy returned error Deploy: No images have been built for blueprint custom"}`

Demonstrating the actual change by making these requests:

`curl -XPOST -d'{"base_image_uri":"not_an_image", "blueprint": { "Name": "custom", "Homeservers": [ { "Name": "hs1", "Users": [], "Rooms": [] }]}}' http://localhost:54321/create`
`{"message":"failed to create deployment: CreateDeployment: Failed to construct blueprint: ConstructBlueprintIfNotExist(custom): failed to ConstructBlueprint: errors whilst constructing blueprint custom: [Error response from daemon: No such image: not_an_image:latest]"}`


`curl -XPOST -d'{"base_image_uri":"not_an_image", "blueprint": { "Name": "custom", "Homeservers": [ { "Name": "hs1", "Users": [], "Rooms": [], "BaseImageURI": "alsonotanimage" }]}}' http://localhost:54321/create`
`{"message":"failed to create deployment: CreateDeployment: Failed to construct blueprint: ConstructBlueprintIfNotExist(custom): failed to ConstructBlueprint: errors whilst constructing blueprint custom: [Error response from daemon: No such image: alsonotanimage:latest]"}`

Also ran the synapse tester against this complement branch and it seemed to work fine.