### PR TITLE
Fix Complement hiding errors when the blueprint and image fails to build

### DIFF
--- a/internal/docker/builder.go
+++ b/internal/docker/builder.go
@@ -181,7 +181,10 @@ func (d *Builder) ConstructBlueprintIfNotExist(bprint b.Blueprint) error {
 		return fmt.Errorf("ConstructBlueprintIfNotExist(%s): failed to ImageList: %w", bprint.Name, err)
 	}
 	if len(images) == 0 {
-		d.ConstructBlueprint(bprint)
+		err := d.ConstructBlueprint(bprint)
+		if err != nil {
+			return fmt.Errorf("ConstructBlueprintIfNotExist(%s): failed to build image: %w", bprint.Name, err)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Fix Complement hiding errors when the blueprint and image fails to build

Before:

```
federation_room_messages_test.go:14: Deploy: Deploy returned error Deploy: No images have been built for blueprint perf_many_messages
```

After:

```
federation_room_messages_test.go:14: Deploy: Failed to construct blueprint: ConstructBlueprintIfNotExist(perf_many_messages): failed to build image: errors whilst constructing blueprint perf_many_messages: [perf_many_messages.hs1 : request http://localhost:57273/_matrix/client/v3/rooms/%21TjBoHVjQldZBcmXRwW:hs1/send/m.room.message/1?access_token=syt_dXNlcl8w_bWvqKHmRcueZttMyINGR_1daNA4&server_name= returned HTTP 403 Forbidden : {"errcode":"M_FORBIDDEN","error":"User @user_0:hs1 not in room !TjBoHVjQldZBcmXRwW:hs1 (None)"} terminated]
```