### PR TITLE
Use MSC2716v4 room version

### DIFF
--- a/tests/msc2716_test.go
+++ b/tests/msc2716_test.go
@@ -44,20 +44,20 @@ var (
 	markerEventType    = "org.matrix.msc2716.marker"
 
 	historicalContentField      = "org.matrix.msc2716.historical"
-	nextBatchIDContentField     = "org.matrix.msc2716.next_batch_id"
-	markerInsertionContentField = "org.matrix.msc2716.marker.insertion"
+	nextBatchIDContentField     = "next_batch_id"
+	markerInsertionContentField = "insertion_event_reference"
 )
 
 var createPublicRoomOpts = map[string]interface{}{
 	"preset":       "public_chat",
 	"name":         "the hangout spot",
-	"room_version": "org.matrix.msc2716v3",
+	"room_version": "org.matrix.msc2716v4",
 }
 
 var createPrivateRoomOpts = map[string]interface{}{
 	"preset":       "private_chat",
 	"name":         "the hangout spot",
-	"room_version": "org.matrix.msc2716v3",
+	"room_version": "org.matrix.msc2716v4",
 }
 
 func TestImportHistoricalMessages(t *testing.T) {


### PR DESCRIPTION
Use MSC2716v4 room version

Companion changes in Synapse https://github.com/matrix-org/synapse/pull/13551

```
$ COMPLEMENT_ALWAYS_PRINT_SERVER_LOGS=1 COMPLEMENT_DIR=../complement ./scripts-dev/complement.sh -run TestImportHistoricalMessages

--- PASS: TestImportHistoricalMessages (42.92s)
    --- PASS: TestImportHistoricalMessages/parallel (16.97s)
        --- SKIP: TestImportHistoricalMessages/parallel/TODO:_Trying_to_send_insertion_event_with_same_`next_batch_id`_will_reject (0.00s)
        --- SKIP: TestImportHistoricalMessages/parallel/TODO:_What_happens_when_you_point_multiple_batches_at_the_same_insertion_event? (0.00s)
        --- PASS: TestImportHistoricalMessages/parallel/Federation (0.00s)
            --- PASS: TestImportHistoricalMessages/parallel/Federation/When_messages_have_already_been_scrolled_back_through,_new_historical_messages_are_visible_in_next_scroll_back_on_federated_server (9.63s)
            --- PASS: TestImportHistoricalMessages/parallel/Federation/Historical_messages_are_visible_when_joining_on_federated_server_-_pre-made_insertion_event (12.75s)
            --- PASS: TestImportHistoricalMessages/parallel/Federation/Historical_messages_are_visible_when_already_joined_on_federated_server (12.84s)
            --- PASS: TestImportHistoricalMessages/parallel/Federation/Historical_messages_show_up_for_remote_federated_homeserver_even_when_the_homeserver_is_missing_the_part_of_the_timeline_where_the_marker_was_sent_and_it_paginates_before_it_occured (14.07s)
            --- PASS: TestImportHistoricalMessages/parallel/Federation/Historical_messages_are_visible_when_joining_on_federated_server_-_auto-generated_base_insertion_event (14.11s)
            --- PASS: TestImportHistoricalMessages/parallel/Federation/Historical_messages_show_up_for_remote_federated_homeserver_even_when_the_homeserver_is_missing_the_part_of_the_timeline_where_multiple_marker_events_were_sent_and_it_paginates_before_they_occured (15.45s)
        --- PASS: TestImportHistoricalMessages/parallel/Existing_room_versions (0.00s)
            --- PASS: TestImportHistoricalMessages/parallel/Existing_room_versions/Not_allowed_to_redact_MSC2716_insertion,_batch,_marker_events (1.39s)
            --- PASS: TestImportHistoricalMessages/parallel/Existing_room_versions/Room_creator_can_send_MSC2716_events (1.51s)
        --- PASS: TestImportHistoricalMessages/parallel/Unrecognised_prev_event_ID_will_throw_an_error (2.25s)
        --- PASS: TestImportHistoricalMessages/parallel/Duplicate_next_batch_id_on_insertion_event_will_be_rejected (3.35s)
        --- PASS: TestImportHistoricalMessages/parallel/Normal_users_aren't_allowed_to_batch_send_historical_messages (3.57s)
        --- PASS: TestImportHistoricalMessages/parallel/Unrecognised_batch_id_will_throw_an_error (3.61s)
        --- PASS: TestImportHistoricalMessages/parallel/Batch_send_endpoint_only_returns_state_events_that_we_passed_in_via_state_events_at_start (4.27s)
        --- PASS: TestImportHistoricalMessages/parallel/Should_be_able_to_send_a_batch_without_any_state_events_at_start_-_user_already_joined_in_the_current_room_state (4.66s)
        --- PASS: TestImportHistoricalMessages/parallel/Non-member_state_events_are_allowed_in_state_events_at_start (4.81s)
        --- PASS: TestImportHistoricalMessages/parallel/Should_be_able_to_batch_send_historical_messages_into_private_room (5.54s)
        --- PASS: TestImportHistoricalMessages/parallel/Historical_events_from_multiple_users_in_the_same_batch (5.60s)
        --- PASS: TestImportHistoricalMessages/parallel/Historical_events_resolve_in_the_correct_order (6.46s)
        --- PASS: TestImportHistoricalMessages/parallel/should_resolve_member_state_events_for_historical_events (6.53s)
        --- PASS: TestImportHistoricalMessages/parallel/Historical_events_from_batch_send_do_not_come_down_in_an_incremental_sync (6.73s)
PASS
ok  	github.com/matrix-org/complement/tests	46.002s
```