### PR TITLE
[server notices] wait for the join to come down sync first

### DIFF
--- a/tests/csapi/admin_test.go
+++ b/tests/csapi/admin_test.go
@@ -65,6 +65,7 @@ func TestServerNotices(t *testing.T) {
 	})
 	t.Run("Alice can join the alert room", func(t *testing.T) {
 		alice.JoinRoom(t, roomID, []string{})
+		alice.MustSyncUntil(t, client.SyncReq{}, client.SyncJoinedTo(alice.UserID, roomID))
 		alice.MustSyncUntil(t, client.SyncReq{}, client.SyncTimelineHasEventID(roomID, eventID))
 	})
 	t.Run("Alice can leave the alert room, after joining it", func(t *testing.T) {


### PR DESCRIPTION
Not exactly sure if we should fix the issue here or in Dendrite:
In Dendrite, the server notice event might be persisted before the join event, but this results in Dendrite missing the server notice event, because the initial sync sets the stream position to something > the server notice event. So in further incremental syncs we wouldn't receive the server notice event.

This now waits for the join to come down sync and does another initial sync, deflaking the test in Dendrite.