### PR TITLE
Keep specific homeserver from blueprint

### DIFF
--- a/cmd/account-snapshot/README.md
+++ b/cmd/account-snapshot/README.md
@@ -23,7 +23,7 @@ Then run Homerunner in single-shot mode: (this will take hours or days depending
 ```
 HOMERUNNER_SNAPSHOT_BLUEPRINT=blueprint.json ./homerunner
 ```
-This will execute the blueprint and commit the resulting images so you can push them to docker hub/gitlab. IMPORTANT: Make sure to set `HOMERUNNER_KEEP_BLUEPRINTS=your-blueprint-name` when running homerunner subsequently or **it will clean up the image**.
+This will execute the blueprint and commit the resulting images so you can push them to docker hub/gitlab. IMPORTANT: Make sure to set `HOMERUNNER_KEEP_BLUEPRINTS=your-blueprint-name` (TODO: Update) when running homerunner subsequently or **it will clean up the image**.
 
 #### Limitations
 

--- a/internal/docker/builder.go
+++ b/internal/docker/builder.go
@@ -124,16 +124,16 @@ func (d *Builder) removeImages() error {
 			d.log("Not cleaning up image with tags: %v", img.RepoTags)
 			continue
 		}
-		bprintName := img.Labels["complement_blueprint"]
+		contextStr := img.Labels[complementLabel]
 		keep := false
 		for _, keepBprint := range d.Config.KeepBlueprints {
-			if bprintName == keepBprint {
+			if contextStr == keepBprint {
 				keep = true
 				break
 			}
 		}
 		if keep {
-			d.log("Keeping image created from blueprint %s", bprintName)
+			d.log("Keeping image created from blueprint %s", contextStr)
 			continue
 		}
 		_, err = d.Docker.ImageRemove(context.Background(), img.ID, types.ImageRemoveOptions{
@@ -180,8 +180,23 @@ func (d *Builder) ConstructBlueprintIfNotExist(bprint b.Blueprint) error {
 	if err != nil {
 		return fmt.Errorf("ConstructBlueprintIfNotExist(%s): failed to ImageList: %w", bprint.Name, err)
 	}
-	if len(images) == 0 {
-		err = d.ConstructBlueprint(bprint)
+	var missingHomeservers []b.Homeserver
+	for _, homeserver := range bprint.Homeservers {
+		found := false
+		for _, image := range images {
+			if image.Labels["complement_hs_name"] == homeserver.Name {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			missingHomeservers = append(missingHomeservers, homeserver)
+		}
+	}
+
+	if len(images) < len(bprint.Homeservers) {
+		err = d.ConstructBlueprint(bprint, missingHomeservers)
 		if err != nil {
 			return fmt.Errorf("ConstructBlueprintIfNotExist(%s): failed to ConstructBlueprint: %w", bprint.Name, err)
 		}
@@ -189,8 +204,8 @@ func (d *Builder) ConstructBlueprintIfNotExist(bprint b.Blueprint) error {
 	return nil
 }
 
-func (d *Builder) ConstructBlueprint(bprint b.Blueprint) error {
-	errs := d.construct(bprint)
+func (d *Builder) ConstructBlueprint(bprint b.Blueprint, homeserversToConstruct []b.Homeserver) error {
+	errs := d.construct(bprint, homeserversToConstruct)
 	if len(errs) > 0 {
 		for _, err := range errs {
 			d.log("could not construct blueprint: %s", err)
@@ -237,7 +252,7 @@ func (d *Builder) ConstructBlueprint(bprint b.Blueprint) error {
 }
 
 // construct all Homeservers sequentially then commits them
-func (d *Builder) construct(bprint b.Blueprint) (errs []error) {
+func (d *Builder) construct(bprint b.Blueprint, homeserversToConstruct []b.Homeserver) (errs []error) {
 	d.log("Constructing blueprint '%s'", bprint.Name)
 
 	networkID, err := createNetworkIfNotExists(d.Docker, d.Config.PackageNamespace, bprint.Name)
@@ -246,8 +261,8 @@ func (d *Builder) construct(bprint b.Blueprint) (errs []error) {
 	}
 
 	runner := instruction.NewRunner(bprint.Name, d.Config.BestEffort, d.Config.DebugLoggingEnabled)
-	results := make([]result, len(bprint.Homeservers))
-	for i, hs := range bprint.Homeservers {
+	results := make([]result, len(homeserversToConstruct))
+	for i, hs := range homeserversToConstruct {
 		res := d.constructHomeserver(bprint.Name, runner, hs, networkID)
 		if res.err != nil {
 			errs = append(errs, res.err)


### PR DESCRIPTION
Keep specific homeserver from blueprint. When testing in https://github.com/matrix-org/complement/pull/443, `hs1` has a room with many users with many messages in it which takes a while to construct in the blueprint which I want to stay cached, and `hs2` is my local Synapse built up over and over to test optimization changes when federating with `hs1`.

Split off from https://github.com/matrix-org/complement/pull/443

Usage:

```
COMPLEMENT_KEEP_BLUEPRINTS="fed.perf_many_messages.hs1" COMPLEMENT_DIR=../complement ./scripts-dev/complement.sh -run TestMessagesOverFederation -p 1
```

### Dev notes

Labels on container:

```
"Labels": {
    "access_token_@charlie:hs2": "syt_Y2hhcmxpZQ_rKpoAAPGqeKxFYkgmAkU_4PG5Hd",
    "complement_blueprint": "perf_many_messages",
    "complement_context": "fed.perf_many_messages.hs2",
    "complement_hs_name": "hs2",
    "complement_pkg": "fed",
    "desktop.docker.io/ports/8008/tcp": "127.0.0.1:0",
    "desktop.docker.io/ports/8448/tcp": "127.0.0.1:0",
    "device_id@charlie:hs2": "NINFGRNLCL",
    "org.opencontainers.image.documentation": "https://github.com/matrix-org/synapse/blob/master/docker/README.md",
    "org.opencontainers.image.licenses": "Apache-2.0",
    "org.opencontainers.image.source": "https://github.com/matrix-org/synapse.git",
    "org.opencontainers.image.url": "https://matrix.org/docs/projects/server/synapse"
}
```