### PR TITLE
Add ability to define HS specific base images

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -110,6 +110,8 @@ jobs:
       - run: docker build -t homeserver -f build/scripts/Complement.Dockerfile .
         if: ${{ matrix.homeserver == 'Dendrite' }}
         working-directory: homeserver
+        env:
+          DOCKER_BUILDKIT: 1
 
       - run: |
           set -o pipefail &&

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,7 +40,7 @@ type Complement struct {
 	CAPrivateKey  *rsa.PrivateKey
 }
 
-var hsRegex = regexp.MustCompile(`COMPLEMENT_BASE_IMAGE_HS\d+=.+$`)
+var hsRegex = regexp.MustCompile(`COMPLEMENT_BASE_IMAGE_(.+)=(.+)$`)
 
 func NewConfigFromEnvVars(pkgNamespace, baseImageURI string) *Complement {
 	cfg := &Complement{BaseImageURIs: map[string]string{}}
@@ -71,10 +71,11 @@ func NewConfigFromEnvVars(pkgNamespace, baseImageURI string) *Complement {
 	}
 	// Parse HS specific base images
 	for _, env := range os.Environ() {
-		if hsRegex.MatchString(env) {
-			parts := strings.Split(env, "=")
-			hs := strings.ToLower(strings.TrimPrefix(parts[0], "COMPLEMENT_BASE_IMAGE_"))
-			cfg.BaseImageURIs[hs] = parts[1]
+		// FindStringSubmatch returns the complete match as well as the capture groups.
+		// In this case we expect there to be 3 matches.
+		if matches := hsRegex.FindStringSubmatch(env); len(matches) == 3 {
+			hs := matches[1]                   // first capture group; homeserver name
+			cfg.BaseImageURIs[hs] = matches[2] // second capture group; homeserver image
 		}
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"math/big"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -23,7 +24,7 @@ type HostMount struct {
 
 type Complement struct {
 	BaseImageURI           string
-	BaseImageArgs          []string
+	BaseImageURIs          map[string]string
 	DebugLoggingEnabled    bool
 	AlwaysPrintServerLogs  bool
 	BestEffort             bool
@@ -39,13 +40,14 @@ type Complement struct {
 	CAPrivateKey  *rsa.PrivateKey
 }
 
+var hsRegex = regexp.MustCompile(`COMPLEMENT_BASE_IMAGE_HS\d+=.+$`)
+
 func NewConfigFromEnvVars(pkgNamespace, baseImageURI string) *Complement {
-	cfg := &Complement{}
+	cfg := &Complement{BaseImageURIs: map[string]string{}}
 	cfg.BaseImageURI = os.Getenv("COMPLEMENT_BASE_IMAGE")
 	if cfg.BaseImageURI == "" {
 		cfg.BaseImageURI = baseImageURI
 	}
-	cfg.BaseImageArgs = strings.Split(os.Getenv("COMPLEMENT_BASE_IMAGE_ARGS"), " ")
 	cfg.DebugLoggingEnabled = os.Getenv("COMPLEMENT_DEBUG") == "1"
 	cfg.AlwaysPrintServerLogs = os.Getenv("COMPLEMENT_ALWAYS_PRINT_SERVER_LOGS") == "1"
 	cfg.EnvVarsPropagatePrefix = os.Getenv("COMPLEMENT_SHARE_ENV_PREFIX")
@@ -67,6 +69,15 @@ func NewConfigFromEnvVars(pkgNamespace, baseImageURI string) *Complement {
 	if cfg.BaseImageURI == "" {
 		panic("COMPLEMENT_BASE_IMAGE must be set")
 	}
+	// Parse HS specific base images
+	for _, env := range os.Environ() {
+		if hsRegex.MatchString(env) {
+			parts := strings.Split(env, "=")
+			hs := strings.ToLower(strings.TrimPrefix(parts[0], "COMPLEMENT_BASE_IMAGE_"))
+			cfg.BaseImageURIs[hs] = parts[1]
+		}
+	}
+
 	cfg.PackageNamespace = pkgNamespace
 
 	// create CA certs and keys

--- a/internal/docker/builder.go
+++ b/internal/docker/builder.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -22,7 +22,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
-	client "github.com/docker/docker/client"
+	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/docker/go-connections/nat"
 
@@ -354,7 +354,10 @@ func (d *Builder) construct(bprint b.Blueprint) (errs []error) {
 // construct this homeserver and execute its instructions, keeping the container alive.
 func (d *Builder) constructHomeserver(blueprintName string, runner *instruction.Runner, hs b.Homeserver, networkID string) result {
 	contextStr := fmt.Sprintf("%s.%s.%s", d.Config.PackageNamespace, blueprintName, hs.Name)
-	d.log("%s : constructing homeserver...\n", contextStr)
+	baseImageURI := d.Config.BaseImageURIs[hs.Name]
+	hs.BaseImageURI = &baseImageURI
+	d.log("%s : constructing homeserver %s using baseimage %s...\n", contextStr, hs.Name, baseImageURI)
+
 	dep, err := d.deployBaseImage(blueprintName, hs, contextStr, networkID)
 	if err != nil {
 		log.Printf("%s : failed to deployBaseImage: %s\n", contextStr, err)
@@ -386,7 +389,7 @@ func (d *Builder) constructHomeserver(blueprintName string, runner *instruction.
 func (d *Builder) deployBaseImage(blueprintName string, hs b.Homeserver, contextStr, networkID string) (*HomeserverDeployment, error) {
 	asIDToRegistrationMap := asIDToRegistrationFromLabels(labelsForApplicationServices(hs))
 	var baseImageURI string
-	if hs.BaseImageURI == nil {
+	if hs.BaseImageURI == nil || *hs.BaseImageURI == "" {
 		baseImageURI = d.Config.BaseImageURI
 	} else {
 		baseImageURI = *hs.BaseImageURI

--- a/internal/docker/builder.go
+++ b/internal/docker/builder.go
@@ -355,7 +355,6 @@ func (d *Builder) construct(bprint b.Blueprint) (errs []error) {
 func (d *Builder) constructHomeserver(blueprintName string, runner *instruction.Runner, hs b.Homeserver, networkID string) result {
 	contextStr := fmt.Sprintf("%s.%s.%s", d.Config.PackageNamespace, blueprintName, hs.Name)
 	d.log("%s : constructing homeserver...\n", contextStr)
-
 	dep, err := d.deployBaseImage(blueprintName, hs, contextStr, networkID)
 	if err != nil {
 		log.Printf("%s : failed to deployBaseImage: %s\n", contextStr, err)
@@ -387,12 +386,12 @@ func (d *Builder) constructHomeserver(blueprintName string, runner *instruction.
 func (d *Builder) deployBaseImage(blueprintName string, hs b.Homeserver, contextStr, networkID string) (*HomeserverDeployment, error) {
 	asIDToRegistrationMap := asIDToRegistrationFromLabels(labelsForApplicationServices(hs))
 	var baseImageURI string
-	// Use HS specific base image if defined
-	if uri, ok := d.Config.BaseImageURIs[hs.Name]; ok {
-		hs.BaseImageURI = &uri
-	}
 	if hs.BaseImageURI == nil {
 		baseImageURI = d.Config.BaseImageURI
+		// Use HS specific base image if defined
+		if uri, ok := d.Config.BaseImageURIs[hs.Name]; ok {
+			baseImageURI = uri
+		}
 	} else {
 		baseImageURI = *hs.BaseImageURI
 	}

--- a/internal/docker/builder.go
+++ b/internal/docker/builder.go
@@ -354,9 +354,7 @@ func (d *Builder) construct(bprint b.Blueprint) (errs []error) {
 // construct this homeserver and execute its instructions, keeping the container alive.
 func (d *Builder) constructHomeserver(blueprintName string, runner *instruction.Runner, hs b.Homeserver, networkID string) result {
 	contextStr := fmt.Sprintf("%s.%s.%s", d.Config.PackageNamespace, blueprintName, hs.Name)
-	baseImageURI := d.Config.BaseImageURIs[hs.Name]
-	hs.BaseImageURI = &baseImageURI
-	d.log("%s : constructing homeserver %s using baseimage %s...\n", contextStr, hs.Name, baseImageURI)
+	d.log("%s : constructing homeserver...\n", contextStr)
 
 	dep, err := d.deployBaseImage(blueprintName, hs, contextStr, networkID)
 	if err != nil {
@@ -389,7 +387,11 @@ func (d *Builder) constructHomeserver(blueprintName string, runner *instruction.
 func (d *Builder) deployBaseImage(blueprintName string, hs b.Homeserver, contextStr, networkID string) (*HomeserverDeployment, error) {
 	asIDToRegistrationMap := asIDToRegistrationFromLabels(labelsForApplicationServices(hs))
 	var baseImageURI string
-	if hs.BaseImageURI == nil || *hs.BaseImageURI == "" {
+	// Use HS specific base image if defined
+	if uri, ok := d.Config.BaseImageURIs[hs.Name]; ok {
+		hs.BaseImageURI = &uri
+	}
+	if hs.BaseImageURI == nil {
 		baseImageURI = d.Config.BaseImageURI
 	} else {
 		baseImageURI = *hs.BaseImageURI


### PR DESCRIPTION
This adds the ability to define homeserver specific base images using environment variables, allowing us to test e.g. Dendrite <> Synapse or Synapse <> Dendrite federation

The images are defined using e.g. `COMPLEMENT_BASE_IMAGE_HS1=complement-synapse COMPLEMENT_BASE_IMAGE_HS2=complement-dendrite`, where `HS1` and `HS2`  are the homservers as defined by the blueprint. If no HS specific image is defined, falls back to `COMPLEMENT_BASE_IMAGE`.