### PR TITLE
Some changes to calls to Docker API for podman compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,17 @@ If you are using [ufw](https://code.launchpad.net/ufw), this can be done with:
 sudo ufw allow in on br-+
 ```
 
+### Running using Podman
+
+It is possible to run the test suite using Podman and the compatibility layer for Docker API.
+Rootless mode is also supported.
+
+To do so you should:
+- `systemctl --user start podman.service` to start the rootless API daemon (can also be enabled).
+- `DOCKER_HOST=unix://$XDG_RUNTIME_DIR/podman/podman.sock BUILDAH_FORMAT=docker COMPLEMENT_HOSTNAME_RUNNING_COMPLEMENT=host.containers.internal ...`
+
+Docker image format is needed because OCI format doesn't support the HEALTHCHECK directive unfortunately.
+
 ### Running against Dendrite
 
 For instance, for Dendrite:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -78,6 +78,9 @@ type Complement struct {
 	CAPrivateKey  *rsa.PrivateKey
 
 	BestEffort bool
+
+	// The hostname of Complement from the perspective of a Homeserver running inside a container
+	HostnameRunningComplement string
 }
 
 var hsRegex = regexp.MustCompile(`COMPLEMENT_BASE_IMAGE_(.+)=(.+)$`)
@@ -127,6 +130,13 @@ func NewConfigFromEnvVars(pkgNamespace, baseImageURI string) *Complement {
 	}
 	if cfg.PackageNamespace == "" {
 		panic("package namespace must be set")
+	}
+
+	HostnameRunningComplement := os.Getenv("COMPLEMENT_HOSTNAME_RUNNING_COMPLEMENT")
+	if HostnameRunningComplement != "" {
+		cfg.HostnameRunningComplement = HostnameRunningComplement
+	} else {
+		cfg.HostnameRunningComplement = "host.docker.internal"
 	}
 
 	return cfg

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -79,7 +79,11 @@ type Complement struct {
 
 	BestEffort bool
 
-	// The hostname of Complement from the perspective of a Homeserver running inside a container
+	// Name: COMPLEMENT_HOSTNAME_RUNNING_COMPLEMENT
+	// Default: host.docker.internal
+	// Description: The hostname of Complement from the perspective of a Homeserver running inside a container.
+	// This can be useful for container runtimes using another hostname to access the host from a container,
+	// like Podman that uses `host.containers.internal` instead.
 	HostnameRunningComplement string
 }
 

--- a/internal/docker/builder.go
+++ b/internal/docker/builder.go
@@ -406,6 +406,7 @@ func (d *Builder) deployBaseImage(blueprintName string, hs b.Homeserver, context
 	)
 }
 
+// Multilines label using Dockefile syntax is unsupported, let's inline \n instead
 func generateASRegistrationYaml(as b.ApplicationService) string {
 	return fmt.Sprintf("id: %s\\n", as.ID) +
 		fmt.Sprintf("hs_token: %s\\n", as.HSToken) +
@@ -421,8 +422,8 @@ func generateASRegistrationYaml(as b.ApplicationService) string {
 		"  aliases: []\\n"
 }
 
-// createNetworkIfNotExists creates a docker network and returns its id.
-// ID is guaranteed not to be empty when err == nil
+// createNetworkIfNotExists creates a docker network and returns its name.
+// Name is guaranteed not to be empty when err == nil
 func createNetworkIfNotExists(docker *client.Client, pkgNamespace, blueprintName string) (networkName string, err error) {
 	// check if a network already exists for this blueprint
 	nws, err := docker.NetworkList(context.Background(), types.NetworkListOptions{

--- a/internal/docker/builder.go
+++ b/internal/docker/builder.go
@@ -346,8 +346,11 @@ func (d *Builder) construct(bprint b.Blueprint) (errs []error) {
 	return errs
 }
 
+// Convert a map of labels to a list of changes directive in Dockerfile format.
+// Labels keys and values can't be multiline (eg. can't contain `\n` character)
+// neither can they contain unescaped `"` character.
 func toChanges(labels map[string]string) []string {
-	changes := make([]string, 0)
+	var changes []string
 	for k, v := range labels {
 		changes = append(changes, fmt.Sprintf("LABEL \"%s\"=\"%s\"", k, v))
 	}
@@ -406,7 +409,7 @@ func (d *Builder) deployBaseImage(blueprintName string, hs b.Homeserver, context
 	)
 }
 
-// Multilines label using Dockefile syntax is unsupported, let's inline \n instead
+// Multilines label using Dockerfile syntax is unsupported, let's inline \n instead
 func generateASRegistrationYaml(as b.ApplicationService) string {
 	return fmt.Sprintf("id: %s\\n", as.ID) +
 		fmt.Sprintf("hs_token: %s\\n", as.HSToken) +

--- a/internal/docker/builder.go
+++ b/internal/docker/builder.go
@@ -328,10 +328,6 @@ func (d *Builder) construct(bprint b.Blueprint) (errs []error) {
 		// Log again so we can see the timings.
 		d.log("%s: Stopped container: %s", res.contextStr, res.containerID)
 
-		for _, c := range changes {
-			d.log(c)
-		}
-
 		// commit the container
 		commit, err := d.Docker.ContainerCommit(context.Background(), res.containerID, types.ContainerCommitOptions{
 			Author:    "Complement",
@@ -407,18 +403,18 @@ func (d *Builder) deployBaseImage(blueprintName string, hs b.Homeserver, context
 }
 
 func generateASRegistrationYaml(as b.ApplicationService) string {
-	return fmt.Sprintf("id: %s\n", as.ID) +
-		fmt.Sprintf("hs_token: %s\n", as.HSToken) +
-		fmt.Sprintf("as_token: %s\n", as.ASToken) +
-		fmt.Sprintf("url: '%s'\n", as.URL) +
-		fmt.Sprintf("sender_localpart: %s\n", as.SenderLocalpart) +
-		fmt.Sprintf("rate_limited: %v\n", as.RateLimited) +
-		"namespaces:\n" +
-		"  users:\n" +
-		"    - exclusive: false\n" +
-		"      regex: .*\n" +
-		"  rooms: []\n" +
-		"  aliases: []\n"
+	return fmt.Sprintf("id: %s\\n", as.ID) +
+		fmt.Sprintf("hs_token: %s\\n", as.HSToken) +
+		fmt.Sprintf("as_token: %s\\n", as.ASToken) +
+		fmt.Sprintf("url: '%s'\\n", as.URL) +
+		fmt.Sprintf("sender_localpart: %s\\n", as.SenderLocalpart) +
+		fmt.Sprintf("rate_limited: %v\\n", as.RateLimited) +
+		"namespaces:\\n" +
+		"  users:\\n" +
+		"    - exclusive: false\\n" +
+		"      regex: .*\\n" +
+		"  rooms: []\\n" +
+		"  aliases: []\\n"
 }
 
 // createNetworkIfNotExists creates a docker network and returns its id.

--- a/internal/docker/deployer.go
+++ b/internal/docker/deployer.go
@@ -184,19 +184,6 @@ func (d *Deployer) Restart(hsDep *HomeserverDeployment, cfg *config.Complement) 
 		return fmt.Errorf("Restart: Failed to stop container %s: %s", hsDep.ContainerID, err)
 	}
 
-	// Remove the container from the network. If we don't do this,
-	// (re)starting the container fails with an error like
-	// "Error response from daemon: endpoint with name complement_fed_1_fed.alice.hs1_1 already exists in network complement_fed_alice".
-	err = d.Docker.NetworkDisconnect(ctx, d.networkID, hsDep.ContainerID, false)
-	if err != nil {
-		return fmt.Errorf("Restart: Failed to disconnect container %s: %s", hsDep.ContainerID, err)
-	}
-
-	err = d.Docker.ContainerStart(ctx, hsDep.ContainerID, types.ContainerStartOptions{})
-	if err != nil {
-		return fmt.Errorf("Restart: Failed to start container %s: %s", hsDep.ContainerID, err)
-	}
-
 	// Wait for the container to be ready.
 	baseURL, fedBaseURL, err := waitForPorts(ctx, d.Docker, hsDep.ContainerID)
 	if err != nil {

--- a/internal/docker/deployer.go
+++ b/internal/docker/deployer.go
@@ -49,7 +49,6 @@ type Deployer struct {
 	DeployNamespace string
 	Docker          *client.Client
 	Counter         int
-	networkID       string
 	debugLogging    bool
 	config          *config.Complement
 }
@@ -93,11 +92,10 @@ func (d *Deployer) Deploy(ctx context.Context, blueprintName string) (*Deploymen
 	if len(images) == 0 {
 		return nil, fmt.Errorf("Deploy: No images have been built for blueprint %s", blueprintName)
 	}
-	networkID, err := createNetworkIfNotExists(d.Docker, d.config.PackageNamespace, blueprintName)
+	networkName, err := createNetworkIfNotExists(d.Docker, d.config.PackageNamespace, blueprintName)
 	if err != nil {
 		return nil, fmt.Errorf("Deploy: %w", err)
 	}
-	d.networkID = networkID
 
 	// deploy images in parallel
 	var mu sync.Mutex // protects mutable values like the counter and errors
@@ -116,7 +114,7 @@ func (d *Deployer) Deploy(ctx context.Context, blueprintName string) (*Deploymen
 		// TODO: Make CSAPI port configurable
 		deployment, err := deployImage(
 			d.Docker, img.ID, fmt.Sprintf("complement_%s_%s_%s_%d", d.config.PackageNamespace, d.DeployNamespace, contextStr, counter),
-			d.config.PackageNamespace, blueprintName, hsName, asIDToRegistrationMap, contextStr, networkID, d.config,
+			d.config.PackageNamespace, blueprintName, hsName, asIDToRegistrationMap, contextStr, networkName, d.config,
 		)
 		if err != nil {
 			if deployment != nil && deployment.ContainerID != "" {
@@ -208,7 +206,7 @@ func (d *Deployer) Restart(hsDep *HomeserverDeployment, cfg *config.Complement) 
 // nolint
 func deployImage(
 	docker *client.Client, imageID string, containerName, pkgNamespace, blueprintName, hsName string,
-	asIDToRegistrationMap map[string]string, contextStr, networkID string, cfg *config.Complement,
+	asIDToRegistrationMap map[string]string, contextStr, networkName string, cfg *config.Complement,
 ) (*HomeserverDeployment, error) {
 	ctx := context.Background()
 	var extraHosts []string
@@ -275,9 +273,8 @@ func deployImage(
 		Mounts:     mounts,
 	}, &network.NetworkingConfig{
 		EndpointsConfig: map[string]*network.EndpointSettings{
-			"complement_" + pkgNamespace + "_" + blueprintName: {
-				NetworkID: networkID,
-				Aliases:   []string{hsName},
+			networkName: {
+				Aliases: []string{hsName},
 			},
 		},
 	}, nil, containerName)
@@ -290,7 +287,7 @@ func deployImage(
 
 	containerID := body.ID
 	if cfg.DebugLoggingEnabled {
-		log.Printf("%s: Created container '%s' using image '%s' on network '%s'", contextStr, containerID, imageID, networkID)
+		log.Printf("%s: Created container '%s' using image '%s' on network '%s'", contextStr, containerID, imageID, networkName)
 	}
 	stubDeployment := &HomeserverDeployment{
 		ContainerID: containerID,

--- a/internal/docker/deployer.go
+++ b/internal/docker/deployer.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -283,7 +283,7 @@ func deployImage(
 		Mounts:     mounts,
 	}, &network.NetworkingConfig{
 		EndpointsConfig: map[string]*network.EndpointSettings{
-			contextStr: {
+			"complement_" + pkgNamespace + "_" + blueprintName: {
 				NetworkID: networkID,
 				Aliases:   []string{hsName},
 			},

--- a/internal/docker/deployer.go
+++ b/internal/docker/deployer.go
@@ -184,6 +184,11 @@ func (d *Deployer) Restart(hsDep *HomeserverDeployment, cfg *config.Complement) 
 		return fmt.Errorf("Restart: Failed to stop container %s: %s", hsDep.ContainerID, err)
 	}
 
+	err = d.Docker.ContainerStart(ctx, hsDep.ContainerID, types.ContainerStartOptions{})
+	if err != nil {
+		return fmt.Errorf("Restart: Failed to start container %s: %s", hsDep.ContainerID, err)
+	}
+
 	// Wait for the container to be ready.
 	baseURL, fedBaseURL, err := waitForPorts(ctx, d.Docker, hsDep.ContainerID)
 	if err != nil {

--- a/internal/docker/labels.go
+++ b/internal/docker/labels.go
@@ -33,7 +33,8 @@ func asIDToRegistrationFromLabels(labels map[string]string) map[string]string {
 	asMap := make(map[string]string)
 	for k, v := range labels {
 		if strings.HasPrefix(k, "application_service_") {
-			asMap[strings.TrimPrefix(k, "application_service_")] = strings.Replace(v, "\\n", "\n", -1)
+			// cf comment of generateASRegistrationYaml for ReplaceAll explanation
+			asMap[strings.TrimPrefix(k, "application_service_")] = strings.ReplaceAll(v, "\\n", "\n")
 		}
 	}
 	return asMap

--- a/internal/docker/labels.go
+++ b/internal/docker/labels.go
@@ -33,7 +33,7 @@ func asIDToRegistrationFromLabels(labels map[string]string) map[string]string {
 	asMap := make(map[string]string)
 	for k, v := range labels {
 		if strings.HasPrefix(k, "application_service_") {
-			asMap[strings.TrimPrefix(k, "application_service_")] = v
+			asMap[strings.TrimPrefix(k, "application_service_")] = strings.Replace(v, "\\n", "\n", -1)
 		}
 	}
 	return asMap

--- a/internal/federation/server.go
+++ b/internal/federation/server.go
@@ -69,7 +69,7 @@ func NewServer(t *testing.T, deployment *docker.Deployment, opts ...func(*Server
 		mux:   mux.NewRouter(),
 		// The server name will be updated when the caller calls Listen() to include the port number
 		// of the HTTP server e.g "host.docker.internal:56353"
-		serverName:                  docker.HostnameRunningComplement,
+		serverName:                  deployment.Config.HostnameRunningComplement,
 		rooms:                       make(map[string]*ServerRoom),
 		aliases:                     make(map[string]string),
 		UnexpectedRequestsAreErrors: true,
@@ -476,10 +476,10 @@ func federationServer(cfg *config.Complement, h http.Handler) (*http.Server, str
 			Locality:      []string{"London"},
 			StreetAddress: []string{"123 Street"},
 			PostalCode:    []string{"12345"},
-			CommonName:    docker.HostnameRunningComplement,
+			CommonName:    cfg.HostnameRunningComplement,
 		},
 	}
-	host := docker.HostnameRunningComplement
+	host := cfg.HostnameRunningComplement
 	if ip := net.ParseIP(host); ip != nil {
 		template.IPAddresses = append(template.IPAddresses, ip)
 	} else {

--- a/internal/federation/server_test.go
+++ b/internal/federation/server_test.go
@@ -11,8 +11,8 @@ import (
 )
 
 func TestComplementServerIsSigned(t *testing.T) {
-	docker.HostnameRunningComplement = "localhost"
 	cfg := config.NewConfigFromEnvVars("test", "unimportant")
+	cfg.HostnameRunningComplement = "localhost"
 	srv := NewServer(t, &docker.Deployment{
 		Config: cfg,
 	})

--- a/tests/federation_room_join_test.go
+++ b/tests/federation_room_join_test.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/matrix-org/complement/internal/b"
 	"github.com/matrix-org/complement/internal/client"
-	"github.com/matrix-org/complement/internal/docker"
 	"github.com/matrix-org/complement/internal/federation"
 	"github.com/matrix-org/complement/internal/match"
 	"github.com/matrix-org/complement/internal/must"
@@ -157,7 +156,7 @@ func TestJoinFederatedRoomWithUnverifiableEvents(t *testing.T) {
 			},
 		})
 		newSignaturesBlock := map[string]interface{}{
-			docker.HostnameRunningComplement: map[string]string{
+			deployment.Config.HostnameRunningComplement: map[string]string{
 				string(srv.KeyID): "/3z+pJjiJXWhwfqIEzmNksvBHCoXTktK/y0rRuWJXw6i1+ygRG/suDCKhFuuz6gPapRmEMPVILi2mJqHHXPKAg",
 			},
 		}
@@ -186,7 +185,7 @@ func TestJoinFederatedRoomWithUnverifiableEvents(t *testing.T) {
 			},
 		})
 		newSignaturesBlock := map[string]interface{}{
-			docker.HostnameRunningComplement: map[string]string{
+			deployment.Config.HostnameRunningComplement: map[string]string{
 				string(srv.KeyID) + "bogus": "/3z+pJjiJXWhwfqIEzmNksvBHCoXTktK/y0rRuWJXw6i1+ygRG/suDCKhFuuz6gPapRmEMPVILi2mJqHHXPKAg",
 			},
 		}
@@ -216,7 +215,7 @@ func TestJoinFederatedRoomWithUnverifiableEvents(t *testing.T) {
 			},
 		}).JSON()
 		rawSig, err := json.Marshal(map[string]interface{}{
-			docker.HostnameRunningComplement: map[string]string{
+			deployment.Config.HostnameRunningComplement: map[string]string{
 				string(srv.KeyID): "/3z+pJjiJXWhwfqIEzmNksvBHCoXTktK/y0rRuWJXw6i1+ygRG/suDCKhFuuz6gPapRmEMPVILi2mJqHHXPKAg",
 			},
 		})

--- a/tests/federation_room_send_test.go
+++ b/tests/federation_room_send_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/matrix-org/gomatrixserverlib"
 
 	"github.com/matrix-org/complement/internal/b"
-	"github.com/matrix-org/complement/internal/docker"
 	"github.com/matrix-org/complement/internal/federation"
 )
 
@@ -53,7 +52,7 @@ func TestOutboundFederationSend(t *testing.T) {
 	roomAlias := srv.MakeAliasMapping("flibble", serverRoom.RoomID)
 
 	// the local homeserver joins the room
-	alice.JoinRoom(t, roomAlias, []string{docker.HostnameRunningComplement})
+	alice.JoinRoom(t, roomAlias, []string{deployment.Config.HostnameRunningComplement})
 
 	// the local homeserver sends an event into the room
 	alice.SendEventSynced(t, serverRoom.RoomID, b.Event{


### PR DESCRIPTION
- Podman expects the network name specified when launching the container to match the name used when creating it even when the network ID is specified, the API spec is unclear about that
- Adding labels when committing a container needs to use `changes` query parameter instead of a POST json, which is unspecified
- Add a config to specify the hostname where Complement on the host can be reached when inside a container. Podman uses `host.containers.internal`