### PR TITLE
Request review of Kegan for complement internals.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,8 @@
 # Automatically request reviews from the synapse-core and dendrite-core teams when a pull request comes in.
 * @matrix-org/synapse-core @matrix-org/dendrite-core
+
+# For modifications to complement internals, also directly request review from Kegan.
+/build/ @matrix-org/synapse-core @matrix-org/dendrite-core @kegsay
+/cmd/ @matrix-org/synapse-core @matrix-org/dendrite-core @kegsay
+/internal/ @matrix-org/synapse-core @matrix-org/dendrite-core @kegsay
+/runtime/ @matrix-org/synapse-core @matrix-org/dendrite-core @kegsay


### PR DESCRIPTION
See documentation at https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

Weirdly the latest rule is what "matches", so you put more specific rules later in the file.

I figured it made sense to still have the teams as reviewers so that things don't get blocked -- what do you think?