### PR TITLE
Raise synapse test timeout to 20mn

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
           - homeserver: Synapse
             tags: synapse_blacklist msc3083 msc3787 faster_joins
             env: "COMPLEMENT_SHARE_ENV_PREFIX=PASS_ PASS_SYNAPSE_COMPLEMENT_DATABASE=sqlite"
-            timeout: 12m
+            timeout: 20m
 
           - homeserver: Dendrite
             tags: msc2836 dendrite_blacklist


### PR DESCRIPTION
It seems like I can't manage to get a valid CI run in https://github.com/matrix-org/complement/pull/463 because of that.