### PR TITLE
Log received `m.device_list_update` EDUs during faster room joins tests

### DIFF
--- a/tests/federation_room_join_partial_state_test.go
+++ b/tests/federation_room_join_partial_state_test.go
@@ -1531,6 +1531,7 @@ func TestPartialStateJoin(t *testing.T) {
 									t.Fatalf("Received unexpected EDU: %s", e)
 								}
 
+								t.Logf("Complement server received m.device_list_update: %v", string(e.Content))
 								var deviceListUpdate gomatrixserverlib.DeviceListUpdateEvent
 								json.Unmarshal(e.Content, &deviceListUpdate)
 								deviceListUpdateChannel <- deviceListUpdate


### PR DESCRIPTION
One of the outgoing device list update tests is flaking: https://github.com/matrix-org/synapse/issues/13977
Some extra logging would be helpful.

