### PR TITLE
Use a different key ID for each complement server

### DIFF
--- a/internal/federation/server.go
+++ b/internal/federation/server.go
@@ -57,7 +57,7 @@ type Server struct {
 // NewServer creates a new federation server with configured options.
 func NewServer(t *testing.T, deployment *docker.Deployment, opts ...func(*Server)) *Server {
 	// generate signing key
-	_, priv, err := ed25519.GenerateKey(nil)
+	pub, priv, err := ed25519.GenerateKey(nil)
 	if err != nil {
 		t.Fatalf("federation.NewServer failed to generate ed25519 key: %s", err)
 	}
@@ -65,7 +65,7 @@ func NewServer(t *testing.T, deployment *docker.Deployment, opts ...func(*Server
 	srv := &Server{
 		t:     t,
 		Priv:  priv,
-		KeyID: "ed25519:complement",
+		KeyID: gomatrixserverlib.KeyID(fmt.Sprintf("ed25519:complement_%x", pub)),
 		mux:   mux.NewRouter(),
 		// The server name will be updated when the caller calls Listen() to include the port number
 		// of the HTTP server e.g "host.docker.internal:56353"


### PR DESCRIPTION
Some tests may choose to re-use the same homeserver deployment across
multiple test cases, each spinning up different complement servers.
However, when a complement server happens to have the same hostname and
port as a previous one, the homeserver under test may retain cached keys
for the old complement server and reject events from the new one.

Give each complement server a unique key ID to stop that from happening.

---

Thanks to @erikjohnston for suggesting the fix.

Fixes https://github.com/matrix-org/synapse/issues/13975.