### PR TITLE
Faster room joins: Fix bug in `awaitPartialStateJoinCompletion`

### DIFF
--- a/tests/federation_room_join_partial_state_test.go
+++ b/tests/federation_room_join_partial_state_test.go
@@ -121,7 +121,14 @@ func TestPartialStateJoin(t *testing.T) {
 	) {
 		t.Helper()
 
-		user.MustSyncUntil(t, client.SyncReq{}, client.SyncJoinedTo(user.UserID, room.RoomID))
+		// Use a `/members` request to wait for the room to be un-partial stated.
+		// We avoid using `/sync`, as it only waits (or used to wait) for full state at
+		// particular events, rather than the whole room.
+		user.MustDoFunc(
+			t,
+			"GET",
+			[]string{"_matrix", "client", "v3", "rooms", room.RoomID, "members"},
+		)
 		t.Logf("%s's partial state join to %s completed.", user.UserID, room.RoomID)
 	}
 


### PR DESCRIPTION
`/sync` is not a good way to wait for a room to transition to full
state, since it only waits for the full state at particular events
instead of the whole room. This caused flakiness in the "Device list
updates no longer reach departed servers after partial state join
completes" test.

Use `/members` instead to wait for partial state joins to complete.

---

Fixes https://github.com/matrix-org/synapse/issues/13977.