### PR TITLE
Faster room joins: Deflake events-arriving-before-prev_events test

### DIFF
--- a/tests/federation_room_join_partial_state_test.go
+++ b/tests/federation_room_join_partial_state_test.go
@@ -919,8 +919,12 @@ func TestPartialStateJoin(t *testing.T) {
 			i += len(transactionEvents)
 		}
 
-		// wait for the last outlier to arrive
-		awaitEventArrival(t, 10*time.Second, alice, serverRoom.RoomID, outliers[len(outliers)-1].EventID())
+		// wait for the outliers to arrive
+		for i := 0; i < len(outliers); i += 10 {
+			awaitEventArrival(t, 5*time.Second, alice, serverRoom.RoomID, outliers[i].EventID())
+		}
+		// ...and wait for the last outlier to arrive
+		awaitEventArrival(t, 5*time.Second, alice, serverRoom.RoomID, outliers[len(outliers)-1].EventID())
 
 		// release the federation /state response
 		psjResult.FinishStateRequest()


### PR DESCRIPTION
Synapse can take a while to persist 100 outliers. Instead of doing one big wait for the last outlier to be persisted, do some smaller waits for intermediate outliers and a small wait for the last outlier.

ie. as long as the homeserver under test is making progress, we are happy to continue waiting.

Fixes https://github.com/matrix-org/synapse/issues/13777.