### PR TITLE
Fixes/changes for federated invitation tests

### DIFF
--- a/tests/federation_rooms_invite_test.go
+++ b/tests/federation_rooms_invite_test.go
@@ -3,11 +3,12 @@ package tests
 import (
 	"testing"
 
+	"github.com/tidwall/gjson"
+
 	"github.com/matrix-org/complement/internal/b"
 	"github.com/matrix-org/complement/internal/client"
 	"github.com/matrix-org/complement/internal/match"
 	"github.com/matrix-org/complement/internal/must"
-	"github.com/tidwall/gjson"
 )
 
 func TestFederationRoomsInvite(t *testing.T) {
@@ -17,85 +18,80 @@ func TestFederationRoomsInvite(t *testing.T) {
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
 	bob := deployment.Client(t, "hs2", "@bob:hs2")
 
-	t.Run("Parallel", func(t *testing.T) {
-		// sytest: Invited user can reject invite over federation
-		t.Run("Invited user can reject invite over federation", func(t *testing.T) {
-			t.Parallel()
-			roomID := alice.CreateRoom(t, map[string]interface{}{
-				"preset": "private_chat",
-			})
+	roomID := alice.CreateRoom(t, map[string]interface{}{
+		"preset": "private_chat",
+		"name":   "Invites room",
+	})
+
+	aliceSince := ""
+	bobSince := ""
+
+	// sytest: Invited user can reject invite over federation
+	t.Run("Invited user can reject invite over federation", func(t *testing.T) {
+		alice.InviteRoom(t, roomID, bob.UserID)
+		bobSince = bob.MustSyncUntil(t, client.SyncReq{Since: bobSince}, client.SyncInvitedTo(bob.UserID, roomID))
+		bob.LeaveRoom(t, roomID)
+		aliceSince = alice.MustSyncUntil(t, client.SyncReq{Since: aliceSince}, client.SyncLeftFrom(bob.UserID, roomID))
+	})
+
+	// sytest: Invited user can reject invite over federation several times
+	t.Run("Invited user can reject invite over federation several times", func(t *testing.T) {
+		for i := 0; i < 3; i++ {
 			alice.InviteRoom(t, roomID, bob.UserID)
-			bob.MustSyncUntil(t, client.SyncReq{}, client.SyncInvitedTo(bob.UserID, roomID))
+			bobSince = bob.MustSyncUntil(t, client.SyncReq{Since: bobSince}, client.SyncInvitedTo(bob.UserID, roomID))
 			bob.LeaveRoom(t, roomID)
-			alice.MustSyncUntil(t, client.SyncReq{}, client.SyncLeftFrom(bob.UserID, roomID))
-		})
+			aliceSince = alice.MustSyncUntil(t, client.SyncReq{Since: aliceSince}, client.SyncLeftFrom(bob.UserID, roomID))
+		}
+	})
 
-		// sytest: Invited user can reject invite over federation several times
-		t.Run("Invited user can reject invite over federation several times", func(t *testing.T) {
-			t.Parallel()
-			roomID := alice.CreateRoom(t, map[string]interface{}{
-				"preset": "private_chat",
-			})
-			for i := 0; i < 3; i++ {
-				alice.InviteRoom(t, roomID, bob.UserID)
-				bob.MustSyncUntil(t, client.SyncReq{}, client.SyncInvitedTo(bob.UserID, roomID))
-				bob.LeaveRoom(t, roomID)
-				alice.MustSyncUntil(t, client.SyncReq{}, client.SyncLeftFrom(bob.UserID, roomID))
-			}
-		})
+	// sytest: Remote invited user can see room metadata
+	t.Run("Remote invited user can see room metadata", func(t *testing.T) {
+		wantFields := map[string]string{
+			"m.room.join_rules": "join_rule",
+			"m.room.name":       "name",
+		}
+		wantValues := map[string]string{
+			"m.room.join_rules": "invite",
+			"m.room.name":       "Invites room",
+		}
+		alice.InviteRoom(t, roomID, bob.UserID)
+		bob.MustSyncUntil(t, client.SyncReq{Since: bobSince}, client.SyncInvitedTo(bob.UserID, roomID))
+		var res gjson.Result
+		res, bobSince = bob.MustSync(t, client.SyncReq{Since: bobSince})
+		verifyState(t, res, wantFields, wantValues, roomID, alice)
+	})
 
-		// sytest: Invited user can reject invite over federation for empty room
-		t.Run("Invited user can reject invite over federation for empty room", func(t *testing.T) {
-			t.Parallel()
-			roomID := alice.CreateRoom(t, map[string]interface{}{
-				"preset": "private_chat",
-			})
-			aliceSince := alice.MustSyncUntil(t, client.SyncReq{}, client.SyncJoinedTo(alice.UserID, roomID))
-			alice.InviteRoom(t, roomID, bob.UserID)
-			charlieSince := bob.MustSyncUntil(t, client.SyncReq{}, client.SyncInvitedTo(bob.UserID, roomID))
-			alice.LeaveRoom(t, roomID)
-			alice.MustSyncUntil(t, client.SyncReq{Since: aliceSince}, client.SyncLeftFrom(alice.UserID, roomID))
-			bob.LeaveRoom(t, roomID)
-			bob.MustSyncUntil(t, client.SyncReq{Since: charlieSince}, client.SyncLeftFrom(bob.UserID, roomID))
-		})
-
-		// sytest: Remote invited user can see room metadata
-		t.Run("Remote invited user can see room metadata", func(t *testing.T) {
-			t.Parallel()
-			roomID := alice.CreateRoom(t, map[string]interface{}{
-				"preset": "private_chat",
-				"name":   "Invites room",
-			})
-
-			alice.InviteRoom(t, roomID, bob.UserID)
-			bob.MustSyncUntil(t, client.SyncReq{}, client.SyncInvitedTo(bob.UserID, roomID))
-			res, _ := bob.MustSync(t, client.SyncReq{})
-			verifyState(t, res, roomID, alice)
-		})
+	// sytest: Invited user can reject invite over federation for empty room
+	t.Run("Invited user can reject invite over federation for empty room", func(t *testing.T) {
+		alice.InviteRoom(t, roomID, bob.UserID)
+		bobSince = bob.MustSyncUntil(t, client.SyncReq{Since: bobSince}, client.SyncInvitedTo(bob.UserID, roomID))
+		alice.LeaveRoom(t, roomID)
+		alice.MustSyncUntil(t, client.SyncReq{Since: aliceSince}, client.SyncLeftFrom(alice.UserID, roomID))
+		bob.LeaveRoom(t, roomID)
+		bob.MustSyncUntil(t, client.SyncReq{Since: bobSince}, client.SyncLeftFrom(bob.UserID, roomID))
 	})
 }
 
 // verifyState checks that the fields in "wantFields" are present in invite_state.events
-func verifyState(t *testing.T, res gjson.Result, roomID string, cl *client.CSAPI) {
-	wantFields := map[string]string{
-		"m.room.join_rules": "join_rule",
-		"m.room.name":       "name",
+func verifyState(t *testing.T, res gjson.Result, wantFields, wantValues map[string]string, roomID string, cl *client.CSAPI) {
+	inviteEvents := res.Get("rooms.invite." + client.GjsonEscape(roomID) + ".invite_state.events")
+	if !inviteEvents.Exists() {
+		t.Errorf("expected invite events, but they don't exist")
 	}
-
-	for _, event := range res.Get("rooms.invite." + client.GjsonEscape(roomID) + ".invite_state.events").Array() {
+	for _, event := range inviteEvents.Array() {
 		eventType := event.Get("type").Str
 		field, ok := wantFields[eventType]
 		if !ok {
 			continue
 		}
-		eventContent := event.Get("content." + field).Str
+		wantValue := wantValues[eventType]
 		eventStateKey := event.Get("state_key").Str
 
 		res := cl.MustDoFunc(t, "GET", []string{"_matrix", "client", "v3", "rooms", roomID, "state", eventType, eventStateKey})
 
 		must.MatchResponse(t, res, match.HTTPResponse{
 			JSON: []match.JSON{
-				match.JSONKeyEqual(field, eventContent),
+				match.JSONKeyEqual(field, wantValue),
 			},
 		})
 	}

--- a/tests/federation_rooms_invite_test.go
+++ b/tests/federation_rooms_invite_test.go
@@ -34,9 +34,7 @@ func TestFederationRoomsInvite(t *testing.T) {
 		bob.JoinRoom(t, roomID, []string{})
 		queryParams := url.Values{}
 		queryParams.Set("format", "event")
-		bob.Debug = true
 		bobSince = bob.MustSyncUntil(t, client.SyncReq{Since: bobSince}, client.SyncJoinedTo(bob.UserID, roomID))
-		bob.Debug = false
 		// now get the direct flag from the server
 		res := bob.MustDoFunc(t, "GET", []string{"_matrix", "client", "v3", "rooms", roomID, "state", "m.room.member", bob.UserID}, client.WithQueries(queryParams))
 		must.MatchResponse(t, res, match.HTTPResponse{
@@ -47,6 +45,7 @@ func TestFederationRoomsInvite(t *testing.T) {
 		})
 		// leave again,
 		bob.LeaveRoom(t, roomID)
+		bobSince = bob.MustSyncUntil(t, client.SyncReq{Since: bobSince}, client.SyncLeftFrom(bob.UserID, roomID))
 		aliceSince = alice.MustSyncUntil(t, client.SyncReq{Since: aliceSince}, client.SyncLeftFrom(bob.UserID, roomID))
 	})
 


### PR DESCRIPTION
Fixes a bug in `verifyState` where we'd compare the expected content with the event itself..
Adds a test that `is_direct` is set in `unsigned.prev_content`, as clients otherwise might not be able to distinguish between DMs and normal rooms.