### PR TITLE
Ignore more /_synapse tests

### DIFF
--- a/sytest.ignored.list
+++ b/sytest.ignored.list
@@ -6,6 +6,10 @@ foo
 
 # Tests synapse admin API
 Can quarantine media in rooms
+/purge_history
+/purge_history by ts
+Shutdown room
+Can backfill purged history
 
 # Tests deprecated endpoints
 Tags appear in the v1 /initialSync


### PR DESCRIPTION
This adds tests from `48admin` which use the `/_synapse` api.

The reason `48admin` wasnt added completely is because `/whois` (a test in 48admin) doesnt use synapse admin apis.