### PR TITLE
Ignore "Checking local federation server" sytest

### DIFF
--- a/sytest.ignored.list
+++ b/sytest.ignored.list
@@ -3,6 +3,7 @@
 
 # Dummy test in 00prepare.pl
 foo
+Checking local federation server
 
 # Tests synapse admin API
 Can quarantine media in rooms


### PR DESCRIPTION
...as this "test" is just a self-check, which we should already be doing in other parts of complement, so this is not an migratable test.