### PR TITLE
Sytest: Add `50federation` / `02server-names` & `10query-profile` remaining tests

### DIFF
--- a/internal/federation/server.go
+++ b/internal/federation/server.go
@@ -243,9 +243,40 @@ func (s *Server) SendFederationRequest(
 	if httpError, ok := err.(gomatrix.HTTPError); ok {
 		t.Logf("[SSAPI] %s %s%s => error(%d): %s (%s)", req.Method(), req.Destination(), req.RequestURI(), httpError.Code, err, time.Since(start))
 	} else if err == nil {
-		t.Logf("[SSAPI] %s %s%s => 2xx (%s)", req.Method(), req.Destination(), req.RequestURI(), time.Since(start))
+		t.Logf("[SSAPI] %s %s%s => (%s)", req.Method(), req.Destination(), req.RequestURI(), time.Since(start))
 	}
 	return err
+}
+
+// DoFederationRequest signs and sends an arbitrary federation request from this server, and returns the response.
+//
+// The requests will be routed according to the deployment map in `deployment`.
+func (s *Server) DoFederationRequest(
+	ctx context.Context,
+	t *testing.T,
+	deployment *docker.Deployment,
+	req gomatrixserverlib.FederationRequest) (*http.Response, error) {
+	if err := req.Sign(gomatrixserverlib.ServerName(s.serverName), s.KeyID, s.Priv); err != nil {
+		return nil, err
+	}
+
+	httpReq, err := req.HTTPRequest()
+	if err != nil {
+		return nil, err
+	}
+
+	httpClient := gomatrixserverlib.NewClient(gomatrixserverlib.WithTransport(&docker.RoundTripper{Deployment: deployment}))
+	start := time.Now()
+
+	var resp *http.Response
+	resp, err = httpClient.DoHTTPRequest(ctx, httpReq)
+
+	if httpError, ok := err.(gomatrix.HTTPError); ok {
+		t.Logf("[SSAPI] %s %s%s => error(%d): %s (%s)", req.Method(), req.Destination(), req.RequestURI(), httpError.Code, err, time.Since(start))
+	} else if err == nil {
+		t.Logf("[SSAPI] %s %s%s => %d (%s)", req.Method(), req.Destination(), req.RequestURI(), resp.StatusCode, time.Since(start))
+	}
+	return resp, err
 }
 
 // MustCreateEvent will create and sign a new latest event for the given room.

--- a/internal/federation/server.go
+++ b/internal/federation/server.go
@@ -243,7 +243,7 @@ func (s *Server) SendFederationRequest(
 	if httpError, ok := err.(gomatrix.HTTPError); ok {
 		t.Logf("[SSAPI] %s %s%s => error(%d): %s (%s)", req.Method(), req.Destination(), req.RequestURI(), httpError.Code, err, time.Since(start))
 	} else if err == nil {
-		t.Logf("[SSAPI] %s %s%s => (%s)", req.Method(), req.Destination(), req.RequestURI(), time.Since(start))
+		t.Logf("[SSAPI] %s %s%s => 2xx (%s)", req.Method(), req.Destination(), req.RequestURI(), time.Since(start))
 	}
 	return err
 }


### PR DESCRIPTION
This adds two sytests:
- `./tests/50federation/02server-names.pl:test "Non-numeric ports in server names are rejected",`
- `./tests/50federation/10query-profile.pl:test "Inbound federation can query profile data",`

This also adds one generic function, `(*federation.Server).DoFederationRequest`, as a counterpart to `SendFederationRequest`, though with the only difference being that it returns the response instead of trying to JSON-deserialise it.

Note: This function is largely a copy of `SendFederationRequest`, I tried to figure out how I can dedup them into one function, but seeing as they both use different functions from the HTTP Client object, it's probably not possible without having it pass a `func(*gomatrixserverlib.Client)` or likewise to a third internal function.