### PR TITLE
Sytest: Add `30rooms/20typing` tests

### DIFF
--- a/tests/csapi/room_typing_test.go
+++ b/tests/csapi/room_typing_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/matrix-org/complement/internal/b"
 	"github.com/matrix-org/complement/internal/client"
+	"github.com/matrix-org/complement/internal/must"
 )
 
 // sytest: PUT /rooms/:room_id/typing/:user_id sets typing notification
@@ -28,15 +29,43 @@ func TestTyping(t *testing.T) {
 		"timeout": 10000,
 	}))
 
-	bob.MustSyncUntil(t, client.SyncReq{Since: token}, client.SyncEphemeralHas(roomID, func(result gjson.Result) bool {
-		if result.Get("type").Str != "m.typing" {
-			return false
-		}
-		for _, item := range result.Get("content").Get("user_ids").Array() {
-			if item.Str == alice.UserID {
-				return true
+	// sytest: Typing notification sent to local room members
+	t.Run("Typing notification sent to local room members", func(t *testing.T) {
+		var usersSeenTyping []interface{}
+
+		bob.MustSyncUntil(t, client.SyncReq{Since: token}, client.SyncEphemeralHas(roomID, func(result gjson.Result) bool {
+			if result.Get("type").Str != "m.typing" {
+				return false
 			}
-		}
-		return false
-	}))
+
+			var res = false
+
+			for _, item := range result.Get("content").Get("user_ids").Array() {
+				usersSeenTyping = append(usersSeenTyping, item.Str)
+
+				if item.Str == alice.UserID {
+					res = true
+				}
+			}
+
+			return res
+		}))
+
+		must.CheckOffAll(t, usersSeenTyping, []interface{}{alice.UserID})
+	})
+
+	// sytest: Typing can be explicitly stopped
+	t.Run("Typing can be explicitly stopped", func(t *testing.T) {
+		alice.MustDoFunc(t, "PUT", []string{"_matrix", "client", "v3", "rooms", roomID, "typing", alice.UserID}, client.WithJSONBody(t, map[string]interface{}{
+			"typing": false,
+		}))
+
+		bob.MustSyncUntil(t, client.SyncReq{Since: token}, client.SyncEphemeralHas(roomID, func(result gjson.Result) bool {
+			if result.Get("type").Str != "m.typing" {
+				return false
+			}
+
+			return len(result.Get("content").Get("user_ids").Array()) == 0
+		}))
+	})
 }

--- a/tests/federation_room_typing_test.go
+++ b/tests/federation_room_typing_test.go
@@ -1,0 +1,51 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/tidwall/gjson"
+
+	"github.com/matrix-org/complement/internal/b"
+	"github.com/matrix-org/complement/internal/client"
+)
+
+func awaitTyping(userId string) func(result gjson.Result) bool {
+	return func(result gjson.Result) bool {
+		if result.Get("type").Str != "m.typing" {
+			return false
+		}
+
+		for _, item := range result.Get("content").Get("user_ids").Array() {
+			if item.Str == userId {
+				return true
+			}
+		}
+
+		return false
+	}
+}
+
+func TestRemoteTyping(t *testing.T) {
+	deployment := Deploy(t, b.BlueprintFederationTwoLocalOneRemote)
+	defer deployment.Destroy(t)
+
+	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	bob := deployment.Client(t, "hs1", "@bob:hs1")
+	charlie := deployment.Client(t, "hs2", "@charlie:hs2")
+
+	roomID := alice.CreateRoom(t, map[string]interface{}{"preset": "public_chat"})
+	bob.JoinRoom(t, roomID, nil)
+	charlie.JoinRoom(t, roomID, []string{"hs1"})
+
+	bobToken := bob.MustSyncUntil(t, client.SyncReq{}, client.SyncJoinedTo(bob.UserID, roomID))
+	charlieToken := charlie.MustSyncUntil(t, client.SyncReq{}, client.SyncJoinedTo(charlie.UserID, roomID))
+
+	alice.MustDoFunc(t, "PUT", []string{"_matrix", "client", "v3", "rooms", roomID, "typing", alice.UserID}, client.WithJSONBody(t, map[string]interface{}{
+		"typing":  true,
+		"timeout": 10000,
+	}))
+
+	bob.MustSyncUntil(t, client.SyncReq{Since: bobToken}, client.SyncEphemeralHas(roomID, awaitTyping(alice.UserID)))
+
+	charlie.MustSyncUntil(t, client.SyncReq{Since: charlieToken}, client.SyncEphemeralHas(roomID, awaitTyping(alice.UserID)))
+}


### PR DESCRIPTION
This adds three sytests:
- `./tests/30rooms/20typing.pl:test "Typing can be explicitly stopped",`
- `./tests/30rooms/20typing.pl:test "Typing notifications also sent to remote room members",`
- `./tests/30rooms/20typing.pl:test "Typing notification sent to local room members",`