### PR TITLE
Sytest: Add `30rooms/22profile` test

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -741,29 +741,41 @@ func SyncInvitedTo(userID, roomID string) SyncCheckOpt {
 	}
 }
 
-// Check that `userID` gets joined to `roomID` by inspecting the join timeline for a membership event
-func SyncJoinedTo(userID, roomID string) SyncCheckOpt {
+// Check that `userID` gets joined to `roomID` by inspecting the join timeline for a membership event.
+//
+// Additional checks can be passed to narrow down the check, all must pass.
+func SyncJoinedTo(userID, roomID string, checks ...func(gjson.Result) bool) SyncCheckOpt {
 	checkJoined := func(ev gjson.Result) bool {
-		return ev.Get("type").Str == "m.room.member" && ev.Get("state_key").Str == userID && ev.Get("content.membership").Str == "join"
+		if ev.Get("type").Str == "m.room.member" && ev.Get("state_key").Str == userID && ev.Get("content.membership").Str == "join" {
+			for _, check := range checks {
+				if !check(ev) {
+					// short-circuit, bail early
+					return false
+				}
+			}
+			// passed both basic join check and all other checks
+			return true
+		}
+		return false
 	}
 	return func(clientUserID string, topLevelSyncJSON gjson.Result) error {
 		// Check both the timeline and the state events for the join event
 		// since on initial sync, the state events may only be in
 		// <room>.state.events.
-		err := loopArray(
+		firstErr := loopArray(
 			topLevelSyncJSON, "rooms.join."+GjsonEscape(roomID)+".timeline.events", checkJoined,
 		)
-		if err == nil {
+		if firstErr == nil {
 			return nil
 		}
 
-		err = loopArray(
+		secondErr := loopArray(
 			topLevelSyncJSON, "rooms.join."+GjsonEscape(roomID)+".state.events", checkJoined,
 		)
-		if err == nil {
+		if secondErr == nil {
 			return nil
 		}
-		return fmt.Errorf("SyncJoinedTo(%s): %s", roomID, err)
+		return fmt.Errorf("SyncJoinedTo(%s): %s & %s", roomID, firstErr, secondErr)
 	}
 }
 

--- a/tests/csapi/room_profile_test.go
+++ b/tests/csapi/room_profile_test.go
@@ -1,0 +1,47 @@
+package csapi_tests
+
+import (
+	"testing"
+
+	"github.com/tidwall/gjson"
+
+	"github.com/matrix-org/complement/internal/b"
+	"github.com/matrix-org/complement/internal/client"
+)
+
+func TestAvatarUrlUpdate(t *testing.T) {
+	testProfileFieldUpdate(t, "avatar_url")
+}
+
+func TestDisplayNameUpdate(t *testing.T) {
+	testProfileFieldUpdate(t, "displayname")
+}
+
+// sytest: $datum updates affect room member events
+func testProfileFieldUpdate(t *testing.T, field string) {
+	deployment := Deploy(t, b.BlueprintAlice)
+	defer deployment.Destroy(t)
+
+	const bogusData = "LemurLover"
+
+	alice := deployment.Client(t, "hs1", "@alice:hs1")
+
+	roomID := alice.CreateRoom(t, map[string]interface{}{
+		"preset": "public_chat",
+	})
+
+	sinceToken := alice.MustSyncUntil(t, client.SyncReq{}, client.SyncJoinedTo(alice.UserID, roomID))
+
+	alice.MustDoFunc(
+		t,
+		"PUT",
+		[]string{"_matrix", "client", "v3", "profile", alice.UserID, field},
+		client.WithJSONBody(t, map[string]interface{}{
+			field: bogusData,
+		}),
+	)
+
+	alice.MustSyncUntil(t, client.SyncReq{Since: sinceToken}, client.SyncJoinedTo(alice.UserID, roomID, func(result gjson.Result) bool {
+		return result.Get("content."+field).Str == bogusData
+	}))
+}


### PR DESCRIPTION
This adds one sytest:
- `./tests/30rooms/22profile.pl:   test "$datum updates affect room member events",`

This also alters `SyncJoinedTo` in a backwards-compatible way to receive additional check functions, to check on the event of the join, this could be useful for things like restricted room joins, or - in this case - checking changed membership profile data.