### PR TITLE
Add sytest-coverage debug flag

### DIFF
--- a/cmd/sytest-coverage/main.go
+++ b/cmd/sytest-coverage/main.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"go/parser"
 	"go/token"
@@ -23,11 +24,23 @@ var (
 	testFilenameRegexp = regexp.MustCompile(`/tests/(.*)\.pl`)
 )
 
+var debug bool
+var verbose bool
+
+func init() {
+	debugFlag := flag.Bool("d", false, "debug mode")
+	verboseFlag := flag.Bool("v", false, "verbose mode")
+
+	flag.Parse()
+
+	debug = *debugFlag
+	verbose = *verboseFlag
+}
+
 // Maps test names to filenames then looks for:
 //   sytest: $test_name
 // in all files in ./tests - if there's a match it marks that test as converted.
 func main() {
-	verbose := len(os.Args) == 2 && os.Args[1] == "-v"
 
 	filenameToTestName, testNameToFilename := getList()
 
@@ -53,6 +66,9 @@ func main() {
 			for _, line := range lines {
 				_, ok := testNameToFilename[line]
 				if !ok {
+					if debug && strings.Contains(line, "sytest:") {
+						fmt.Printf("Found unrecognised sytest marker in %s: %v\n", path, line)
+					}
 					continue
 				}
 				convertedTests[line] = true

--- a/sytest.ignored.list
+++ b/sytest.ignored.list
@@ -35,7 +35,6 @@ Room initialSync
 Room initialSync with limit=0 gives no messages
 Read receipts are visible to /initialSync
 Newly created users see their own presence in /initialSync (SYT-34)
-Push rules come down in an initial /sync
 Guest user calling /events doesn't tightloop
 Guest user cannot call /events globally
 !53groups


### PR DESCRIPTION
This:
- Adds a debug (`-d`) flag to `sytest-coverage`, to print unrecognised `"sytest: "`-containing comment lines.
  - This is useful for when we update the sytest.list, and tests are removed that were previously added to complement.
  - Or, when `"sytest: "`-containing lines are shuffled around or slightly edited, to catch those.
- Removes `Push rules come down in an initial /sync` from the ignored sytest list.
  - This test was present in the codebase, and after looking at the corresponding sytest, it seems to have been included by accident in the past, simply due to the wording of the test, and not an introspective of if the test uses deprecated endpoints or not.

Internally:
- This moves over the manual flag recognition to golang `flag`-based handling, which would do a lot of boilerplate for us.