### PR TITLE
Fix local members presence test

### DIFF
--- a/tests/csapi/rooms_members_local_test.go
+++ b/tests/csapi/rooms_members_local_test.go
@@ -13,7 +13,24 @@ import (
 )
 
 func TestMembersLocal(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := Deploy(t, b.MustValidate(b.Blueprint{
+		Name: "ab",
+		Homeservers: []b.Homeserver{
+			{
+				Name: "hs1",
+				Users: []b.User{
+					{
+						Localpart:   "@alice",
+						DisplayName: "Alice",
+					},
+					{
+						Localpart:   "@bob",
+						DisplayName: "Bob",
+					},
+				},
+			},
+		},
+	}))
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
@@ -53,7 +70,6 @@ func TestMembersLocal(t *testing.T) {
 
 		// sytest: Existing members see new members' presence
 		t.Run("Existing members see new members' presence", func(t *testing.T) {
-			runtime.SkipIf(t, runtime.Dendrite) // Still failing
 			t.Parallel()
 			alice.MustSyncUntil(t, client.SyncReq{Since: sinceToken},
 				client.SyncJoinedTo(bob.UserID, roomID),

--- a/tests/csapi/rooms_members_local_test.go
+++ b/tests/csapi/rooms_members_local_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/matrix-org/complement/internal/b"
 	"github.com/matrix-org/complement/internal/client"
+	"github.com/matrix-org/complement/internal/match"
+	"github.com/matrix-org/complement/internal/must"
 	"github.com/matrix-org/complement/runtime"
 	"github.com/tidwall/gjson"
 )
@@ -17,6 +19,18 @@ func TestMembersLocal(t *testing.T) {
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
 	bob := deployment.Client(t, "hs1", "@bob:hs1")
 	roomID := alice.CreateRoom(t, map[string]interface{}{"preset": "public_chat"})
+
+	res := bob.DoFunc(
+		t,
+		"PUT",
+		[]string{"_matrix", "client", "v3", "presence", bob.UserID, "status"},
+		client.WithJSONBody(t, map[string]interface{}{
+			"presence": "online",
+		}),
+	)
+	must.MatchResponse(t, res, match.HTTPResponse{
+		StatusCode: 200,
+	})
 
 	_, sinceToken := alice.MustSync(t, client.SyncReq{TimeoutMillis: "0"})
 

--- a/tests/csapi/rooms_members_local_test.go
+++ b/tests/csapi/rooms_members_local_test.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/tidwall/gjson"
+
 	"github.com/matrix-org/complement/internal/b"
 	"github.com/matrix-org/complement/internal/client"
 	"github.com/matrix-org/complement/internal/match"
 	"github.com/matrix-org/complement/internal/must"
-	"github.com/matrix-org/complement/runtime"
-	"github.com/tidwall/gjson"
 )
 
 func TestMembersLocal(t *testing.T) {


### PR DESCRIPTION
This makes it able to be ran in isolation, and fixes it for dendrite test failures, as https://github.com/matrix-org/dendrite/issues/2803 is fixed.

Fixes https://github.com/matrix-org/complement/issues/515