### PR TITLE
Do once-over on all `SkipIf`s in codebase, adding issue numbers, un-skipping passing tests

### DIFF
--- a/tests/csapi/apidoc_room_state_test.go
+++ b/tests/csapi/apidoc_room_state_test.go
@@ -330,7 +330,6 @@ func TestRoomState(t *testing.T) {
 			})
 		})
 		t.Run("GET /rooms/:room_id/joined_members is forbidden after leaving room", func(t *testing.T) {
-			runtime.SkipIf(t, runtime.Dendrite) // FIXME: https://github.com/matrix-org/dendrite/issues/2802
 			t.Parallel()
 			roomID := authedClient.CreateRoom(t, map[string]interface{}{})
 			authedClient.LeaveRoom(t, roomID)

--- a/tests/csapi/apidoc_room_state_test.go
+++ b/tests/csapi/apidoc_room_state_test.go
@@ -330,7 +330,7 @@ func TestRoomState(t *testing.T) {
 			})
 		})
 		t.Run("GET /rooms/:room_id/joined_members is forbidden after leaving room", func(t *testing.T) {
-			runtime.SkipIf(t, runtime.Dendrite) // https://github.com/matrix-org/complement/pull/424
+			runtime.SkipIf(t, runtime.Dendrite) // FIXME: https://github.com/matrix-org/dendrite/issues/2802
 			t.Parallel()
 			roomID := authedClient.CreateRoom(t, map[string]interface{}{})
 			authedClient.LeaveRoom(t, roomID)

--- a/tests/csapi/apidoc_room_state_test.go
+++ b/tests/csapi/apidoc_room_state_test.go
@@ -1,6 +1,7 @@
 package csapi_tests
 
 import (
+	"net/http"
 	"net/url"
 	"testing"
 	"time"
@@ -11,9 +12,6 @@ import (
 	"github.com/matrix-org/complement/internal/client"
 	"github.com/matrix-org/complement/internal/match"
 	"github.com/matrix-org/complement/internal/must"
-	"github.com/matrix-org/complement/runtime"
-
-	"net/http"
 )
 
 func TestRoomState(t *testing.T) {

--- a/tests/csapi/device_lists_test.go
+++ b/tests/csapi/device_lists_test.go
@@ -328,7 +328,7 @@ func TestDeviceListUpdates(t *testing.T) {
 	t.Run("when remote user leaves a room", func(t *testing.T) { testOtherUserLeave(t, deployment, "hs1", "hs2") })
 	t.Run("when leaving a room with a local user", func(t *testing.T) { testLeave(t, deployment, "hs1", "hs1") })
 	t.Run("when leaving a room with a remote user", func(t *testing.T) {
-		runtime.SkipIf(t, runtime.Synapse) // https://github.com/matrix-org/synapse/issues/13650
+		runtime.SkipIf(t, runtime.Synapse) // FIXME: https://github.com/matrix-org/synapse/issues/13650
 		testLeave(t, deployment, "hs1", "hs2")
 	})
 	t.Run("when local user rejoins a room", func(t *testing.T) { testOtherUserRejoin(t, deployment, "hs1", "hs1") })

--- a/tests/csapi/invalid_test.go
+++ b/tests/csapi/invalid_test.go
@@ -168,7 +168,7 @@ func getFilters() []map[string]interface{} {
 
 // sytest: Check creating invalid filters returns 4xx
 func TestFilter(t *testing.T) {
-	runtime.SkipIf(t, runtime.Dendrite) // TODO remove if https://github.com/matrix-org/dendrite/issues/2067 is fixed
+	runtime.SkipIf(t, runtime.Dendrite) // FIXME: https://github.com/matrix-org/dendrite/issues/2067
 
 	deployment := Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)

--- a/tests/csapi/push_test.go
+++ b/tests/csapi/push_test.go
@@ -11,14 +11,10 @@ import (
 	"github.com/matrix-org/complement/internal/client"
 	"github.com/matrix-org/complement/internal/match"
 	"github.com/matrix-org/complement/internal/must"
-	"github.com/matrix-org/complement/runtime"
 )
 
-// @shadowjonathan: do we need this test anymore?
 // sytest: Getting push rules doesn't corrupt the cache SYN-390
 func TestPushRuleCacheHealth(t *testing.T) {
-	runtime.SkipIf(t, runtime.Dendrite) // Dendrite does not support push notifications (yet)
-
 	deployment := Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 

--- a/tests/csapi/room_relations_test.go
+++ b/tests/csapi/room_relations_test.go
@@ -12,11 +12,9 @@ import (
 	"github.com/matrix-org/complement/internal/client"
 	"github.com/matrix-org/complement/internal/match"
 	"github.com/matrix-org/complement/internal/must"
-	"github.com/matrix-org/complement/runtime"
 )
 
 func TestRelations(t *testing.T) {
-	runtime.SkipIf(t, runtime.Dendrite) // not supported
 	deployment := Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
@@ -112,7 +110,6 @@ func TestRelations(t *testing.T) {
 }
 
 func TestRelationsPagination(t *testing.T) {
-	runtime.SkipIf(t, runtime.Dendrite) // not supported
 	deployment := Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 

--- a/tests/csapi/rooms_members_local_test.go
+++ b/tests/csapi/rooms_members_local_test.go
@@ -36,7 +36,7 @@ func TestMembersLocal(t *testing.T) {
 
 		// sytest: Existing members see new members' presence
 		t.Run("Existing members see new members' presence", func(t *testing.T) {
-			runtime.SkipIf(t, runtime.Dendrite) // Still failing
+			runtime.SkipIf(t, runtime.Dendrite) // FIXME: https://github.com/matrix-org/dendrite/issues/2803
 			t.Parallel()
 			alice.MustSyncUntil(t, client.SyncReq{},
 				client.SyncJoinedTo(bob.UserID, roomID),

--- a/tests/csapi/sync_test.go
+++ b/tests/csapi/sync_test.go
@@ -102,7 +102,7 @@ func TestTentativeEventualJoiningAfterRejecting(t *testing.T) {
 }
 
 func TestSync(t *testing.T) {
-	runtime.SkipIf(t, runtime.Dendrite) // too flakey, fails with sync_test.go:135: unchanged room !7ciB69Jg2lCc4Vdf:hs1 should not be in the sync
+	runtime.SkipIf(t, runtime.Dendrite) // FIXME: https://github.com/matrix-org/dendrite/issues/1324
 	// sytest: Can sync
 	deployment := Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
@@ -162,7 +162,7 @@ func TestSync(t *testing.T) {
 		})
 		// sytest: Newly joined room has correct timeline in incremental sync
 		t.Run("Newly joined room has correct timeline in incremental sync", func(t *testing.T) {
-			runtime.SkipIf(t, runtime.Dendrite) // does not yet pass
+			runtime.SkipIf(t, runtime.Dendrite) // FIXME: https://github.com/matrix-org/dendrite/issues/1324
 			t.Parallel()
 			filter = map[string]interface{}{
 				"room": map[string]interface{}{
@@ -211,7 +211,7 @@ func TestSync(t *testing.T) {
 		})
 		// sytest: Newly joined room includes presence in incremental sync
 		t.Run("Newly joined room includes presence in incremental sync", func(t *testing.T) {
-			runtime.SkipIf(t, runtime.Dendrite) // does not yet pass
+			runtime.SkipIf(t, runtime.Dendrite) // FIXME: https://github.com/matrix-org/dendrite/issues/1324
 			roomID := alice.CreateRoom(t, map[string]interface{}{"preset": "public_chat"})
 			alice.MustSyncUntil(t, client.SyncReq{}, client.SyncJoinedTo(alice.UserID, roomID))
 			_, nextBatch := bob.MustSync(t, client.SyncReq{})
@@ -231,7 +231,7 @@ func TestSync(t *testing.T) {
 		})
 		// sytest: Get presence for newly joined members in incremental sync
 		t.Run("Get presence for newly joined members in incremental sync", func(t *testing.T) {
-			runtime.SkipIf(t, runtime.Dendrite) // does not yet pass
+			runtime.SkipIf(t, runtime.Dendrite) // FIXME: https://github.com/matrix-org/dendrite/issues/1324
 			roomID := alice.CreateRoom(t, map[string]interface{}{"preset": "public_chat"})
 			nextBatch := alice.MustSyncUntil(t, client.SyncReq{}, client.SyncJoinedTo(alice.UserID, roomID))
 			sendMessages(t, alice, roomID, "dummy message", 1)

--- a/tests/csapi/upload_keys_test.go
+++ b/tests/csapi/upload_keys_test.go
@@ -54,7 +54,7 @@ func TestUploadKey(t *testing.T) {
 
 		// sytest: Rejects invalid device keys
 		t.Run("Rejects invalid device keys", func(t *testing.T) {
-			runtime.SkipIf(t, runtime.Dendrite, runtime.Synapse) // Dendrite doesn't pass, Synapse has it blacklisted
+			runtime.SkipIf(t, runtime.Dendrite, runtime.Synapse) // Blacklisted on Synapse, Dendrite FIXME: https://github.com/matrix-org/dendrite/issues/2804
 			t.Parallel()
 			// algorithms, keys and signatures are required fields, but missing
 			reqBody := client.WithJSONBody(t, map[string]interface{}{

--- a/tests/federation_room_ban_test.go
+++ b/tests/federation_room_ban_test.go
@@ -12,7 +12,7 @@ import (
 // Create a federation room. Bob bans Alice. Bob unbans Alice. Bob invites Alice (unbanning her). Ensure the invite is
 // received and can be accepted.
 func TestUnbanViaInvite(t *testing.T) {
-	runtime.SkipIf(t, runtime.Synapse) // https://github.com/matrix-org/synapse/issues/1563
+	runtime.SkipIf(t, runtime.Synapse) // FIXME: https://github.com/matrix-org/synapse/issues/1563
 	deployment := Deploy(t, b.BlueprintFederationOneToOneRoom)
 	defer deployment.Destroy(t)
 

--- a/tests/federation_room_join_test.go
+++ b/tests/federation_room_join_test.go
@@ -200,7 +200,10 @@ func TestJoinFederatedRoomWithUnverifiableEvents(t *testing.T) {
 		alice.JoinRoom(t, roomAlias, nil)
 	})
 	t.Run("/send_join response with state with unverifiable auth events shouldn't block room join", func(t *testing.T) {
-		runtime.SkipIf(t, runtime.Dendrite) // https://github.com/matrix-org/dendrite/issues/2028
+		// FIXME: https://github.com/matrix-org/dendrite/issues/2800
+		//  (previously https://github.com/matrix-org/dendrite/issues/2028)
+		runtime.SkipIf(t, runtime.Dendrite)
+
 		room := srv.MustMakeRoom(t, ver, federation.InitialRoomEvents(ver, charlie))
 		roomAlias := srv.MakeAliasMapping("UnverifiableAuthEvents", room.RoomID)
 
@@ -528,7 +531,9 @@ func typeAndStateKeyForEvent(result gjson.Result) string {
 }
 
 func TestJoinFederatedRoomFromApplicationServiceBridgeUser(t *testing.T) {
-	runtime.SkipIf(t, runtime.Dendrite) // Dendrite doesn't read AS registration files from Complement yet
+	// Dendrite doesn't read AS registration files from Complement yet
+	runtime.SkipIf(t, runtime.Dendrite) // FIXME: https://github.com/matrix-org/complement/issues/514
+
 	deployment := Deploy(t, b.BlueprintHSWithApplicationService)
 	defer deployment.Destroy(t)
 

--- a/tests/restricted_rooms_test.go
+++ b/tests/restricted_rooms_test.go
@@ -225,7 +225,7 @@ func TestRestrictedRoomsRemoteJoinLocalUser(t *testing.T) {
 }
 
 func doTestRestrictedRoomsRemoteJoinLocalUser(t *testing.T, roomVersion string, joinRule string) {
-	runtime.SkipIf(t, runtime.Dendrite) // requires more debugging
+	runtime.SkipIf(t, runtime.Dendrite) // FIXME: https://github.com/matrix-org/dendrite/issues/2801
 
 	deployment := Deploy(t, b.BlueprintFederationTwoLocalOneRemote)
 	defer deployment.Destroy(t)
@@ -352,7 +352,7 @@ func TestRestrictedRoomsRemoteJoinFailOver(t *testing.T) {
 }
 
 func doTestRestrictedRoomsRemoteJoinFailOver(t *testing.T, roomVersion string, joinRule string) {
-	runtime.SkipIf(t, runtime.Dendrite) // requires more debugging
+	runtime.SkipIf(t, runtime.Dendrite) // FIXME: https://github.com/matrix-org/dendrite/issues/2801
 
 	deployment := Deploy(t, b.Blueprint{
 		Name: "federation_three_homeservers",


### PR DESCRIPTION
Seeing as almost all SkipIfs in complement are due to the fact the originating homeservers do not implement the functionality, I did a once-over to check all of them, and paired them with those issues, and standardized the format of `SkipIf` comments along the way.

Like this, the intended way how to skip a test on a homeserver then always comes paired with an issue to watch or resolve to remove that skip, else these skips would bitrot and the related tests aren't executed, potentially hiding non-compliant behaviour.

Furthermore, some tests *did* pass inbetween then and now, those skips have been removed.