### PR TITLE
Add "Test URL preview" sytest and basic webserver creation

### DIFF
--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -13,12 +13,13 @@ import (
 )
 
 type Server struct {
-	Port     int
+	Url      string
+	port     int
 	server   *http.Server
 	listener net.Listener
 }
 
-func NewServer(t *testing.T, configFunc func(router *mux.Router)) *Server {
+func NewServer(t *testing.T, comp *config.Complement, configFunc func(router *mux.Router)) *Server {
 	t.Helper()
 
 	listener, err := net.Listen("tcp", ":0")
@@ -37,7 +38,8 @@ func NewServer(t *testing.T, configFunc func(router *mux.Router)) *Server {
 	go server.Serve(listener)
 
 	return &Server{
-		Port:     port,
+		Url:      fmt.Sprintf("http://%s:%d", comp.HostnameRunningComplement, port),
+		port:     port,
 		server:   server,
 		listener: listener,
 	}
@@ -46,9 +48,4 @@ func NewServer(t *testing.T, configFunc func(router *mux.Router)) *Server {
 func (s *Server) Close() {
 	s.server.Shutdown(context.Background())
 	s.listener.Close()
-}
-
-// Url returns the formatted URL that homeservers can access the server with, without leading slash
-func (s *Server) Url(comp *config.Complement) string {
-	return fmt.Sprintf("http://%s:%d", comp.HostnameRunningComplement, s.Port)
 }

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1,0 +1,54 @@
+package web
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+
+	"github.com/gorilla/mux"
+
+	"github.com/matrix-org/complement/internal/config"
+)
+
+type Server struct {
+	Port     int
+	server   *http.Server
+	listener net.Listener
+}
+
+func NewServer(t *testing.T, configFunc func(router *mux.Router)) *Server {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("Could not create listener for web server: %s", err)
+	}
+
+	port := listener.Addr().(*net.TCPAddr).Port
+
+	r := mux.NewRouter()
+
+	configFunc(r)
+
+	server := &http.Server{Addr: ":0", Handler: r}
+
+	go server.Serve(listener)
+
+	return &Server{
+		Port:     port,
+		server:   server,
+		listener: listener,
+	}
+}
+
+func (s *Server) Close() {
+	s.server.Shutdown(context.Background())
+	s.listener.Close()
+}
+
+// Url returns the formatted URL that homeservers can access the server with, without leading slash
+func (s *Server) Url(comp *config.Complement) string {
+	return fmt.Sprintf("http://%s:%d", comp.HostnameRunningComplement, s.Port)
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -13,8 +13,8 @@ import (
 )
 
 type Server struct {
-	Url      string
-	port     int
+	URL      string
+	Port     int
 	server   *http.Server
 	listener net.Listener
 }
@@ -38,8 +38,8 @@ func NewServer(t *testing.T, comp *config.Complement, configFunc func(router *mu
 	go server.Serve(listener)
 
 	return &Server{
-		Url:      fmt.Sprintf("http://%s:%d", comp.HostnameRunningComplement, port),
-		port:     port,
+		URL:      fmt.Sprintf("http://%s:%d", comp.HostnameRunningComplement, port),
+		Port:     port,
 		server:   server,
 		listener: listener,
 	}

--- a/tests/csapi/url_preview_test.go
+++ b/tests/csapi/url_preview_test.go
@@ -1,0 +1,97 @@
+package csapi_tests
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/tidwall/gjson"
+
+	"github.com/matrix-org/complement/internal/b"
+	"github.com/matrix-org/complement/internal/client"
+	"github.com/matrix-org/complement/internal/data"
+	"github.com/matrix-org/complement/internal/match"
+	"github.com/matrix-org/complement/internal/must"
+	"github.com/matrix-org/complement/internal/web"
+	"github.com/matrix-org/complement/runtime"
+)
+
+const oGraphTitle = "The Rock"
+const oGraphType = "video.movie"
+const oGraphUrl = "http://www.imdb.com/title/tt0117500/"
+const oGraphImage = "test.png"
+
+var oGraphHtml = fmt.Sprintf(`
+<html prefix="og: http://ogp.me/ns#">
+<head>
+<title>The Rock (1996)</title>
+<meta property="og:title" content="%s" />
+<meta property="og:type" content="%s" />
+<meta property="og:url" content="%s" />
+<meta property="og:image" content="%s" />
+</head>
+<body></body>
+</html>
+`, oGraphTitle, oGraphType, oGraphUrl, oGraphImage)
+
+// sytest: Test URL preview
+func TestUrlPreview(t *testing.T) {
+	runtime.SkipIf(t, runtime.Dendrite) // FIXME: https://github.com/matrix-org/dendrite/issues/621
+	runtime.SkipIf(t, runtime.Synapse)  // FIXME: https://github.com/matrix-org/synapse/pull/14198
+
+	deployment := Deploy(t, b.BlueprintAlice)
+	defer deployment.Destroy(t)
+
+	webServer := web.NewServer(t, func(router *mux.Router) {
+		router.HandleFunc("/test.png", func(w http.ResponseWriter, req *http.Request) {
+			t.Log("/test.png fetched")
+
+			w.Header().Set("Content-Type", "image/png")
+			w.WriteHeader(200)
+			w.Write(data.MatrixPng)
+		}).Methods("GET")
+		router.HandleFunc("/test.html", func(w http.ResponseWriter, req *http.Request) {
+			t.Log("/test.html fetched")
+
+			w.Header().Set("Content-Type", "text/html")
+			w.WriteHeader(200)
+			w.Write([]byte(oGraphHtml))
+		}).Methods("GET")
+	})
+	defer webServer.Close()
+
+	alice := deployment.Client(t, "hs1", "@alice:hs1")
+
+	res := alice.MustDoFunc(t, "GET", []string{"_matrix", "media", "r0", "preview_url"},
+		client.WithQueries(url.Values{
+			"url": []string{fmt.Sprintf("%s/test.html", webServer.Url(complementBuilder.Config))},
+		}),
+	)
+
+	var e = client.GjsonEscape
+
+	must.MatchResponse(t, res, match.HTTPResponse{
+		JSON: []match.JSON{
+			match.JSONKeyEqual(e("og:title"), oGraphTitle),
+			match.JSONKeyEqual(e("og:type"), oGraphType),
+			match.JSONKeyEqual(e("og:url"), oGraphUrl),
+			match.JSONKeyEqual(e("matrix:image:size"), 2239.0),
+			match.JSONKeyEqual(e("og:image:height"), 129.0),
+			match.JSONKeyEqual(e("og:image:width"), 279.0),
+			func(body []byte) error {
+				res := gjson.GetBytes(body, e("og:image"))
+				if !res.Exists() {
+					return fmt.Errorf("can not find key og:image")
+				}
+				if !strings.HasPrefix(res.Str, "mxc://") {
+					return fmt.Errorf("image is not mxc")
+				}
+
+				return nil
+			},
+		},
+	})
+}

--- a/tests/csapi/url_preview_test.go
+++ b/tests/csapi/url_preview_test.go
@@ -66,7 +66,7 @@ func TestUrlPreview(t *testing.T) {
 
 	res := alice.MustDoFunc(t, "GET", []string{"_matrix", "media", "v3", "preview_url"},
 		client.WithQueries(url.Values{
-			"url": []string{webServer.Url + "/test.html"},
+			"url": []string{webServer.URL + "/test.html"},
 		}),
 	)
 

--- a/tests/csapi/url_preview_test.go
+++ b/tests/csapi/url_preview_test.go
@@ -40,7 +40,6 @@ var oGraphHtml = fmt.Sprintf(`
 // sytest: Test URL preview
 func TestUrlPreview(t *testing.T) {
 	runtime.SkipIf(t, runtime.Dendrite) // FIXME: https://github.com/matrix-org/dendrite/issues/621
-	runtime.SkipIf(t, runtime.Synapse)  // FIXME: https://github.com/matrix-org/synapse/pull/14198
 
 	deployment := Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)

--- a/tests/csapi/url_preview_test.go
+++ b/tests/csapi/url_preview_test.go
@@ -44,7 +44,7 @@ func TestUrlPreview(t *testing.T) {
 	deployment := Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
-	webServer := web.NewServer(t, func(router *mux.Router) {
+	webServer := web.NewServer(t, complementBuilder.Config, func(router *mux.Router) {
 		router.HandleFunc("/test.png", func(w http.ResponseWriter, req *http.Request) {
 			t.Log("/test.png fetched")
 
@@ -64,9 +64,9 @@ func TestUrlPreview(t *testing.T) {
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
 
-	res := alice.MustDoFunc(t, "GET", []string{"_matrix", "media", "r0", "preview_url"},
+	res := alice.MustDoFunc(t, "GET", []string{"_matrix", "media", "v3", "preview_url"},
 		client.WithQueries(url.Values{
-			"url": []string{fmt.Sprintf("%s/test.html", webServer.Url(complementBuilder.Config))},
+			"url": []string{webServer.Url + "/test.html"},
 		}),
 	)
 


### PR DESCRIPTION
This follows up on #279, specifically [this](https://github.com/matrix-org/complement/pull/279#discussion_r833158719) comment.

This re-adds the URL preview test, but also adds a basic framework in `internal/web` for those webservers, with example use being displayed in the re-added test.

This PR is related to https://github.com/matrix-org/synapse/pull/14198, which ~~needs to land first before the test can be un-skipped~~ had landed.