### PR TITLE
Sytest: Add `46direct/01directmessage` tests

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -850,3 +850,48 @@ func SplitMxc(mxcUri string) (string, string) {
 
 	return origin, mediaId
 }
+
+// SendToDeviceMessages sends to-device messages over /sendToDevice/.
+//
+// The messages parameter is nested as follows:
+// user_id -> device_id -> content (map[string]interface{})
+func (c *CSAPI) SendToDeviceMessages(t *testing.T, evType string, messages map[string]map[string]map[string]interface{}) {
+	t.Helper()
+	c.txnID++
+	c.MustDoFunc(
+		t,
+		"PUT",
+		[]string{"_matrix", "client", "v3", "sendToDevice", evType, strconv.Itoa(c.txnID)},
+		WithJSONBody(
+			t,
+			map[string]map[string]map[string]map[string]interface{}{
+				"messages": messages,
+			},
+		),
+	)
+}
+
+// Check that sync has received a to-device message,
+// with optional user filtering.
+//
+// If fromUser == "", all messages will be passed through to the check function.
+// `check` will be called for all messages that have passed the filter.
+//
+// `check` gets passed the full event, including sender and type.
+func SyncToDeviceHas(fromUser string, check func(gjson.Result) bool) SyncCheckOpt {
+	return func(clientUserID string, topLevelSyncJSON gjson.Result) error {
+		err := loopArray(
+			topLevelSyncJSON, "to_device.events", func(result gjson.Result) bool {
+				if fromUser != "" && result.Get("sender").Str != fromUser {
+					return false
+				} else {
+					return check(result)
+				}
+			},
+		)
+		if err == nil {
+			return nil
+		}
+		return fmt.Errorf("SyncToDeviceHas(%v): %s", fromUser, err)
+	}
+}

--- a/tests/csapi/to_device_test.go
+++ b/tests/csapi/to_device_test.go
@@ -1,0 +1,60 @@
+package csapi_tests
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/tidwall/gjson"
+
+	"github.com/matrix-org/complement/internal/b"
+	"github.com/matrix-org/complement/internal/client"
+)
+
+// sytest: Can send a message directly to a device using PUT /sendToDevice
+// sytest: Can recv a device message using /sync
+// sytest: Can send a to-device message to two users which both receive it using /sync
+func TestToDeviceMessages(t *testing.T) {
+	deployment := Deploy(t, b.BlueprintOneToOneRoom)
+	defer deployment.Destroy(t)
+
+	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	bob := deployment.Client(t, "hs1", "@bob:hs1")
+	charlie := deployment.RegisterUser(t, "hs1", "charlie", "charliepassword", false)
+
+	_, bobSince := bob.MustSync(t, client.SyncReq{TimeoutMillis: "0"})
+	_, charlieSince := charlie.MustSync(t, client.SyncReq{TimeoutMillis: "0"})
+
+	content := map[string]interface{}{
+		"my_key": "my_value",
+	}
+
+	alice.SendToDeviceMessages(t, "my.test.type", map[string]map[string]map[string]interface{}{
+		bob.UserID: {
+			bob.DeviceID: content,
+		},
+		charlie.UserID: {
+			charlie.DeviceID: content,
+		},
+	})
+
+	checkEvent := func(result gjson.Result) bool {
+		if result.Get("type").Str != "my.test.type" {
+			return false
+		}
+
+		evContentRes := result.Get("content")
+
+		if !evContentRes.Exists() || !evContentRes.IsObject() {
+			return false
+		}
+
+		evContent := evContentRes.Value()
+
+		return reflect.DeepEqual(evContent, content)
+	}
+
+	bob.MustSyncUntil(t, client.SyncReq{Since: bobSince}, client.SyncToDeviceHas(alice.UserID, checkEvent))
+
+	charlie.MustSyncUntil(t, client.SyncReq{Since: charlieSince}, client.SyncToDeviceHas(alice.UserID, checkEvent))
+
+}


### PR DESCRIPTION
This adds three sytests;
- `./tests/46direct/01directmessage.pl:test "Can recv a device message using /sync",`
- `./tests/46direct/01directmessage.pl:test "Can send a message directly to a device using PUT /sendToDevice",`
- `./tests/46direct/01directmessage.pl:test "Can send a to-device message to two users which both receive it using /sync",`

This also adds the following to `internal/`:
- `SendToDeviceMessages`, to more easily send to-device messages, in the correct format.
- `SyncToDeviceHas` `SyncCheckOpt`, to check for to-device messages in sync responses.