### PR TITLE
Sytest: Add `30rooms/01state` tests

### DIFF
--- a/sytest.ignored.list
+++ b/sytest.ignored.list
@@ -35,7 +35,8 @@ New room members see first user's profile information in per-room initialSync
 A departed room is still included in /initialSync (SPEC-216)
 Can get rooms/{roomId}/initialSync for a departed room (SPEC-216)
 initialSync sees my presence status
-Global initialSyncGlobal initialSync with limit=0 gives no messages
+Global initialSync
+Global initialSync with limit=0 gives no messages
 Room initialSync
 Room initialSync with limit=0 gives no messages
 Read receipts are visible to /initialSync

--- a/tests/csapi/rooms_state_test.go
+++ b/tests/csapi/rooms_state_test.go
@@ -127,7 +127,7 @@ func TestRoomCreationReportsEventsToMyself(t *testing.T) {
 			secondID := *getEventIdForState(t, alice, roomID, "m.room.member", alice.UserID)
 
 			if firstID != secondID {
-				t.Fatalf("Both Event IDs from supposedly-idempotent room joins diff, %s != %s", firstID, secondID)
+				t.Fatalf("Both Event IDs from supposedly-idempotent room joins differ, %s != %s", firstID, secondID)
 			}
 		})
 	})

--- a/tests/csapi/rooms_state_test.go
+++ b/tests/csapi/rooms_state_test.go
@@ -5,6 +5,7 @@ package csapi_tests
 
 import (
 	"testing"
+	"time"
 
 	"github.com/tidwall/gjson"
 
@@ -13,29 +14,20 @@ import (
 	"github.com/matrix-org/complement/internal/must"
 )
 
-// TODO:
-// Setting room topic reports m.room.topic to myself
-// Global initialSync
-// Global initialSync with limit=0 gives no messages
-// Room initialSync
-// Room initialSync with limit=0 gives no messages
-// Setting state twice is idempotent
-// Joining room twice is idempotent
-
-// Test that the m.room.create and m.room.member events for a room we created comes down /sync
 func TestRoomCreationReportsEventsToMyself(t *testing.T) {
 	deployment := Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	userID := "@alice:hs1"
 	alice := deployment.Client(t, "hs1", userID)
+	bob := deployment.RegisterUser(t, "hs1", "bob", "bobpassword", false)
 	roomID := alice.CreateRoom(t, struct{}{})
 
 	t.Run("parallel", func(t *testing.T) {
 		// sytest: Room creation reports m.room.create to myself
 		t.Run("Room creation reports m.room.create to myself", func(t *testing.T) {
 			t.Parallel()
-			alice := deployment.Client(t, "hs1", userID)
+
 			alice.MustSyncUntil(t, client.SyncReq{}, client.SyncTimelineHas(roomID, func(ev gjson.Result) bool {
 				if ev.Get("type").Str != "m.room.create" {
 					return false
@@ -45,10 +37,11 @@ func TestRoomCreationReportsEventsToMyself(t *testing.T) {
 				return true
 			}))
 		})
+
 		// sytest: Room creation reports m.room.member to myself
 		t.Run("Room creation reports m.room.member to myself", func(t *testing.T) {
 			t.Parallel()
-			alice := deployment.Client(t, "hs1", userID)
+
 			alice.MustSyncUntil(t, client.SyncReq{}, client.SyncTimelineHas(roomID, func(ev gjson.Result) bool {
 				if ev.Get("type").Str != "m.room.member" {
 					return false
@@ -59,5 +52,98 @@ func TestRoomCreationReportsEventsToMyself(t *testing.T) {
 				return true
 			}))
 		})
+
+		// sytest: Setting room topic reports m.room.topic to myself
+		t.Run("Setting room topic reports m.room.topic to myself", func(t *testing.T) {
+			t.Parallel()
+
+			const roomTopic = "Testing topic for the new room"
+
+			alice.SendEventSynced(t, roomID, b.Event{
+				Type:     "m.room.topic",
+				StateKey: b.Ptr(""),
+				Content: map[string]interface{}{
+					"topic": roomTopic,
+				},
+			})
+
+			alice.MustSyncUntil(t, client.SyncReq{}, client.SyncTimelineHas(roomID, func(ev gjson.Result) bool {
+				if ev.Get("type").Str != "m.room.topic" {
+					return false
+				}
+				if !ev.Get("state_key").Exists() {
+					return false
+				}
+				must.EqualStr(t, ev.Get("sender").Str, userID, "wrong sender")
+				must.EqualStr(t, ev.Get("content").Get("topic").Str, roomTopic, "wrong content.topic")
+				return true
+			}))
+		})
+
+		// sytest: Setting state twice is idempotent
+		t.Run("Setting state twice is idempotent", func(t *testing.T) {
+			t.Parallel()
+
+			stateEvent := b.Event{
+				Type:     "a.test.state.type",
+				StateKey: b.Ptr(""),
+				Content: map[string]interface{}{
+					"a_key": "a_value",
+				},
+			}
+
+			firstID := alice.SendEventSynced(t, roomID, stateEvent)
+			secondID := alice.SendEventSynced(t, roomID, stateEvent)
+
+			if firstID != secondID {
+				t.Fatalf("Both Event IDs from supposedly-idempotent state-setting differ, %s != %s", firstID, secondID)
+			}
+		})
+
+		// sytest: Joining room twice is idempotent
+		t.Run("Joining room twice is idempotent", func(t *testing.T) {
+			t.Parallel()
+
+			roomID := bob.CreateRoom(t, map[string]interface{}{
+				"visibility": "public",
+				"preset":     "public_chat",
+			})
+
+			alice.JoinRoom(t, roomID, nil)
+			alice.MustSyncUntil(t, client.SyncReq{}, client.SyncJoinedTo(alice.UserID, roomID))
+
+			firstID := *getEventIdForState(t, alice, roomID, "m.room.member", alice.UserID)
+
+			alice.JoinRoom(t, roomID, nil)
+
+			// Unfortunately there is no way to definitively wait
+			// for a 'potentially false second join event' without
+			// also failing the test on timeout, with the current APIs.
+			//
+			// So we take a conservative estimate of a 5-second sleep delay
+			// before we check on the server again.
+			time.Sleep(5 * time.Second)
+
+			secondID := *getEventIdForState(t, alice, roomID, "m.room.member", alice.UserID)
+
+			if firstID != secondID {
+				t.Fatalf("Both Event IDs from supposedly-idempotent room joins diff, %s != %s", firstID, secondID)
+			}
+		})
 	})
+}
+
+func getEventIdForState(t *testing.T, client *client.CSAPI, roomID, evType, stateKey string) *string {
+	res := client.MustDoFunc(t, "GET", []string{"_matrix", "client", "v3", "rooms", roomID, "state"})
+
+	jsonBody := must.ParseJSON(t, res.Body)
+	result := gjson.ParseBytes(jsonBody)
+
+	for _, ev := range result.Array() {
+		if ev.Get("type").Str == evType && ev.Get("state_key").Str == stateKey {
+			return b.Ptr(ev.Get("event_id").Str)
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
This adds the following sytests:
- `./tests/30rooms/01state.pl:test "Joining room twice is idempotent",`
- `./tests/30rooms/01state.pl:test "Setting room topic reports m.room.topic to myself",`
- `./tests/30rooms/01state.pl:test "Setting state twice is idempotent",`

This also fixes a typo in the `sytest.ignored.list`