### PR TITLE
Sytest: Add `30rooms/05aliases` tests

### DIFF
--- a/tests/federation_room_alias_test.go
+++ b/tests/federation_room_alias_test.go
@@ -17,7 +17,7 @@ func TestRemoteAliasRequestsUnderstandUnicode(t *testing.T) {
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
 	bob := deployment.Client(t, "hs2", "@bob:hs2")
 
-	const unicodeAlias = "#老虎Â£я:hs1"
+	const unicodeAlias = "#老虎Â£я🤨👉ඞ:hs1"
 
 	roomID := alice.CreateRoom(t, map[string]interface{}{})
 

--- a/tests/federation_room_alias_test.go
+++ b/tests/federation_room_alias_test.go
@@ -1,0 +1,35 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/matrix-org/complement/internal/b"
+	"github.com/matrix-org/complement/internal/client"
+	"github.com/matrix-org/complement/internal/match"
+	"github.com/matrix-org/complement/internal/must"
+)
+
+// sytest: Remote room alias queries can handle Unicode
+func TestRemoteAliasRequestsUnderstandUnicode(t *testing.T) {
+	deployment := Deploy(t, b.BlueprintFederationOneToOneRoom)
+	defer deployment.Destroy(t)
+
+	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	bob := deployment.Client(t, "hs2", "@bob:hs2")
+
+	const unicodeAlias = "#老虎Â£я:hs1"
+
+	roomID := alice.CreateRoom(t, map[string]interface{}{})
+
+	alice.MustDoFunc(t, "PUT", []string{"_matrix", "client", "v3", "directory", "room", unicodeAlias}, client.WithJSONBody(t, map[string]interface{}{
+		"room_id": roomID,
+	}))
+
+	res := bob.DoFunc(t, "GET", []string{"_matrix", "client", "v3", "directory", "room", unicodeAlias})
+	must.MatchResponse(t, res, match.HTTPResponse{
+		StatusCode: 200,
+		JSON: []match.JSON{
+			match.JSONKeyEqual("room_id", roomID),
+		},
+	})
+}


### PR DESCRIPTION
This adds 7 sytests:
- `./tests/30rooms/05aliases.pl:test "Can delete canonical alias",`
- `./tests/30rooms/05aliases.pl:test "Regular users can add and delete aliases in the default room configuration",`
- `./tests/30rooms/05aliases.pl:test "Regular users can add and delete aliases when m.room.aliases is restricted",`
- `./tests/30rooms/05aliases.pl:test "Remote room alias queries can handle Unicode",`
- `./tests/30rooms/05aliases.pl:test "Room aliases can contain Unicode",`
- `./tests/30rooms/05aliases.pl:test "Users can't delete other's aliases",`
- `./tests/30rooms/05aliases.pl:test "Users with sufficient power-level can delete other's aliases",`