### PR TITLE
Revert "Enable debug logging for TestWriteMDirectAccountData"

### DIFF
--- a/tests/direct_messaging_test.go
+++ b/tests/direct_messaging_test.go
@@ -28,10 +28,6 @@ func TestWriteMDirectAccountData(t *testing.T) {
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
 	bob := deployment.Client(t, "hs1", "@bob:hs1")
-
-	// additional logging to debug https://github.com/matrix-org/synapse/issues/13334
-	alice.Debug = true
-
 	roomID := alice.CreateRoom(t, map[string]interface{}{
 		"invite":    []string{bob.UserID},
 		"is_direct": true,


### PR DESCRIPTION
Reverts matrix-org/complement#493

It looks an awful lot like this fixed the problem... let's back it out to see if it starts happening again.

cf https://github.com/matrix-org/synapse/issues/13334#issuecomment-1290599757