### PR TITLE
Add forgotten sytest comment (`20typing`)

### DIFF
--- a/tests/federation_room_typing_test.go
+++ b/tests/federation_room_typing_test.go
@@ -25,6 +25,7 @@ func awaitTyping(userId string) func(result gjson.Result) bool {
 	}
 }
 
+// sytest: Typing notifications also sent to remote room members
 func TestRemoteTyping(t *testing.T) {
 	deployment := Deploy(t, b.BlueprintFederationTwoLocalOneRemote)
 	defer deployment.Destroy(t)


### PR DESCRIPTION
In #510 I seem to have forgotten to add a sytest comment, whoops.