### PR TITLE
Use http.server.Close (not .Shutdown) for cleanup

### DIFF
--- a/internal/federation/server.go
+++ b/internal/federation/server.go
@@ -468,7 +468,7 @@ func (s *Server) Listen() (cancel func()) {
 	}()
 
 	return func() {
-		err := s.srv.Shutdown(context.Background())
+		err := s.srv.Close()
 		if err != nil {
 			s.t.Fatalf("ListenFederationServer: failed to shutdown server: %s", err)
 		}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1,7 +1,6 @@
 package web
 
 import (
-	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -46,6 +45,6 @@ func NewServer(t *testing.T, comp *config.Complement, configFunc func(router *mu
 }
 
 func (s *Server) Close() {
-	s.server.Shutdown(context.Background())
+	s.server.Close()
 	s.listener.Close()
 }


### PR DESCRIPTION
Per the conversation starting here:
https://matrix.to/#/!alCakyySsFIAVfZLDL:matrix.org/$B_wrGA9l3SwDDuufbOxMw_VyrwH_Vg00coJDRQTG7_8?via=matrix.org&via=element.io&via=sw1v.org

During test cleanup there's no need for us to try to gracefully shutdown---we're about to completely destroy the container anyway.