### PR TITLE
Buffer channels in faster joins device list tests

### DIFF
--- a/tests/federation_room_join_partial_state_test.go
+++ b/tests/federation_room_join_partial_state_test.go
@@ -1830,8 +1830,8 @@ func TestPartialStateJoin(t *testing.T) {
 		) {
 			alice = deployment.RegisterUser(t, "hs1", aliceLocalpart, "secret", false)
 
-			deviceListUpdateChannel1 = make(chan gomatrixserverlib.DeviceListUpdateEvent)
-			deviceListUpdateChannel2 = make(chan gomatrixserverlib.DeviceListUpdateEvent)
+			deviceListUpdateChannel1 = make(chan gomatrixserverlib.DeviceListUpdateEvent, 10)
+			deviceListUpdateChannel2 = make(chan gomatrixserverlib.DeviceListUpdateEvent, 10)
 
 			createDeviceListUpdateTestServer := func(
 				t *testing.T, deployment *docker.Deployment,


### PR DESCRIPTION
Kegan advises that this will help prevent a class of deadlock we've see (thank you Kegan). See
https://github.com/matrix-org/synapse/issues/14010#issuecomment-1295108331 and https://matrix.to/#/!alCakyySsFIAVfZLDL:matrix.org/$Tk4PR9KGtfCJTFLFW0ecytvFYxf3C_36UW9C5F7fRzE?via=matrix.org&via=element.io&via=sw1v.org

Closes https://github.com/matrix-org/synapse/issues/14010. (Hopefully; we can reopen if needed.)