### PR TITLE
Add `MatchJSON`, `MatchJSONBytes` and `MatchGJSON`

### DIFF
--- a/internal/must/must.go
+++ b/internal/must/must.go
@@ -132,6 +132,35 @@ func MatchFederationRequest(t *testing.T, fedReq *gomatrixserverlib.FederationRe
 	}
 }
 
+// MatchGJSON performs JSON assertions on a gjson.Result object.
+func MatchGJSON(t *testing.T, jsonResult gjson.Result, matchers ...match.JSON) {
+	t.Helper()
+
+	MatchJSON(t, jsonResult.Str, matchers...)
+}
+
+// MatchJSON performs JSON assertions on a raw JSON string.
+func MatchJSON(t *testing.T, json string, matchers ...match.JSON) {
+	t.Helper()
+
+	MatchJSONBytes(t, []byte(json), matchers...)
+}
+
+// MatchJSONBytes performs JSON assertions on a raw json byte slice.
+func MatchJSONBytes(t *testing.T, rawJson []byte, matchers ...match.JSON) {
+	t.Helper()
+
+	if !gjson.ValidBytes(rawJson) {
+		t.Fatalf("MatchJSONBytes: rawJson is not valid JSON")
+	}
+
+	for _, jm := range matchers {
+		if err := jm(rawJson); err != nil {
+			t.Fatalf("MatchJSONBytes %s", err)
+		}
+	}
+}
+
 // EqualStr ensures that got==want else logs an error.
 func EqualStr(t *testing.T, got, want, msg string) {
 	t.Helper()

--- a/tests/csapi/apidoc_server_capabilities_test.go
+++ b/tests/csapi/apidoc_server_capabilities_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/matrix-org/complement/internal/b"
 	"github.com/matrix-org/complement/internal/match"
 	"github.com/matrix-org/complement/internal/must"
-	"github.com/tidwall/gjson"
 )
 
 func TestServerCapabilities(t *testing.T) {
@@ -19,13 +18,13 @@ func TestServerCapabilities(t *testing.T) {
 
 	// sytest: GET /capabilities is present and well formed for registered user
 	data := authedClient.GetCapabilities(t)
-	j := gjson.ParseBytes(data)
-	if !j.Get(`capabilities.m\.room_versions`).Exists() {
-		t.Fatal("expected m.room_versions not found")
-	}
-	if !j.Get(`capabilities.m\.change_password`).Exists() {
-		t.Fatal("expected m.change_password not found")
-	}
+
+	must.MatchJSONBytes(
+		t,
+		data,
+		match.JSONKeyPresent(`capabilities.m\.room_versions`),
+		match.JSONKeyPresent(`capabilities.m\.change_password`),
+	)
 
 	// sytest: GET /v3/capabilities is not public
 	res := unauthedClient.DoFunc(t, "GET", []string{"_matrix", "client", "v3", "capabilities"})


### PR DESCRIPTION
Resolves #528

This adds three convenience methods, which call eachother for deduplication.

The effective round-trip from gjson.Result.Str to byteslice and back is unfortunate, but it's how `match.JSON` is defined.