### PR TITLE
Sytest: Add `10apidoc/36room-levels` tests

### DIFF
--- a/sytest.ignored.list
+++ b/sytest.ignored.list
@@ -12,6 +12,10 @@ Can quarantine media in rooms
 Shutdown room
 Can backfill purged history
 
+# Dummy test that exists only to prove a capability
+# (in 10apidoc/36room-levels)
+Both GET and PUT work
+
 # Tests deprecated endpoints
 Tags appear in the v1 /initialSync
 Tags appear in the v1 /events stream

--- a/tests/csapi/power_levels_test.go
+++ b/tests/csapi/power_levels_test.go
@@ -76,10 +76,21 @@ func TestPowerLevels(t *testing.T) {
 				match.JSONKeyTypeEqual("events_default", gjson.Number),
 				match.JSONKeyTypeEqual("users_default", gjson.Number),
 
-				match.JSONKeyTypeEqual("events", gjson.JSON),
+				match.JSONMapEach("events", func(k, v gjson.Result) error {
+					if v.Type != gjson.Number {
+						return fmt.Errorf("key %s is not a number", k.Str)
+					} else {
+						return nil
+					}
+				}),
 
-				match.JSONKeyTypeEqual("users", gjson.JSON),
-				match.JSONKeyTypeEqual("users."+client.GjsonEscape(alice.UserID), gjson.Number),
+				match.JSONMapEach("users", func(k, v gjson.Result) error {
+					if v.Type != gjson.Number {
+						return fmt.Errorf("key %s is not a number", k.Str)
+					} else {
+						return nil
+					}
+				}),
 
 				func(body []byte) error {
 					userDefault := int(gjson.GetBytes(body, "users_default").Num)
@@ -101,7 +112,8 @@ func TestPowerLevels(t *testing.T) {
 		PLContent := map[string]interface{}{
 			"invite": 100.0,
 			"users": map[string]interface{}{
-				alice.UserID: 100.0,
+				alice.UserID:                    100.0,
+				"@random-other-user:their.home": 20.0,
 			},
 		}
 

--- a/tests/csapi/power_levels_test.go
+++ b/tests/csapi/power_levels_test.go
@@ -4,6 +4,9 @@ import (
 	"testing"
 
 	"github.com/matrix-org/complement/internal/b"
+	"github.com/matrix-org/complement/internal/client"
+	"github.com/matrix-org/complement/internal/match"
+	"github.com/matrix-org/complement/internal/must"
 )
 
 // This test ensures that an authorised (PL 100) user is able to modify the users_default value
@@ -38,5 +41,85 @@ func TestDemotingUsersViaUsersDefault(t *testing.T) {
 			"events":        map[string]int64{},
 			"notifications": map[string]int64{},
 		},
+	})
+}
+
+func TestPowerLevels(t *testing.T) {
+	deployment := Deploy(t, b.BlueprintAlice)
+	defer deployment.Destroy(t)
+
+	alice := deployment.Client(t, "hs1", "@alice:hs1")
+
+	roomID := alice.CreateRoom(t, map[string]interface{}{})
+
+	// sytest: GET /rooms/:room_id/state/m.room.power_levels can fetch levels
+	t.Run("GET /rooms/:room_id/state/m.room.power_levels can fetch levels", func(t *testing.T) {
+		// Test if the old state still exists
+		res := alice.MustDoFunc(t, "GET", []string{"_matrix", "client", "v3", "rooms", roomID, "state", "m.room.power_levels"})
+
+		must.MatchResponse(t, res, match.HTTPResponse{
+			StatusCode: 200,
+			JSON: []match.JSON{
+				match.JSONKeyPresent("users"),
+			},
+		})
+	})
+
+	// sytest: PUT /rooms/:room_id/state/m.room.power_levels can set levels
+	t.Run("PUT /rooms/:room_id/state/m.room.power_levels can set levels", func(t *testing.T) {
+		alice.SendEventSynced(t, roomID, b.Event{
+			Type:     "m.room.power_levels",
+			StateKey: b.Ptr(""),
+			Content: map[string]interface{}{
+				"invite": 100,
+				"users": map[string]interface{}{
+					alice.UserID: 100,
+				},
+			},
+		})
+	})
+
+	// sytest: PUT power_levels should not explode if the old power levels were empty
+	t.Run("PUT power_levels should not explode if the old power levels were empty", func(t *testing.T) {
+		// Absence of an "events" key
+		alice.SendEventSynced(t, roomID, b.Event{
+			Type:     "m.room.power_levels",
+			StateKey: b.Ptr(""),
+			Content: map[string]interface{}{
+				"users": map[string]interface{}{
+					alice.UserID: 100,
+				},
+			},
+		})
+
+		// Absence of a "users" key
+		alice.SendEventSynced(t, roomID, b.Event{
+			Type:     "m.room.power_levels",
+			StateKey: b.Ptr(""),
+			Content:  map[string]interface{}{},
+		})
+
+		// This should give a 403 (not a 500)
+		res := alice.DoFunc(
+			t,
+			"PUT",
+			[]string{"_matrix", "client", "v3", "rooms", roomID, "state", "m.room.power_levels"},
+			client.WithJSONBody(t, map[string]interface{}{
+				"users": map[string]string{},
+			}),
+		)
+		must.MatchResponse(t, res, match.HTTPResponse{
+			StatusCode: 403,
+		})
+
+		// Test if the old state still exists
+		res = alice.MustDoFunc(t, "GET", []string{"_matrix", "client", "v3", "rooms", roomID, "state", "m.room.power_levels"})
+
+		must.MatchResponse(t, res, match.HTTPResponse{
+			StatusCode: 200,
+			JSON: []match.JSON{
+				match.JSONKeyMissing("users"),
+			},
+		})
 	})
 }


### PR DESCRIPTION
This adds three sytests:
- `./tests/10apidoc/36room-levels.pl:test "GET /rooms/:room_id/state/m.room.power_levels can fetch levels",`
- `./tests/10apidoc/36room-levels.pl:test "PUT /rooms/:room_id/state/m.room.power_levels can set levels",`
- `./tests/10apidoc/36room-levels.pl:test "PUT power_levels should not explode if the old power levels were empty",`

This skips a test called "Both GET and PUT work" because its sole existence in sytest appears to be to prove the ability to set and get powerlevels, for other test's requirements.