### PR TITLE
MatchGJSON: `jsonResult.Raw` instead of `jsonResult.Str`

### DIFF
--- a/internal/must/must.go
+++ b/internal/must/must.go
@@ -136,7 +136,7 @@ func MatchFederationRequest(t *testing.T, fedReq *gomatrixserverlib.FederationRe
 func MatchGJSON(t *testing.T, jsonResult gjson.Result, matchers ...match.JSON) {
 	t.Helper()
 
-	MatchJSON(t, jsonResult.Str, matchers...)
+	MatchJSON(t, jsonResult.Raw, matchers...)
 }
 
 // MatchJSON performs JSON assertions on a raw JSON string.


### PR DESCRIPTION
Encountered while working on another test, seems like I slipped in a bug with this