### PR TITLE
Add regression test for room summaries

### DIFF
--- a/tests/csapi/sync_test.go
+++ b/tests/csapi/sync_test.go
@@ -436,6 +436,7 @@ func TestPresenceSyncDifferentRooms(t *testing.T) {
 }
 
 func TestRoomSummary(t *testing.T) {
+	runtime.SkipIf(t, runtime.Synapse) // Currently more of a Dendrite test, so skip on Synapse
 	deployment := Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 	alice := deployment.Client(t, "hs1", "@alice:hs1")


### PR DESCRIPTION
A simple test to verify room summaries are correctly send down sync.