### PR TITLE
Sytest: Add `40presence` tests

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -696,6 +696,43 @@ func SyncEphemeralHas(roomID string, check func(gjson.Result) bool) SyncCheckOpt
 	}
 }
 
+// Check that the sync contains presence from a user, optionally with an expected presence (set to nil to not check),
+// and optionally with extra checks.
+func SyncPresenceHas(fromUser string, expectedPresence *string, checks ...func(gjson.Result) bool) SyncCheckOpt {
+	return func(clientUserID string, topLevelSyncJSON gjson.Result) error {
+		presenceEvents := topLevelSyncJSON.Get("presence.events")
+		if !presenceEvents.Exists() {
+			return fmt.Errorf("presence.events does not exist")
+		}
+		for _, x := range presenceEvents.Array() {
+			if !(x.Get("type").Exists() &&
+				x.Get("sender").Exists() &&
+				x.Get("content").Exists() &&
+				x.Get("content.presence").Exists()) {
+				return fmt.Errorf(
+					"malformatted presence event, expected the following fields: [sender, type, content, content.presence]: %s",
+					x.Raw,
+				)
+			} else if x.Get("sender").Str != fromUser {
+				continue
+			} else if expectedPresence != nil && x.Get("content.presence").Str != *expectedPresence {
+				return fmt.Errorf(
+					"found presence for user %s, but not expected presence: got %s, want %s",
+					fromUser, x.Get("content.presence").Str, *expectedPresence,
+				)
+			} else {
+				for i, check := range checks {
+					if !check(x) {
+						return fmt.Errorf("matched presence event to user %s, but check %d did not pass", fromUser, i)
+					}
+				}
+				return nil
+			}
+		}
+		return fmt.Errorf("did not find %s in presence events", fromUser)
+	}
+}
+
 // Checks that `userID` gets invited to `roomID`.
 //
 // This checks different parts of the /sync response depending on the client making the request.

--- a/tests/csapi/apidoc_presence_test.go
+++ b/tests/csapi/apidoc_presence_test.go
@@ -7,6 +7,8 @@ package csapi_tests
 import (
 	"testing"
 
+	"github.com/tidwall/gjson"
+
 	"github.com/matrix-org/complement/internal/b"
 	"github.com/matrix-org/complement/internal/client"
 	"github.com/matrix-org/complement/internal/match"
@@ -14,13 +16,15 @@ import (
 )
 
 func TestPresence(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
-	authedClient := deployment.Client(t, "hs1", "@alice:hs1")
+	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	bob := deployment.Client(t, "hs1", "@bob:hs1")
+
 	// sytest: GET /presence/:user_id/status fetches initial status
 	t.Run("GET /presence/:user_id/status fetches initial status", func(t *testing.T) {
-		res := authedClient.DoFunc(t, "GET", []string{"_matrix", "client", "v3", "presence", "@alice:hs1", "status"})
+		res := alice.DoFunc(t, "GET", []string{"_matrix", "client", "v3", "presence", "@alice:hs1", "status"})
 		must.MatchResponse(t, res, match.HTTPResponse{
 			JSON: []match.JSON{
 				match.JSONKeyPresent("presence"),
@@ -34,16 +38,56 @@ func TestPresence(t *testing.T) {
 			"status_msg": statusMsg,
 			"presence":   "online",
 		})
-		res := authedClient.DoFunc(t, "PUT", []string{"_matrix", "client", "v3", "presence", "@alice:hs1", "status"}, reqBody)
+		res := alice.DoFunc(t, "PUT", []string{"_matrix", "client", "v3", "presence", "@alice:hs1", "status"}, reqBody)
 		must.MatchResponse(t, res, match.HTTPResponse{
 			StatusCode: 200,
 		})
-		res = authedClient.DoFunc(t, "GET", []string{"_matrix", "client", "v3", "presence", "@alice:hs1", "status"})
+		res = alice.DoFunc(t, "GET", []string{"_matrix", "client", "v3", "presence", "@alice:hs1", "status"})
 		must.MatchResponse(t, res, match.HTTPResponse{
 			JSON: []match.JSON{
 				match.JSONKeyPresent("presence"),
 				match.JSONKeyEqual("status_msg", statusMsg),
 			},
 		})
+	})
+	// sytest: Presence can be set from sync
+	t.Run("Presence can be set from sync", func(t *testing.T) {
+		_, bobSinceToken := bob.MustSync(t, client.SyncReq{TimeoutMillis: "0"})
+
+		alice.MustSync(t, client.SyncReq{TimeoutMillis: "0", SetPresence: "unavailable"})
+
+		bob.MustSyncUntil(t, client.SyncReq{Since: bobSinceToken}, client.SyncPresenceHas(alice.UserID, b.Ptr("unavailable")))
+	})
+	// sytest: Presence changes are reported to local room members
+	t.Run("Presence changes are reported to local room members", func(t *testing.T) {
+		_, bobSinceToken := bob.MustSync(t, client.SyncReq{TimeoutMillis: "0"})
+
+		statusMsg := "Update for room members"
+		alice.MustDoFunc(t, "PUT", []string{"_matrix", "client", "v3", "presence", "@alice:hs1", "status"},
+			client.WithJSONBody(t, map[string]interface{}{
+				"status_msg": statusMsg,
+				"presence":   "online",
+			}),
+		)
+
+		bob.MustSyncUntil(t, client.SyncReq{Since: bobSinceToken},
+			client.SyncPresenceHas(alice.UserID, b.Ptr("online"), func(ev gjson.Result) bool {
+				return ev.Get("content.status_msg").Str == statusMsg
+			}),
+		)
+	})
+	// sytest: Presence changes to UNAVAILABLE are reported to local room members
+	t.Run("Presence changes to UNAVAILABLE are reported to local room members", func(t *testing.T) {
+		_, bobSinceToken := bob.MustSync(t, client.SyncReq{TimeoutMillis: "0"})
+
+		alice.MustDoFunc(t, "PUT", []string{"_matrix", "client", "v3", "presence", "@alice:hs1", "status"},
+			client.WithJSONBody(t, map[string]interface{}{
+				"presence": "unavailable",
+			}),
+		)
+
+		bob.MustSyncUntil(t, client.SyncReq{Since: bobSinceToken},
+			client.SyncPresenceHas(alice.UserID, b.Ptr("unavailable")),
+		)
 	})
 }

--- a/tests/csapi/rooms_members_local_test.go
+++ b/tests/csapi/rooms_members_local_test.go
@@ -1,10 +1,7 @@
 package csapi_tests
 
 import (
-	"fmt"
 	"testing"
-
-	"github.com/tidwall/gjson"
 
 	"github.com/matrix-org/complement/internal/b"
 	"github.com/matrix-org/complement/internal/client"
@@ -41,22 +38,7 @@ func TestMembersLocal(t *testing.T) {
 			t.Parallel()
 			alice.MustSyncUntil(t, client.SyncReq{},
 				client.SyncJoinedTo(bob.UserID, roomID),
-				func(clientUserID string, topLevelSyncJSON gjson.Result) error {
-					presenceEvents := topLevelSyncJSON.Get("presence.events")
-					if !presenceEvents.Exists() {
-						return fmt.Errorf("presence.events does not exist")
-					}
-					for _, x := range presenceEvents.Array() {
-						fieldsExists := x.Get("type").Exists() && x.Get("content").Exists() && x.Get("sender").Exists()
-						if !fieldsExists {
-							return fmt.Errorf("expected fields type, content and sender")
-						}
-						if x.Get("sender").Str == bob.UserID {
-							return nil
-						}
-					}
-					return fmt.Errorf("did not find %s in presence events", bob.UserID)
-				},
+				client.SyncPresenceHas(bob.UserID, nil),
 			)
 		})
 	})

--- a/tests/federation_presence_test.go
+++ b/tests/federation_presence_test.go
@@ -1,0 +1,51 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/tidwall/gjson"
+
+	"github.com/matrix-org/complement/internal/b"
+	"github.com/matrix-org/complement/internal/client"
+)
+
+func TestRemotePresence(t *testing.T) {
+	deployment := Deploy(t, b.BlueprintFederationOneToOneRoom)
+	defer deployment.Destroy(t)
+
+	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	bob := deployment.Client(t, "hs2", "@bob:hs2")
+
+	// sytest: Presence changes are also reported to remote room members
+	t.Run("Presence changes are also reported to remote room members", func(t *testing.T) {
+		_, bobSinceToken := bob.MustSync(t, client.SyncReq{TimeoutMillis: "0"})
+
+		statusMsg := "Update for room members"
+		alice.MustDoFunc(t, "PUT", []string{"_matrix", "client", "v3", "presence", "@alice:hs1", "status"},
+			client.WithJSONBody(t, map[string]interface{}{
+				"status_msg": statusMsg,
+				"presence":   "online",
+			}),
+		)
+
+		bob.MustSyncUntil(t, client.SyncReq{Since: bobSinceToken},
+			client.SyncPresenceHas(alice.UserID, b.Ptr("online"), func(ev gjson.Result) bool {
+				return ev.Get("content.status_msg").Str == statusMsg
+			}),
+		)
+	})
+	// sytest: Presence changes to UNAVAILABLE are reported to remote room members
+	t.Run("Presence changes to UNAVAILABLE are reported to remote room members", func(t *testing.T) {
+		_, bobSinceToken := bob.MustSync(t, client.SyncReq{TimeoutMillis: "0"})
+
+		alice.MustDoFunc(t, "PUT", []string{"_matrix", "client", "v3", "presence", "@alice:hs1", "status"},
+			client.WithJSONBody(t, map[string]interface{}{
+				"presence": "unavailable",
+			}),
+		)
+
+		bob.MustSyncUntil(t, client.SyncReq{Since: bobSinceToken},
+			client.SyncPresenceHas(alice.UserID, b.Ptr("unavailable")),
+		)
+	})
+}


### PR DESCRIPTION
This adds 5 sytests:
- `./tests/40presence.pl:test "Presence can be set from sync",`
- `./tests/40presence.pl:test "Presence changes are also reported to remote room members",`
- `./tests/40presence.pl:test "Presence changes are reported to local room members",`
- `./tests/40presence.pl:test "Presence changes to UNAVAILABLE are reported to local room members",`
- `./tests/40presence.pl:test "Presence changes to UNAVAILABLE are reported to remote room members",`

This also adds an internal function `client.SyncPresenceHas`