### PR TITLE
Use `.Raw` to get the string representation of a gjson `Result` in `MatchGJSON`

### DIFF
--- a/internal/must/must.go
+++ b/internal/must/must.go
@@ -136,7 +136,7 @@ func MatchFederationRequest(t *testing.T, fedReq *gomatrixserverlib.FederationRe
 func MatchGJSON(t *testing.T, jsonResult gjson.Result, matchers ...match.JSON) {
 	t.Helper()
 
-	MatchJSON(t, jsonResult.Str, matchers...)
+	MatchJSON(t, jsonResult.Raw, matchers...)
 }
 
 // MatchJSON performs JSON assertions on a raw JSON string.


### PR DESCRIPTION
#542 added some useful helper methods to the `must` package. I attempted to use `MatchGJSON` in the following example code:

```golang
r = gjson.Parse("\"user\": \"@alice:example.com\"")
must.MatchGJSON(t, r, match.JSONKeyEqual("user", "@alice:example.com"))
```

but I received the following error:

```
msc3391_test.go:46: MatchJSONBytes: rawJson is not valid JSON
```

which comes from:

https://github.com/matrix-org/complement/blob/0c4207853177b224a13700c9ab55dcd5089ab8fe/internal/must/must.go#L149-L162

I believe `gjson.Result.Str` is invalid here, as it's only intended to be run on a json value of type string. The code I use above is running it on an object, which produces an empty string. Not `{"user": "@alice:example.com"}`. To get that, we need to use `gjson.Result.Raw`, which I think was the original intention here.