### PR TITLE
Prevent non-2xx responses from failing tests when using `client.GetGlobalAccountData`

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -170,7 +170,7 @@ func (c *CSAPI) InviteRoom(t *testing.T, roomID string, userID string) {
 }
 
 func (c *CSAPI) GetGlobalAccountData(t *testing.T, eventType string) *http.Response {
-	return c.MustDoFunc(t, "GET", []string{"_matrix", "client", "v3", "user", c.UserID, "account_data", eventType})
+	return c.DoFunc(t, "GET", []string{"_matrix", "client", "v3", "user", c.UserID, "account_data", eventType})
 }
 
 func (c *CSAPI) SetGlobalAccountData(t *testing.T, eventType string, content map[string]interface{}) *http.Response {


### PR DESCRIPTION
I wanted to check that an account data type *didn't* exist in a test I was writing. I want to do this by checking that the response from `client.GetGlobalAccountData` returned a 404.

This wasn't possible currently as `client.GetGlobalAccountData` makes use of `client.MustDoFunc`, which fails tests if a non-2xx HTTP status code was returned:

https://github.com/matrix-org/complement/blob/b9753e03b5f8a3814d96bd37fd6e4ce4cbbd2513/internal/client/client.go#L172-L174

This PR changes it to `client.DoFunc`, allowing 404 responses to be returned and checked in calling code.

I verified that no tests currently rely on `client.GetGlobalAccountData` checking for 2xx responses.