### PR TITLE
Homerunner: Permit running HS with remote networking, and provide docker build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@ complement
 .idea
 .bin
 .DS_Store
-homerunner
+# Homerunner can end up in various places
+/homerunner
+/cmd/homerunner/homerunner

--- a/cmd/homerunner/Dockerfile
+++ b/cmd/homerunner/Dockerfile
@@ -1,0 +1,34 @@
+# This dockerfile simply holds `homerunner` when run in a containerized env.
+# see matrix-org/complement/dockerfiles for links to the complement
+# images that are used in tests.
+
+# NB: building needs to be done from the root of the complement directory, ie
+# `~/work/complement> docker build -t cmd/homerunner/Dockerfile . `
+# to ensure the whole project is passed to the docker container to build.
+
+# Build
+
+FROM golang:1.19-buster
+RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/complement.list
+RUN apt-get update && apt-get install -y libolm3 libolm-dev/buster-backports
+
+WORKDIR /app
+COPY . /app
+
+RUN go build ./cmd/homerunner
+
+# Executable
+
+FROM debian:buster
+RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/complement.list
+RUN apt-get update && apt-get install -y libolm3 && apt-get clean
+
+COPY --from=0 /app/homerunner /usr/local/bin/homerunner
+
+HEALTHCHECK --interval=1m --timeout=5s \
+  CMD curl -f http://localhost:54321/ || exit 1
+
+
+EXPOSE 54321/tcp
+ENTRYPOINT ["/usr/local/bin/homerunner"]
+

--- a/cmd/homerunner/README.md
+++ b/cmd/homerunner/README.md
@@ -142,3 +142,12 @@ Access tokens are returned when deploying the blueprint but sometimes you want t
 ### Health
 
 Homerunner will respond to `GET /health` with a 200 response. You can use this to check if homerunner is ready when running your tests.
+
+
+### Running using dind (docker-in-docker)
+
+The provided Docker container contains just homerunner, and a separate docker daemon will be required
+to host the homeservers that are started.
+
+This can be done by mounting the unix socket into the container, or running a `docker:dind` sidecar and exporting `DOCKER_HOST` correctly (eg `tcp://localhost:2375/`).
+

--- a/cmd/homerunner/README.md
+++ b/cmd/homerunner/README.md
@@ -9,6 +9,7 @@ HOMERUNNER_PORT=54321                                             # port to list
 HOMERUNNER_SPAWN_HS_TIMEOUT_SECS=5                                # how long to wait for the base image to spin up
 HOMERUNNER_KEEP_BLUEPRINTS='clean_hs federation_one_to_one_room'  # space delimited blueprint names to keep images for
 HOMERUNNER_SNAPSHOT_BLUEPRINT=/some/file.json                     # single shot execute this blueprint then commit the image, does not run the server
+HOMERUNNER_HS_PORTBINDING_IP=127.0.0.1                            # IP to bind homeserver ports on, if not local-only
 ```
 
 To build and run:

--- a/cmd/homerunner/main.go
+++ b/cmd/homerunner/main.go
@@ -22,6 +22,7 @@ type Config struct {
 	SpawnHSTimeout         time.Duration
 	KeepBlueprints         []string
 	Snapshot               string
+	HSPortBindingIP        string
 }
 
 func (c *Config) DeriveComplementConfig(baseImageURI string) *config.Complement {
@@ -29,6 +30,7 @@ func (c *Config) DeriveComplementConfig(baseImageURI string) *config.Complement 
 	cfg.BestEffort = true
 	cfg.KeepBlueprints = c.KeepBlueprints
 	cfg.SpawnHSTimeout = c.SpawnHSTimeout
+	cfg.HSPortBindingIP = c.HSPortBindingIP
 	return cfg
 }
 
@@ -39,6 +41,7 @@ func NewConfig() *Config {
 		SpawnHSTimeout:         5 * time.Second,
 		KeepBlueprints:         strings.Split(os.Getenv("HOMERUNNER_KEEP_BLUEPRINTS"), " "),
 		Snapshot:               os.Getenv("HOMERUNNER_SNAPSHOT_BLUEPRINT"),
+		HSPortBindingIP:        os.GetEnv("HOMERUNNER_HS_PORTBINDING_IP", "127.0.0.1"),
 	}
 	if val, _ := strconv.Atoi(os.Getenv("HOMERUNNER_LIFETIME_MINS")); val != 0 {
 		cfg.HomeserverLifetimeMins = val

--- a/cmd/homerunner/main.go
+++ b/cmd/homerunner/main.go
@@ -41,7 +41,7 @@ func NewConfig() *Config {
 		SpawnHSTimeout:         5 * time.Second,
 		KeepBlueprints:         strings.Split(os.Getenv("HOMERUNNER_KEEP_BLUEPRINTS"), " "),
 		Snapshot:               os.Getenv("HOMERUNNER_SNAPSHOT_BLUEPRINT"),
-		HSPortBindingIP:        os.GetEnv("HOMERUNNER_HS_PORTBINDING_IP", "127.0.0.1"),
+		HSPortBindingIP:        os.Getenv("HOMERUNNER_HS_PORTBINDING_IP", "127.0.0.1"),
 	}
 	if val, _ := strconv.Atoi(os.Getenv("HOMERUNNER_LIFETIME_MINS")); val != 0 {
 		cfg.HomeserverLifetimeMins = val

--- a/cmd/homerunner/main.go
+++ b/cmd/homerunner/main.go
@@ -34,6 +34,15 @@ func (c *Config) DeriveComplementConfig(baseImageURI string) *config.Complement 
 	return cfg
 }
 
+func Getenv(key string, default_value string) string {
+	value, exists := os.LookupEnv(key)
+        if (exists) {
+		return value
+	} else {
+		return default_value
+	}
+}
+
 func NewConfig() *Config {
 	cfg := &Config{
 		HomeserverLifetimeMins: 30,
@@ -41,7 +50,7 @@ func NewConfig() *Config {
 		SpawnHSTimeout:         5 * time.Second,
 		KeepBlueprints:         strings.Split(os.Getenv("HOMERUNNER_KEEP_BLUEPRINTS"), " "),
 		Snapshot:               os.Getenv("HOMERUNNER_SNAPSHOT_BLUEPRINT"),
-		HSPortBindingIP:        os.Getenv("HOMERUNNER_HS_PORTBINDING_IP", "127.0.0.1"),
+		HSPortBindingIP:        Getenv("HOMERUNNER_HS_PORTBINDING_IP", "127.0.0.1"),
 	}
 	if val, _ := strconv.Atoi(os.Getenv("HOMERUNNER_LIFETIME_MINS")); val != 0 {
 		cfg.HomeserverLifetimeMins = val

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -85,6 +85,8 @@ type Complement struct {
 	// This can be useful for container runtimes using another hostname to access the host from a container,
 	// like Podman that uses `host.containers.internal` instead.
 	HostnameRunningComplement string
+
+	HSPortBindingIP string
 }
 
 var hsRegex = regexp.MustCompile(`COMPLEMENT_BASE_IMAGE_(.+)=(.+)$`)
@@ -143,6 +145,8 @@ func NewConfigFromEnvVars(pkgNamespace, baseImageURI string) *Complement {
 		cfg.HostnameRunningComplement = "host.docker.internal"
 	}
 
+	// HSPortBindingIP is fixed here, but used by homerunner to override.
+	cfg.HSPortBindingIP = "127.0.0.1"
 	return cfg
 }
 

--- a/internal/docker/builder.go
+++ b/internal/docker/builder.go
@@ -33,6 +33,8 @@ import (
 var (
 	// HostnameRunningDocker is the hostname of the docker daemon from the perspective of Complement.
 	HostnameRunningDocker = "localhost"
+	// HostnameRunningComplement is the hostname of Complement from the perspective of a Homeserver.
+	HostnameRunningComplement = "host.docker.internal"
 )
 
 const complementLabel = "complement_context"
@@ -494,7 +496,7 @@ func endpoints(p nat.PortMap, csPort, ssPort int) (baseURL, fedBaseURL string, e
 	if len(csapiPortInfo) == 0 {
 		return "", "", fmt.Errorf("port %s exposed with not mapped port: %+v", csapiPort, p)
 	}
-	baseURL = fmt.Sprintf("http://"+HostnameRunningDocker+":%s", csapiPortInfo[0].HostPort)
+	baseURL = fmt.Sprintf("http://"+csapiPortInfo[0].HostIP+":%s", csapiPortInfo[0].HostPort)
 
 	ssapiPort := fmt.Sprintf("%d/tcp", ssPort)
 	ssapiPortInfo, ok := p[nat.Port(ssapiPort)]
@@ -504,7 +506,7 @@ func endpoints(p nat.PortMap, csPort, ssPort int) (baseURL, fedBaseURL string, e
 	if len(ssapiPortInfo) == 0 {
 		return "", "", fmt.Errorf("port %s exposed with not mapped port: %+v", ssapiPort, p)
 	}
-	fedBaseURL = fmt.Sprintf("https://"+HostnameRunningDocker+":%s", ssapiPortInfo[0].HostPort)
+	fedBaseURL = fmt.Sprintf("https://"+csapiPortInfo[0].HostIP+":%s", ssapiPortInfo[0].HostPort)
 	return
 }
 

--- a/internal/docker/deployer.go
+++ b/internal/docker/deployer.go
@@ -256,16 +256,17 @@ func deployImage(
 			"complement_hs_name":   hsName,
 		},
 	}, &container.HostConfig{
+		CapAdd: []string{"NET_ADMIN",}, // TODO : this should be some sort of option
 		PublishAllPorts: true,
 		PortBindings: nat.PortMap{
 			nat.Port("8008/tcp"): []nat.PortBinding{
 				{
-					HostIP: "127.0.0.1",
+					HostIP: cfg.HSPortBindingIP,
 				},
 			},
 			nat.Port("8448/tcp"): []nat.PortBinding{
 				{
-					HostIP: "127.0.0.1",
+					HostIP: cfg.HSPortBindingIP,
 				},
 			},
 		},


### PR DESCRIPTION
The aim of this PR is to allow homerunner to start servers using docker-dind, and make them available over a non-local network. We can take advantage of this in a k8s environment by running servers on the PodIP, and so make them available outside of the pod.

This is wanted for  trafficlight, where a adapters wrap and automate real clients (eg, ios/android/web) and so running many of them can be heavyweight. Currently we can run everything locally on a single desktop, but managing simultaneous runs of multiple tests needs us to spread the load across hosts.

The change should be a noop for complement run tests, retaining the default behaviour there, and without a configuration option being set, is also a noop for homerunner users.

If we wanted, this could also allow running a homerunner as a hosted service outside of k8s, with the resultant servers available over the network.