### PR TITLE
Test to make sure a remote invite event over federation makes it to application service

### DIFF
--- a/internal/b/hs_with_application_service.go
+++ b/internal/b/hs_with_application_service.go
@@ -31,6 +31,10 @@ var BlueprintHSWithApplicationService = MustValidate(Blueprint{
 					Localpart:   "@charlie",
 					DisplayName: "Charlie",
 				},
+				{
+					Localpart:   "@frank",
+					DisplayName: "Frank",
+				},
 			},
 			ApplicationServices: []ApplicationService{
 				{

--- a/internal/b/hs_with_application_service.go
+++ b/internal/b/hs_with_application_service.go
@@ -32,6 +32,13 @@ var BlueprintHSWithApplicationService = MustValidate(Blueprint{
 					DisplayName: "Charlie",
 				},
 			},
+			ApplicationServices: []ApplicationService{
+				{
+					ID:              "my_as_on_hs2_id",
+					SenderLocalpart: "the-bridge-user",
+					RateLimited:     false,
+				},
+			},
 		},
 	},
 })

--- a/tests/federation_rooms_invite_test.go
+++ b/tests/federation_rooms_invite_test.go
@@ -24,8 +24,9 @@ func TestFederationRoomsInvite(t *testing.T) {
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	// bob := deployment.Client(t, "hs2", "@bob:hs2")
+	// bob := deployment.Client(t, "hs1", "@bob:hs1")
 	remoteCharlie := deployment.Client(t, "hs2", "@charlie:hs2")
+	// remoteFrank := deployment.Client(t, "hs2", "@frank:hs2")
 
 	t.Run("Parallel", func(t *testing.T) {
 		t.Run("invite event over federation is seen by application service", func(t *testing.T) {
@@ -99,9 +100,15 @@ func TestFederationRoomsInvite(t *testing.T) {
 			roomID := alice.CreateRoom(t, map[string]interface{}{
 				"preset": "private_chat",
 				"name":   "Invites room",
+				// "invite": []string{bob.UserID},
 			})
 
+			// Invite another local user
+			// alice.InviteRoom(t, roomID, bob.UserID)
+
+			// Invite some remote users
 			alice.InviteRoom(t, roomID, remoteCharlie.UserID)
+			// alice.InviteRoom(t, roomID, remoteFrank.UserID)
 
 			wantFields := map[string]string{
 				"m.room.join_rules": "join_rule",


### PR DESCRIPTION
Test to make sure a remote invite event over federation makes it to application service. The test seems to pass just fine and I see the invite event coming through.

Application service testing code based off of https://github.com/matrix-org/complement/pull/221



---

Test to verify [suspicions from Rocket.chat](https://matrix.to/#/!bIONdorpQAHXPdfOvV:matrix.org/$XzkwxPJozw5j2NA03bobs5dk4jmjxMHBNIJxsYercrU?via=matrix.org&via=lant.uk) (internal link)


### Dev notes

```
$ COMPLEMENT_ALWAYS_PRINT_SERVER_LOGS=1 COMPLEMENT_DIR=../complement ./scripts-dev/complement.sh -run TestFederationRoomsInvite

=== RUN   TestFederationRoomsInvite
2022/11/23 21:12:48 Sharing [SERVER_NAME=hs1 SYNAPSE_COMPLEMENT_DATABASE=sqlite SYNAPSE_COMPLEMENT_USE_WORKERS=] host environment variables with container
2022/11/23 21:12:56 Sharing [SERVER_NAME=hs2 SYNAPSE_COMPLEMENT_DATABASE=sqlite SYNAPSE_COMPLEMENT_USE_WORKERS=] host environment variables with container
2022/11/23 21:13:06 Sharing [SERVER_NAME=hs1 SYNAPSE_COMPLEMENT_DATABASE=sqlite SYNAPSE_COMPLEMENT_USE_WORKERS=] host environment variables with container
2022/11/23 21:13:06 Sharing [SERVER_NAME=hs2 SYNAPSE_COMPLEMENT_DATABASE=sqlite SYNAPSE_COMPLEMENT_USE_WORKERS=] host environment variables with container
    federation_rooms_invite_test.go:23: Deploy times: 17.222481177s blueprints, 5.593088383s containers
=== RUN   TestFederationRoomsInvite/Parallel
=== RUN   TestFederationRoomsInvite/Parallel/invite_event_over_federation_is_seen_by_application_service
=== PAUSE TestFederationRoomsInvite/Parallel/invite_event_over_federation_is_seen_by_application_service
=== CONT  TestFederationRoomsInvite/Parallel/invite_event_over_federation_is_seen_by_application_service
=== CONT  TestFederationRoomsInvite
    client.go:599: [CSAPI] POST hs1/_matrix/client/v3/createRoom => 200 OK (292.276838ms)
    client.go:599: [CSAPI] POST hs1/_matrix/client/v3/rooms/!rfFOcrkqVClrJZQTlY:hs1/invite => 200 OK (821.404146ms)
time="2022-11-23T21:13:12-06:00" level=error msg="Saw event on application service" content="{\"displayname\":\"Charlie\",\"membership\":\"invite\"}" event_id=m.room.member state_key="@charlie:hs2"
    client.go:599: [CSAPI] GET hs2/_matrix/client/v3/sync => 200 OK (41.11582ms)
    client.go:599: [CSAPI] GET hs2/_matrix/client/v3/sync => 200 OK (7.979624ms)
    client.go:599: [CSAPI] GET hs1/_matrix/client/v3/rooms/!rfFOcrkqVClrJZQTlY:hs1/state/m.room.name/ => 200 OK (6.67833ms)
    client.go:599: [CSAPI] GET hs1/_matrix/client/v3/rooms/!rfFOcrkqVClrJZQTlY:hs1/state/m.room.join_rules/ => 200 OK (8.409172ms)
time="2022-11-23T21:13:12-06:00" level=error msg=afewfeew eventIDsWeSawOverTransactions="[$TnreUvN6VRtR5c0B1hl7YDrGRrB1EeFhdFJIz_wxNRg]"
2022/11/23 21:13:14 ============================================

--- PASS: TestFederationRoomsInvite (25.73s)
    --- PASS: TestFederationRoomsInvite/Parallel (0.00s)
        --- PASS: TestFederationRoomsInvite/Parallel/invite_event_over_federation_is_seen_by_application_service (1.18s)
PASS
ok  	github.com/matrix-org/complement/tests	26.808s
2022/11/23 21:12:49 config: &{BaseImageURI:complement-synapse DebugLoggingEnabled:false AlwaysPrintServerLogs:true EnvVarsPropagatePrefix:PASS_ SpawnHSTimeout:30s KeepBlueprints:[] HostMounts:[] BaseImageURIs:map[] PackageNamespace:csapi CACertificate:0xc0012e4000 CAPrivateKey:0xc0000212c0 BestEffort:false HostnameRunningComplement:host.docker.internal}
testing: warning: no tests to run
PASS
ok  	github.com/matrix-org/complement/tests/csapi	1.970s [no tests to run]
```