### PR TITLE
Fix setup for `TestMembersLocal` tests and split into sync types

### DIFF
--- a/tests/csapi/rooms_members_local_test.go
+++ b/tests/csapi/rooms_members_local_test.go
@@ -24,6 +24,7 @@ func TestMembersLocal(t *testing.T) {
 	)
 
 	_, incrementalSyncToken := alice.MustSync(t, client.SyncReq{})
+	bob.JoinRoom(t, roomID, []string{})
 
 	t.Run("Parallel", func(t *testing.T) {
 		// sytest: New room members see their own join event
@@ -36,7 +37,6 @@ func TestMembersLocal(t *testing.T) {
 		// sytest: Existing members see new members' join events
 		t.Run("Existing members see new members' join events", func(t *testing.T) {
 			t.Parallel()
-			bob.JoinRoom(t, roomID, []string{})
 			// SyncJoinedTo already checks everything we need to know
 			alice.MustSyncUntil(t, client.SyncReq{}, client.SyncJoinedTo(bob.UserID, roomID))
 		})

--- a/tests/csapi/rooms_members_local_test.go
+++ b/tests/csapi/rooms_members_local_test.go
@@ -15,6 +15,7 @@ func TestMembersLocal(t *testing.T) {
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
 	bob := deployment.Client(t, "hs1", "@bob:hs1")
 	roomID := alice.CreateRoom(t, map[string]interface{}{"preset": "public_chat"})
+	_, incrementalSyncToken := alice.MustSync(t, client.SyncReq{})
 
 	t.Run("Parallel", func(t *testing.T) {
 		// sytest: New room members see their own join event
@@ -33,10 +34,23 @@ func TestMembersLocal(t *testing.T) {
 		})
 
 		// sytest: Existing members see new members' presence
-		t.Run("Existing members see new members' presence", func(t *testing.T) {
+		// Split into initial and incremental sync cases in Complement.
+		t.Run("Existing members see new members' presence in initial sync", func(t *testing.T) {
 			runtime.SkipIf(t, runtime.Dendrite) // FIXME: https://github.com/matrix-org/dendrite/issues/2803
 			t.Parallel()
+			alice.MustSyncUntil(t, client.SyncReq{}, client.SyncJoinedTo(bob.UserID, roomID))
 			alice.MustSyncUntil(t, client.SyncReq{},
+				client.SyncJoinedTo(bob.UserID, roomID),
+				client.SyncPresenceHas(bob.UserID, nil),
+			)
+		})
+
+		// sytest: Existing members see new members' presence
+		// Split into initial and incremental sync cases in Complement.
+		t.Run("Existing members see new members' presence in incremental sync", func(t *testing.T) {
+			runtime.SkipIf(t, runtime.Dendrite) // FIXME: https://github.com/matrix-org/dendrite/issues/2803
+			t.Parallel()
+			alice.MustSyncUntil(t, client.SyncReq{Since: incrementalSyncToken},
 				client.SyncJoinedTo(bob.UserID, roomID),
 				client.SyncPresenceHas(bob.UserID, nil),
 			)

--- a/tests/csapi/rooms_members_local_test.go
+++ b/tests/csapi/rooms_members_local_test.go
@@ -15,6 +15,14 @@ func TestMembersLocal(t *testing.T) {
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
 	bob := deployment.Client(t, "hs1", "@bob:hs1")
 	roomID := alice.CreateRoom(t, map[string]interface{}{"preset": "public_chat"})
+
+	bob.MustDoFunc(
+		t, "PUT", []string{"_matrix", "client", "v3", "presence", bob.UserID, "status"},
+		client.WithJSONBody(t, map[string]interface{}{
+			"presence": "online",
+		}),
+	)
+
 	_, incrementalSyncToken := alice.MustSync(t, client.SyncReq{})
 
 	t.Run("Parallel", func(t *testing.T) {


### PR DESCRIPTION
Depending on timings, the "Existing members see new members' presence"
test in `TestMembersLocal` may see the expected join and presence in an
initial or incremental sync. Both types of sync elicit different
behaviour in homeserver implementations, such as Synapse. Split the test
into initial and incremental sync variants to eliminate the race
condition.

In addition, fix the initial sync case by explicitly setting Bob's
presence to online. The spec does not guarantee that Bob will have a
non-offline presence after merely joining a room, nor does the spec
guarantee that offline presences will show up in initial syncs.

Fixes https://github.com/matrix-org/synapse/issues/13199.