### PR TITLE
Ignore files generated by the `direnv` development tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ complement
 # Homerunner can end up in various places
 /homerunner
 /cmd/homerunner/homerunner
+
+# For direnv users
+/.envrc
+.direnv/


### PR DESCRIPTION
[direnv](https://direnv.net/) is a tool to automatically configure your shell in some way when entering a project's directory. I personally use it to activate a [nix flake](https://nixos.wiki/wiki/Flakes) profile - so appropriate tools and native dependencies are installed at the correct version when entering my local complement checkout.

The `.envrc` and `.direnv/` directories are a byproduct of this tool, and aren't meant to be committed to source control, hence adding them to the .gitignore file to make the life of `direnv` users easier.

The same has been done on Synapse: https://github.com/matrix-org/synapse/pull/12335.