### PR TITLE
Remove deprecated `home_server` field

### DIFF
--- a/tests/csapi/apidoc_login_test.go
+++ b/tests/csapi/apidoc_login_test.go
@@ -55,7 +55,6 @@ func TestLogin(t *testing.T) {
 			must.MatchResponse(t, res, match.HTTPResponse{
 				JSON: []match.JSON{
 					match.JSONKeyTypeEqual("access_token", gjson.String),
-					match.JSONKeyEqual("home_server", "hs1"),
 				},
 			})
 		})
@@ -96,7 +95,6 @@ func TestLogin(t *testing.T) {
 			must.MatchResponse(t, res, match.HTTPResponse{
 				JSON: []match.JSON{
 					match.JSONKeyTypeEqual("access_token", gjson.String),
-					match.JSONKeyEqual("home_server", "hs1"),
 				},
 			})
 		})


### PR DESCRIPTION
The `home_server` field in responses to `/register` and `/login` is deprecated since [r0.4.0](https://matrix.org/docs/spec/client_server/r0.4.0.html)
Same as https://github.com/matrix-org/sytest/pull/1325, but removes it completely.