### PR TITLE
Add `GetAllPushRules`, `GetPushRule` and `SetPushRule` client helper methods

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -235,8 +235,9 @@ func (c *CSAPI) GetPushRule(t *testing.T, scope string, kind string, ruleID stri
 }
 
 // SetPushRule creates a new push rule on the user, or modifies an existing one.
-// `before` and `after` parameters can be provided, which if set will map to the
-// `before` and `after` query parameters on the set push rules endpoint:
+// If `before` or `after` parameters are not set to an empty string, their values
+// will be set as the `before` and `after` query parameters respectively on the
+// "set push rules" client endpoint:
 // https://spec.matrix.org/v1.5/client-server-api/#get_matrixclientv3pushrules.
 //
 // Example of setting a push rule with ID 'com.example.rule2' that must come after 'com.example.rule1':
@@ -244,16 +245,16 @@ func (c *CSAPI) GetPushRule(t *testing.T, scope string, kind string, ruleID stri
 //	c.SetPushRule(t, "global", "underride", "com.example.rule2", map[string]interface{}{
 //	  "actions": []string{"dont_notify"},
 //	}, nil, "com.example.rule1")
-func (c *CSAPI) SetPushRule(t *testing.T, scope string, kind string, ruleID string, body map[string]interface{}, before *string, after *string) *http.Response {
+func (c *CSAPI) SetPushRule(t *testing.T, scope string, kind string, ruleID string, body map[string]interface{}, before string, after string) *http.Response {
 	t.Helper()
 
 	// If the `before` or `after` arguments have been provided, construct same-named query parameters
 	queryParams := url.Values{}
-	if before != nil {
-		queryParams.Add("before", *before)
+	if before != "" {
+		queryParams.Add("before", before)
 	}
-	if after != nil {
-		queryParams.Add("after", *after)
+	if after != "" {
+		queryParams.Add("after", after)
 	}
 
 	return c.MustDoFunc(t, "PUT", []string{"_matrix", "client", "v3", "pushrules", scope, kind, ruleID}, WithJSONBody(t, body), WithQueries(queryParams))

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -238,7 +238,7 @@ func (c *CSAPI) GetPushRule(t *testing.T, scope string, kind string, ruleID stri
 // If `before` or `after` parameters are not set to an empty string, their values
 // will be set as the `before` and `after` query parameters respectively on the
 // "set push rules" client endpoint:
-// https://spec.matrix.org/v1.5/client-server-api/#get_matrixclientv3pushrules.
+// https://spec.matrix.org/v1.5/client-server-api/#put_matrixclientv3pushrulesscopekindruleid
 //
 // Example of setting a push rule with ID 'com.example.rule2' that must come after 'com.example.rule1':
 //

--- a/tests/csapi/account_change_password_pushers_test.go
+++ b/tests/csapi/account_change_password_pushers_test.go
@@ -59,7 +59,7 @@ func TestChangePasswordPushers(t *testing.T) {
 	})
 
 	// sytest: Pushers created with a the same access token are not deleted on password change
-	t.Run("Pushers created with a the same access token are not deleted on password change", func(t *testing.T) {
+	t.Run("Pushers created with the same access token are not deleted on password change", func(t *testing.T) {
 		reqBody := client.WithJSONBody(t, map[string]interface{}{
 			"data": map[string]interface{}{
 				"url": "https://dummy.url/_matrix/push/v1/notify",

--- a/tests/csapi/push_test.go
+++ b/tests/csapi/push_test.go
@@ -20,26 +20,16 @@ func TestPushRuleCacheHealth(t *testing.T) {
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
 
-	alice.MustDoFunc(t, "PUT", []string{"_matrix", "client", "v3", "pushrules", "global", "sender", alice.UserID}, client.WithJSONBody(t, map[string]interface{}{
+	// Set a global push rule
+	alice.SetPushRule(t, "global", "sender", alice.UserID, map[string]interface{}{
 		"actions": []string{"dont_notify"},
-	}))
+	}, nil, nil)
 
-	// the extra "" is to make sure the submitted URL ends with a trailing slash
-	res := alice.MustDoFunc(t, "GET", []string{"_matrix", "client", "v3", "pushrules", ""})
+	// Fetch the rule once and check its contents
+	must.MatchGJSON(t, alice.GetAllPushRules(t), match.JSONKeyEqual("global.sender.0.actions.0", "dont_notify"))
 
-	must.MatchResponse(t, res, match.HTTPResponse{
-		JSON: []match.JSON{
-			match.JSONKeyEqual("global.sender.0.actions.0", "dont_notify"),
-		},
-	})
-
-	res = alice.MustDoFunc(t, "GET", []string{"_matrix", "client", "v3", "pushrules", ""})
-
-	must.MatchResponse(t, res, match.HTTPResponse{
-		JSON: []match.JSON{
-			match.JSONKeyEqual("global.sender.0.actions.0", "dont_notify"),
-		},
-	})
+	// Fetch the rule and check its contents again. It should not have changed.
+	must.MatchGJSON(t, alice.GetAllPushRules(t), match.JSONKeyEqual("global.sender.0.actions.0", "dont_notify"))
 }
 
 func TestPushSync(t *testing.T) {

--- a/tests/csapi/push_test.go
+++ b/tests/csapi/push_test.go
@@ -23,7 +23,7 @@ func TestPushRuleCacheHealth(t *testing.T) {
 	// Set a global push rule
 	alice.SetPushRule(t, "global", "sender", alice.UserID, map[string]interface{}{
 		"actions": []string{"dont_notify"},
-	}, nil, nil)
+	}, "", "")
 
 	// Fetch the rule once and check its contents
 	must.MatchGJSON(t, alice.GetAllPushRules(t), match.JSONKeyEqual("global.sender.0.actions.0", "dont_notify"))


### PR DESCRIPTION
Some helper methods to get and set push rules. We also refactor [tests/csapi/push_test.go](https://github.com/matrix-org/complement/pull/577/files#diff-538b85fd27b45b086bd4368eac7da9042a0d290e62de779779792572203037f0) to use them.