### PR TITLE
Fix panics due to closed channel in some tests

### DIFF
--- a/tests/csapi/push_test.go
+++ b/tests/csapi/push_test.go
@@ -111,6 +111,9 @@ func checkWokenUp(t *testing.T, csapi *client.CSAPI, syncReq client.SyncReq, fn 
 	errChan := make(chan error, 1)
 	syncStarted := make(chan struct{})
 	go func() {
+		defer close(errChan)
+		defer close(syncStarted)
+
 		var syncResp gjson.Result
 		syncStarted <- struct{}{}
 		syncResp, nextBatch = csapi.MustSync(t, syncReq)
@@ -142,7 +145,5 @@ func checkWokenUp(t *testing.T, csapi *client.CSAPI, syncReq client.SyncReq, fn 
 		t.Errorf("sync failed to return")
 	}
 
-	close(errChan)
-	close(syncStarted)
 	return nextBatch
 }

--- a/tests/federation_room_join_partial_state_test.go
+++ b/tests/federation_room_join_partial_state_test.go
@@ -134,10 +134,10 @@ func TestPartialStateJoin(t *testing.T) {
 
 		// attempts to sync should now block. Fire off a goroutine to try it.
 		syncResponseChan := make(chan gjson.Result)
-		defer close(syncResponseChan)
 		go func() {
 			response, _ := alice.MustSync(t, client.SyncReq{})
 			syncResponseChan <- response
+			close(syncResponseChan)
 		}()
 
 		// wait for the state_ids request to arrive
@@ -881,7 +881,6 @@ func TestPartialStateJoin(t *testing.T) {
 
 		// Fire off a goroutine to send the request, and write the response back to a channel.
 		clientMembersRequestResponseChan := make(chan *http.Response)
-		defer close(clientMembersRequestResponseChan)
 		go func() {
 			queryParams := url.Values{}
 			queryParams.Set("at", syncToken)
@@ -891,6 +890,7 @@ func TestPartialStateJoin(t *testing.T) {
 				[]string{"_matrix", "client", "v3", "rooms", serverRoom.RoomID, "members"},
 				client.WithQueries(queryParams),
 			)
+			close(clientMembersRequestResponseChan)
 		}()
 
 		// release the federation /state response
@@ -941,10 +941,10 @@ func TestPartialStateJoin(t *testing.T) {
 
 		// attempts to sync should block. Fire off a goroutine to try it.
 		syncResponseChan := make(chan gjson.Result)
-		defer close(syncResponseChan)
 		go func() {
 			response, _ := alice.MustSync(t, client.SyncReq{})
 			syncResponseChan <- response
+			close(syncResponseChan)
 		}()
 
 		// we expect another state_ids request to arrive.
@@ -1030,10 +1030,10 @@ func TestPartialStateJoin(t *testing.T) {
 		fedStateIdsRequestReceivedWaiter.Waitf(t, 5*time.Second, "Waiting for /state_ids request")
 
 		syncResponseChan := make(chan gjson.Result)
-		defer close(syncResponseChan)
 		go func() {
 			response, _ := charlie.MustSync(t, client.SyncReq{})
 			syncResponseChan <- response
+			close(syncResponseChan)
 		}()
 
 		// the client-side requests should still be waiting
@@ -1660,10 +1660,10 @@ func TestPartialStateJoin(t *testing.T) {
 
 		// attempts to sync should now block. Fire off a goroutine to try it.
 		jmResponseChan := make(chan *http.Response)
-		defer close(jmResponseChan)
 		go func() {
 			response := alice.MustDoFunc(t, "GET", []string{"_matrix", "client", "v3", "rooms", serverRoom.RoomID, "joined_members"})
 			jmResponseChan <- response
+			close(jmResponseChan)
 		}()
 
 		// wait for the state_ids request to arrive


### PR DESCRIPTION
A number of tests start goroutines that write into channels when completed, however the tests would close the channel if it exited early (e.g. due to a timeout).

Instead, make the goroutine that writes into the channel the one that closes it.

This does mean that the goroutines will continue past the end of the test (?), but they did that before too. I am wondering if there is a better way of doing these things...