### PR TITLE
Tests for eager-sync behaviour during and after a partial join

### DIFF
--- a/tests/federation_room_join_partial_state_test.go
+++ b/tests/federation_room_join_partial_state_test.go
@@ -1187,6 +1187,8 @@ func TestPartialStateJoin(t *testing.T) {
 		// reply to hs2 with a bogus /state_ids response
 		fedStateIdsSendResponseWaiter.Finish()
 
+		// We expect hs2 to fall back to requesting state from hs1, in order to
+		// complete the partial state join
 		nextBatch = charlie.MustSyncUntil(
 			t,
 			client.SyncReq{Since: nextBatch},

--- a/tests/federation_room_join_partial_state_test.go
+++ b/tests/federation_room_join_partial_state_test.go
@@ -255,7 +255,7 @@ func TestPartialStateJoin(t *testing.T) {
 	})
 
 	t.Run("EagerIncrementalSyncDuringPartialStateJoin", func(t *testing.T) {
-		eagerSyncDuringPartialStateJoinTest(t, "initial", true)
+		eagerSyncDuringPartialStateJoinTest(t, "incremental", true)
 	})
 
 	// when Alice does a lazy-loading sync, she should see the room immediately

--- a/tests/federation_room_join_partial_state_test.go
+++ b/tests/federation_room_join_partial_state_test.go
@@ -151,9 +151,8 @@ func TestPartialStateJoin(t *testing.T) {
 			if incremental {
 				return client.SyncReq{Since: eagerSyncToken}
 			} else {
-				// TODO: making repeated initial syncs might mean Synapse gives us a
-				// sync result from cache. Can we prevent that somehow? Restart the
-				// server would do it, but seems nuclear.
+				// NB: We are assuming that the responses to repeated initial syncs
+				// are not cached by the homeserver.
 				return client.SyncReq{Since: ""}
 			}
 		}

--- a/tests/federation_room_join_partial_state_test.go
+++ b/tests/federation_room_join_partial_state_test.go
@@ -1114,11 +1114,11 @@ func TestPartialStateJoin(t *testing.T) {
 		psjResult.FinishStateRequest()
 
 		// the /sync request should now complete, with the new room
-		response, _ = alice.MustSync(t, client.SyncReq{Since: nextBatch})
-
-		if !response.Get(syncJoinedRoomPath).Exists() {
-			t.Fatal("Sync should now include the joined room since resync is over")
-		}
+		nextBatch = alice.MustSyncUntil(
+			t,
+			client.SyncReq{Since: nextBatch},
+			client.SyncJoinedTo(alice.UserID, serverRoom.RoomID),
+		)
 	})
 
 	// test that a partial-state join can fall back to other homeservers when re-syncing
@@ -1187,11 +1187,11 @@ func TestPartialStateJoin(t *testing.T) {
 		// reply to hs2 with a bogus /state_ids response
 		fedStateIdsSendResponseWaiter.Finish()
 
-		response, _ = charlie.MustSync(t, client.SyncReq{Since: nextBatch})
-
-		if !response.Get(syncJoinedRoomPath).Exists() {
-			t.Fatal("hs2 /sync completed without join to new room")
-		}
+		nextBatch = charlie.MustSyncUntil(
+			t,
+			client.SyncReq{Since: nextBatch},
+			client.SyncJoinedTo(charlie.UserID, roomID),
+		)
 	})
 
 	// test a lazy-load-members sync while re-syncing partial state, followed by completion of state syncing,

--- a/tests/federation_room_join_partial_state_test.go
+++ b/tests/federation_room_join_partial_state_test.go
@@ -242,7 +242,7 @@ func TestPartialStateJoin(t *testing.T) {
 
 		roomRes := response.Get(syncJoinedRoomPath)
 		if !roomRes.Exists() {
-			t.Fatal("Sync should now include the joined room since resync is over")
+			t.Fatal("Sync does NOT include the joined room after the resync, but should")
 		}
 
 		// check that the state includes both charlie and derek.

--- a/tests/federation_room_join_partial_state_test.go
+++ b/tests/federation_room_join_partial_state_test.go
@@ -227,6 +227,7 @@ func TestPartialStateJoin(t *testing.T) {
 
 		// release the federation /state response
 		psjResult.FinishStateRequest()
+		awaitPartialStateJoinCompletion(t, serverRoom, alice)
 
 		t.Log("8. Have Alice eager-sync. She should see the remote room, including" +
 			"Charlie and Derek.")

--- a/tests/federation_room_join_partial_state_test.go
+++ b/tests/federation_room_join_partial_state_test.go
@@ -228,26 +228,21 @@ func TestPartialStateJoin(t *testing.T) {
 		// release the federation /state response
 		psjResult.FinishStateRequest()
 
-		t.Log("8. Have Alice eager-sync. She should see the remote room.")
-		response, eagerSyncToken = alice.MustSync(t, getEagerSyncReq())
-
-		roomRes := response.Get(syncJoinedRoomPath)
-		if !roomRes.Exists() {
-			t.Fatal("Sync should now include the joined room since resync is over")
+		t.Log("8. Have Alice eager-sync. She should see the remote room, including" +
+			"Charlie and Derek.")
+		remoteMembershipFor := func(localpart string) func(result gjson.Result) bool {
+			return func(result gjson.Result) bool {
+				return result.Get("type").Str == "m.room.member" && result.Get("state_key").Str == server.UserID(localpart)
+			}
 		}
 
-		// check that the state includes both charlie and derek.
-		matcher := match.JSONCheckOffAllowUnwanted("state.events",
-			[]interface{}{
-				"m.room.member|" + server.UserID("charlie"),
-				"m.room.member|" + server.UserID("derek"),
-			}, func(result gjson.Result) interface{} {
-				return strings.Join([]string{result.Map()["type"].Str, result.Map()["state_key"].Str}, "|")
-			}, nil,
+		_ = alice.MustSyncUntil(
+			t,
+			getEagerSyncReq(),
+			client.SyncJoinedTo(alice.UserID, serverRoom.RoomID),
+			client.SyncStateHas(serverRoom.RoomID, remoteMembershipFor("charlie")),
+			client.SyncStateHas(serverRoom.RoomID, remoteMembershipFor("derek")),
 		)
-		if err := matcher([]byte(roomRes.Raw)); err != nil {
-			t.Errorf("Did not find expected state events in /sync response: %s", err)
-		}
 	}
 
 	t.Run("EagerInitialSyncDuringPartialStateJoin", func(t *testing.T) {

--- a/tests/federation_room_join_partial_state_test.go
+++ b/tests/federation_room_join_partial_state_test.go
@@ -173,7 +173,7 @@ func TestPartialStateJoin(t *testing.T) {
 		psjResult := beginPartialStateJoin(t, server, serverRoom, alice)
 		defer psjResult.Destroy(t)
 
-		// 2. Have Alice lazy-sync until she sees (1).
+		t.Log("2. Have Alice lazy-sync until she sees (1).")
 		lazySyncToken = alice.MustSyncUntil(
 			t,
 			getLazySyncReq(),

--- a/tests/federation_room_join_partial_state_test.go
+++ b/tests/federation_room_join_partial_state_test.go
@@ -151,6 +151,9 @@ func TestPartialStateJoin(t *testing.T) {
 			if incremental {
 				return client.SyncReq{Since: eagerSyncToken}
 			} else {
+				// TODO: making repeated initial syncs might mean Synapse gives us a
+				// sync result from cache. Can we prevent that somehow? Restart the
+				// server would do it, but seems nuclear.
 				return client.SyncReq{Since: ""}
 			}
 		}

--- a/tests/federation_room_join_partial_state_test.go
+++ b/tests/federation_room_join_partial_state_test.go
@@ -166,7 +166,15 @@ func TestPartialStateJoin(t *testing.T) {
 		_, eagerSyncToken = alice.MustSync(t, client.SyncReq{})
 
 		t.Log("1. Partial join Alice to a remote room.")
-		server := createTestServer(t, deployment)
+		server := createTestServer(
+			t,
+			deployment,
+			// Allow PDUs and EDUs, since Alice will send a message in the room.
+			federation.HandleTransactionRequests(
+				func(e *gomatrixserverlib.Event) {},
+				func(e gomatrixserverlib.EDU) {},
+			),
+		)
 		cancel := server.Listen()
 		defer cancel()
 		serverRoom := createTestRoom(t, server, alice.GetDefaultRoomVersion(t))

--- a/tests/federation_room_join_partial_state_test.go
+++ b/tests/federation_room_join_partial_state_test.go
@@ -169,6 +169,70 @@ func TestPartialStateJoin(t *testing.T) {
 		}
 	})
 
+	t.Run("NonLazyLongPollingSyncDuringPartialStateJoin", func(t *testing.T) {
+		alice := deployment.RegisterUser(t, "hs1", "t99alice", "secret", false)
+
+		server := createTestServer(t, deployment)
+		cancel := server.Listen()
+		defer cancel()
+		serverRoom := createTestRoom(t, server, alice.GetDefaultRoomVersion(t))
+		psjResult := beginPartialStateJoin(t, server, serverRoom, alice)
+		defer psjResult.Destroy(t)
+
+		// Alice has now joined the room, and the server is syncing the state in the background.
+
+		// initial sync shouldn't include the room yet, but still return immediatly
+		response, nextBatch := alice.MustSync(t, client.SyncReq{
+			TimeoutMillis: "10000",
+		})
+
+		syncJoinedRoomPath := "rooms.join." + client.GjsonEscape(serverRoom.RoomID)
+		if response.Get(syncJoinedRoomPath).Exists() {
+			t.Fatal("Sync shouldn't include the joined room until resync is over")
+		}
+
+		// Begin a long polling sync that shouldn't return yet since no change happened
+		responseChan := make(chan gjson.Result, 1)
+		syncStarted := make(chan struct{})
+		go func() {
+			defer close(responseChan)
+			defer close(syncStarted)
+
+			syncStarted <- struct{}{}
+			response, _ := alice.MustSync(t, client.SyncReq{
+				TimeoutMillis: "10000",
+				Since:         nextBatch,
+			})
+			responseChan <- response
+		}()
+
+		// Try to wait for the sync to actually start, then un-partial-state the room
+		select {
+		case <-syncStarted:
+			// wait for the state_ids request to arrive
+			psjResult.AwaitStateIdsRequest(t)
+			// release the federation /state response
+			psjResult.FinishStateRequest()
+		case <-time.After(time.Second * 5):
+			// even though this should mostly be impossible, make sure we have a timeout
+			t.Fatalf("goroutine didn't start")
+		}
+
+		// Try to wait for the sync to return or timeout after 15 seconds,
+		// as the above tests are using a timeout of 10 seconds
+		select {
+		case response = <-responseChan:
+		case <-time.After(time.Second * 5):
+			t.Errorf("sync should have returned before the timeout")
+		}
+
+		// the /sync request should now complete, with the new room
+		roomRes := response.Get(syncJoinedRoomPath)
+		if !roomRes.Exists() {
+			t.Fatal("Sync should now include the joined room since resync is over")
+		}
+	})
+
 	// when Alice does a lazy-loading sync, she should see the room immediately
 	t.Run("CanLazyLoadingSyncDuringPartialStateJoin", func(t *testing.T) {
 		alice := deployment.RegisterUser(t, "hs1", "t2alice", "secret", false)


### PR DESCRIPTION
Based on #584 by @MatMaul.

Matches https://github.com/matrix-org/synapse/pull/14870

