### PR TITLE
Ignore presence updates in test

### DIFF
--- a/tests/federation_room_join_partial_state_test.go
+++ b/tests/federation_room_join_partial_state_test.go
@@ -215,7 +215,9 @@ func TestPartialStateJoin(t *testing.T) {
 				},
 				// we don't expect EDUs
 				func(e gomatrixserverlib.EDU) {
-					t.Fatalf("Received unexpected EDU: %s", e.Content)
+					if e.Type != "m.presence" {
+						t.Fatalf("Received unexpected EDU: %s", e.Content)
+					}
 				},
 			),
 		)


### PR DESCRIPTION
Otherwise the test fails if the server receives a presence update during the partial join