### PR TITLE
Increase thread safety on variables

### DIFF
--- a/internal/federation/handle.go
+++ b/internal/federation/handle.go
@@ -163,6 +163,7 @@ func SendJoinRequestsHandler(s *Server, w http.ResponseWriter, req *http.Request
 
 	// build the state list *before* we insert the new event
 	var stateEvents []*gomatrixserverlib.Event
+	room.StateMutex.RLock()
 	for _, ev := range room.State {
 		// filter out non-critical memberships if this is a partial-state join
 		if expectPartialState {
@@ -172,6 +173,7 @@ func SendJoinRequestsHandler(s *Server, w http.ResponseWriter, req *http.Request
 		}
 		stateEvents = append(stateEvents, ev)
 	}
+	room.StateMutex.RUnlock()
 
 	authEvents := room.AuthChainForEvents(stateEvents)
 

--- a/tests/csapi/device_lists_test.go
+++ b/tests/csapi/device_lists_test.go
@@ -2,6 +2,7 @@ package csapi_tests
 
 import (
 	"fmt"
+	"sync/atomic"
 	"testing"
 
 	"github.com/matrix-org/complement/internal/b"
@@ -19,11 +20,11 @@ import (
 //  1. `/sync`'s `device_lists.changed/left` contain the correct user IDs.
 //  2. `/keys/query` returns the correct information after device list updates.
 func TestDeviceListUpdates(t *testing.T) {
-	localpartIndex := 0
+	var localpartIndex int64 = 0
 	// generateLocalpart generates a unique localpart based on the given name.
 	generateLocalpart := func(localpart string) string {
-		localpartIndex++
-		return fmt.Sprintf("%s%d", localpart, localpartIndex)
+		index := atomic.AddInt64(&localpartIndex, 1)
+		return fmt.Sprintf("%s%d", localpart, index)
 	}
 
 	// uploadNewKeys uploads a new set of keys for a given client.

--- a/tests/msc2716_test.go
+++ b/tests/msc2716_test.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1446,7 +1447,7 @@ func createMessageEventsForBatchSendRequest(
 			"origin_server_ts": insertOriginServerTs + (timeBetweenMessagesMS * uint64(i)),
 			"content": map[string]interface{}{
 				"msgtype":              "m.text",
-				"body":                 fmt.Sprintf("Historical %d (batch=%d)", i, batchCount),
+				"body":                 fmt.Sprintf("Historical %d (batch=%d)", i, atomic.LoadInt64(&batchCount)),
 				historicalContentField: true,
 			},
 		}
@@ -1514,7 +1515,7 @@ func batchSendHistoricalMessages(
 		t.Fatalf("msc2716.batchSendHistoricalMessages got %d HTTP status code from batch send response but want %d", res.StatusCode, expectedStatus)
 	}
 
-	batchCount++
+	atomic.AddInt64(&batchCount, 1)
 
 	return res
 }

--- a/tests/room_timestamp_to_event_test.go
+++ b/tests/room_timestamp_to_event_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"net/url"
 	"strconv"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -236,12 +237,12 @@ type eventTime struct {
 	AfterTimestamp  time.Time
 }
 
-var txnCounter int = 0
+var txnCounter int64 = 0
 
 func getTxnID(prefix string) (txnID string) {
-	txnId := fmt.Sprintf("%s-%d", prefix, txnCounter)
+	txnId := fmt.Sprintf("%s-%d", prefix, atomic.LoadInt64(&txnCounter))
 
-	txnCounter++
+	atomic.AddInt64(&txnCounter, 1)
 
 	return txnId
 }


### PR DESCRIPTION
While experimenting with Complement and trying to speed up a few things, I noticed some race conditions causing inconsistent results. I started tracking them down one-by-one using the `-race` flag on `go test`. Fixing these allows heavier usage of `t.Parallel()` during tests while sharing a deployment and registering fresh users with `RegisterUser()`(ala, federation_room_join_partial_state_test.go and #471) and it's siblings and derivatives. This alone will not(unfortunately) speed up Complement on Synapse(especially on Github CI), but will pave the way for less odd and inconsistent errors in the future. Hopefully, some flakes will go away as well(looking at you `Client Timeout while awaiting headers`).

Mutex's and RWMutex's were the main go-to, but atomic.AddInt64() was also used in a few places where I felt it was more appropriate.

There is an entire set of data races I couldn't touch from this repo, those caused by [gorilla's mux](https://github.com/gorilla/mux) package. The problem stems from the complement test server that is created to test federation responses. Sometimes a test server is created, then started with `Listen()`, and ***then*** an additional Handler is added on to the server(which is necessary to get the results of the test). This causes a data race in the Router.routes slice when Router.Match is concurrently called.  Unfortunately, this package is [no longer maintained and has been archived](https://github.com/gorilla/mux/issues/659). If someone at matrix.org would like to fork it, I can submit the PR to patch it. I'm still exploring other packages that might meet the requirements as a replacement, but would appreciate suggestions or a fuller list of said requirements than I can get by just reading the source code.

Should be reviewable commit-wise.

Useful links:
* https://stackoverflow.com/questions/36167200/how-safe-are-golang-maps-for-concurrent-read-write-operations

Signed-off-by: Jason Little <realtyem@gmail.com>