### PR TITLE
Faster room joins: Deflake events-arriving-before-prev_events test again

### DIFF
--- a/tests/federation_room_join_partial_state_test.go
+++ b/tests/federation_room_join_partial_state_test.go
@@ -1383,7 +1383,10 @@ func TestPartialStateJoin(t *testing.T) {
 
 		// alice should be able to sync the room. We can't use SyncJoinedTo here because that looks for the
 		// membership event in the response (which we won't see, because all of the outlier events).
-		// instead let's just check for the presence of the room in the timeline
+		// instead let's just check for the presence of the room in the timeline.
+		// it can take a while for the homeserver to update its state for 100+ events, so raise
+		// the default timeout.
+		alice.SyncUntilTimeout = 20 * time.Second
 		alice.MustSyncUntil(t,
 			client.SyncReq{},
 			func(clientUserID string, topLevelSyncJSON gjson.Result) error {


### PR DESCRIPTION
We previously attempted to deflake this test in #490 by waiting longer
for the 100 outlier events to be persisted. This turned out to be
insufficient, as calculating the full state for all 100 events can also
take a while and delay the room's appearance in /sync.

Raise the timeout for waiting for the room to appear in /sync from 5
seconds to 20 seconds. Going off the logs of the failing test runs, it
takes 6 to 10 seconds for the room to appear in /sync.

---

Fixes https://github.com/matrix-org/synapse/issues/13777.