### PR TITLE
Add workflow_dispatch to ci.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [ 'master', 'main' ]
   pull_request:
+  workflow_dispatch:
 
 jobs:
   check-signoff:
@@ -25,7 +26,7 @@ jobs:
           sudo apt-get update && sudo apt-get install -y libolm3 libolm-dev
       - name: "Run internal Complement tests"
         run: |
-          go test ./internal/... 
+          go test ./internal/...
       - name: "Run Homerunner tests" # use a simple static dendrite image to sanity check homerunner works
         run: |
           mkdir -p homeserver
@@ -76,7 +77,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p homeserver
-          
+
           # Attempt to use the version of the homeserver which best matches the
           # current build.
           #
@@ -84,7 +85,7 @@ jobs:
           #    similarly named branch (GITHUB_HEAD_REF for pull requests,
           #    otherwise GITHUB_REF).
           # 2. otherwise, use the default homeserver branch ("HEAD")
-          
+
           for BRANCH_NAME in "$GITHUB_HEAD_REF" "${GITHUB_REF#refs/heads/}" "HEAD"; do
             # Skip empty branch names, merge commits, and our default branch.
             # (If we are on complement's default branch, we want to fall through to the HS's default branch


### PR DESCRIPTION
Allow running the suite of CI tests without creating a PR. Right now, in order to test a change in Complement, I have to create a Pull Request either against this repo or my own. With this, I can just run it on my personal repo/branch by clicking a button.

### Pull Request Checklist

- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)

Signed-off-by: Jason Little <realtyem@gmail.com>