### PR TITLE
Test that Synapse will purge a room during resync

### DIFF
--- a/tests/federation_room_join_partial_state_test.go
+++ b/tests/federation_room_join_partial_state_test.go
@@ -3646,7 +3646,12 @@ func TestPartialStateJoin(t *testing.T) {
 		}
 		t.Log("Alice begins a partial join to a room")
 		alice := deployment.RegisterUser(t, "hs1", "t46alice", "secret", true)
-		server := createTestServer(t, deployment)
+		// Ignore PDUs (leaves from shutting down the room) and EDUs (presence).
+		server := createTestServer(
+			t,
+			deployment,
+			federation.HandleTransactionRequests(nil, nil),
+		)
 		cancel := server.Listen()
 		defer cancel()
 

--- a/tests/federation_room_join_partial_state_test.go
+++ b/tests/federation_room_join_partial_state_test.go
@@ -3645,7 +3645,7 @@ func TestPartialStateJoin(t *testing.T) {
 			t.Skipf("Skipping test of Synapse-internal API on %s", runtime.Homeserver)
 		}
 		t.Log("Alice begins a partial join to a room")
-		alice := deployment.RegisterUser(t, "hs1", "t41alice", "secret", true)
+		alice := deployment.RegisterUser(t, "hs1", "t46alice", "secret", true)
 		server := createTestServer(t, deployment)
 		cancel := server.Listen()
 		defer cancel()


### PR DESCRIPTION
See https://github.com/matrix-org/synapse/pull/15068.

IDK if we want Synapse-specific tests in Synapse, but short of https://github.com/matrix-org/complement/issues/226 I think this is the least-bad option.