### PR TITLE
Fix `TestDeviceListUpdates` flakes, again

### DIFF
--- a/tests/csapi/device_lists_test.go
+++ b/tests/csapi/device_lists_test.go
@@ -159,6 +159,7 @@ func TestDeviceListUpdates(t *testing.T) {
 		aliceNextBatch = alice.MustSyncUntil(
 			t,
 			client.SyncReq{Since: aliceNextBatch},
+			client.SyncJoinedTo(bob.UserID, roomID),
 			syncDeviceListsHas("changed", bob.UserID),
 		)
 		mustQueryKeys(t, alice, bob.UserID, checkBobKeys)
@@ -200,6 +201,7 @@ func TestDeviceListUpdates(t *testing.T) {
 		aliceNextBatch = alice.MustSyncUntil(
 			t,
 			client.SyncReq{Since: aliceNextBatch},
+			client.SyncJoinedTo(alice.UserID, roomID),
 			syncDeviceListsHas("changed", bob.UserID),
 		)
 		mustQueryKeys(t, alice, bob.UserID, checkBobKeys)
@@ -246,6 +248,7 @@ func TestDeviceListUpdates(t *testing.T) {
 		aliceNextBatch = alice.MustSyncUntil(
 			t,
 			client.SyncReq{Since: aliceNextBatch},
+			client.SyncLeftFrom(bob.UserID, roomID),
 			syncDeviceListsHas("left", bob.UserID),
 		)
 
@@ -290,6 +293,7 @@ func TestDeviceListUpdates(t *testing.T) {
 		aliceNextBatch = alice.MustSyncUntil(
 			t,
 			client.SyncReq{Since: aliceNextBatch},
+			client.SyncLeftFrom(alice.UserID, roomID),
 			syncDeviceListsHas("left", bob.UserID),
 		)
 
@@ -335,6 +339,7 @@ func TestDeviceListUpdates(t *testing.T) {
 		alice.MustSyncUntil(
 			t,
 			client.SyncReq{Since: aliceNextBatch},
+			client.SyncLeftFrom(bob.UserID, roomID),
 			syncDeviceListsHas("left", bob.UserID),
 		)
 
@@ -352,6 +357,7 @@ func TestDeviceListUpdates(t *testing.T) {
 		alice.MustSyncUntil(
 			t,
 			client.SyncReq{Since: aliceNextBatch},
+			client.SyncJoinedTo(bob.UserID, roomID),
 			syncDeviceListsHas("changed", bob.UserID),
 		)
 		mustQueryKeys(t, alice, bob.UserID, checkBobKeys)


### PR DESCRIPTION
When a homeserver (Synapse) performs a partial state join to a room, it
may emit `device_lists.changed` entries for users it thinks are in the
room, despite the room not appearing in the /sync response yet. This is
questionable behaviour, but not forbidden by the spec. Once the
homeserver is fully joined to the room, it may emit another round of
`device_lists.changed` entries for users it knows are definitely in the
room.

These extra entries were causing test cases to advance prematurely and
randomly fail. To fix the tests, we explicitly check for join events
alongside the `device_lists.changed` entries produced by joins. In
effect, we ensure that homeservers are fully joined to the test rooms
before continuing the rest of the tests.

For consistency, we also check for leave events alongside
`device_lists.left` entries.

---

Fixes https://github.com/matrix-org/synapse/issues/14103.
