### PR TITLE
Test the scope of a transaction IDs

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -459,6 +459,80 @@ func (c *CSAPI) LoginUser(t *testing.T, localpart, password string, opts ...Logi
 	return userID, accessToken, deviceID
 }
 
+// LoginUserWithDeviceID will log in to a homeserver on an existing device
+func (c *CSAPI) LoginUserWithDeviceID(t *testing.T, localpart, password, deviceID string) (userID, accessToken string) {
+	t.Helper()
+	reqBody := map[string]interface{}{
+		"identifier": map[string]interface{}{
+			"type": "m.id.user",
+			"user": localpart,
+		},
+		"device_id": deviceID,
+		"password":  password,
+		"type":      "m.login.password",
+	}
+	res := c.MustDoFunc(t, "POST", []string{"_matrix", "client", "v3", "login"}, WithJSONBody(t, reqBody))
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		t.Fatalf("unable to read response body: %v", err)
+	}
+
+	userID = gjson.GetBytes(body, "user_id").Str
+	accessToken = gjson.GetBytes(body, "access_token").Str
+	if gjson.GetBytes(body, "device_id").Str != deviceID {
+		t.Fatalf("device_id returned by login does not match the one requested")
+	}
+	return userID, accessToken
+}
+
+// LoginUserWithRefreshToken will log in to a homeserver, with refresh token enabled,
+// and create a new device on an existing user.
+func (c *CSAPI) LoginUserWithRefreshToken(t *testing.T, localpart, password string) (userID, accessToken, refreshToken, deviceID string, expiresInMs int64) {
+	t.Helper()
+	reqBody := map[string]interface{}{
+		"identifier": map[string]interface{}{
+			"type": "m.id.user",
+			"user": localpart,
+		},
+		"password":      password,
+		"type":          "m.login.password",
+		"refresh_token": true,
+	}
+	res := c.MustDoFunc(t, "POST", []string{"_matrix", "client", "v3", "login"}, WithJSONBody(t, reqBody))
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		t.Fatalf("unable to read response body: %v", err)
+	}
+
+	userID = gjson.GetBytes(body, "user_id").Str
+	accessToken = gjson.GetBytes(body, "access_token").Str
+	deviceID = gjson.GetBytes(body, "device_id").Str
+	refreshToken = gjson.GetBytes(body, "refresh_token").Str
+	expiresInMs = gjson.GetBytes(body, "expires_in_ms").Int()
+	return userID, accessToken, refreshToken, deviceID, expiresInMs
+}
+
+// RefreshToken will consume a refresh token and return a new access token and refresh token.
+func (c *CSAPI) ConsumeRefreshToken(t *testing.T, refreshToken string) (newAccessToken, newRefreshToken string, expiresInMs int64) {
+	t.Helper()
+	reqBody := map[string]interface{}{
+		"refresh_token": refreshToken,
+	}
+	res := c.MustDoFunc(t, "POST", []string{"_matrix", "client", "v3", "refresh"}, WithJSONBody(t, reqBody))
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		t.Fatalf("unable to read response body: %v", err)
+	}
+
+	newAccessToken = gjson.GetBytes(body, "access_token").Str
+	newRefreshToken = gjson.GetBytes(body, "refresh_token").Str
+	expiresInMs = gjson.GetBytes(body, "expires_in_ms").Int()
+	return newAccessToken, newRefreshToken, expiresInMs
+}
+
 // RegisterUser will register the user with given parameters and
 // return user ID, access token and device ID. It fails the test on network error.
 func (c *CSAPI) RegisterUser(t *testing.T, localpart, password string) (userID, accessToken, deviceID string) {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -459,33 +459,6 @@ func (c *CSAPI) LoginUser(t *testing.T, localpart, password string, opts ...Logi
 	return userID, accessToken, deviceID
 }
 
-// LoginUserWithDeviceID will log in to a homeserver on an existing device
-func (c *CSAPI) LoginUserWithDeviceID(t *testing.T, localpart, password, deviceID string) (userID, accessToken string) {
-	t.Helper()
-	reqBody := map[string]interface{}{
-		"identifier": map[string]interface{}{
-			"type": "m.id.user",
-			"user": localpart,
-		},
-		"device_id": deviceID,
-		"password":  password,
-		"type":      "m.login.password",
-	}
-	res := c.MustDoFunc(t, "POST", []string{"_matrix", "client", "v3", "login"}, WithJSONBody(t, reqBody))
-
-	body, err := ioutil.ReadAll(res.Body)
-	if err != nil {
-		t.Fatalf("unable to read response body: %v", err)
-	}
-
-	userID = gjson.GetBytes(body, "user_id").Str
-	accessToken = gjson.GetBytes(body, "access_token").Str
-	if gjson.GetBytes(body, "device_id").Str != deviceID {
-		t.Fatalf("device_id returned by login does not match the one requested")
-	}
-	return userID, accessToken
-}
-
 // LoginUserWithRefreshToken will log in to a homeserver, with refresh token enabled,
 // and create a new device on an existing user.
 func (c *CSAPI) LoginUserWithRefreshToken(t *testing.T, localpart, password string) (userID, accessToken, refreshToken, deviceID string, expiresInMs int64) {


### PR DESCRIPTION
This adds two tests, which check the current spec behaviour of transaction IDs, which are that they are scoped to a series of access tokens, and not the device ID.

The first test highlight this behaviour, by logging in with refresh token enabled, sending an event, using the refresh token and syncing with the new access token. On the sync, the transaction ID should be there, but currently in Synapse it is not.

This test will fail in Synapse because the behaviour does not match the spec, and it will fail in Dendrite because it does not implement refreshable access tokens. Let me know if I should at it to their respective blacklist?

The second test highlight that the transaction ID is not scoped to the device ID, by logging in twice with the same device ID, sending an event with the first access token, and syncing with the second access token. In that case, the sync should not contain the transaction ID, but I think it's the case in HS implementations which use the device ID to scope the transaction IDs, like Conduit.

Related: matrix-org/matrix-spec#1133, matrix-org/matrix-spec#1236, matrix-org/synapse#13064 and matrix-org/synapse#13083
