### PR TITLE
Don't require room_alias in /createRoom response

### DIFF
--- a/tests/csapi/apidoc_room_create_test.go
+++ b/tests/csapi/apidoc_room_create_test.go
@@ -1,7 +1,6 @@
 package csapi_tests
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/tidwall/gjson"
@@ -36,7 +35,6 @@ func TestRoomCreate(t *testing.T) {
 			}, match.HTTPResponse{
 				StatusCode: 200,
 				JSON: []match.JSON{
-					match.JSONKeyEqual("room_alias", fmt.Sprintf("#%s:hs1", roomAlias)),
 					match.JSONKeyTypeEqual("room_id", gjson.String),
 				},
 			})


### PR DESCRIPTION
This ports https://github.com/matrix-org/sytest/pull/1216 to complement.

See also
https://github.com/matrix-org/synapse/pull/14884#issuecomment-1403516617

