### PR TITLE
More tests for leaves during a partial state resync

### DIFF
--- a/tests/federation_room_join_partial_state_test.go
+++ b/tests/federation_room_join_partial_state_test.go
@@ -3512,7 +3512,7 @@ func TestPartialStateJoin(t *testing.T) {
 				client.SyncLeftFrom(alice.UserID, serverRoom.RoomID),
 			)
 
-			t.Logf("Alice's leave is recieved by the resident server")
+			t.Logf("Alice's leave is received by the resident server")
 			select {
 			case <-time.After(1 * time.Second):
 				t.Fatal("Resident server did not receive Alice's leave")

--- a/tests/federation_room_join_partial_state_test.go
+++ b/tests/federation_room_join_partial_state_test.go
@@ -3359,7 +3359,7 @@ func TestPartialStateJoin(t *testing.T) {
 	// Test that display name changes do not block during a resync.
 	// Display name changes are represented by `m.room_membership` events with a membership of
 	// "join", and can be confused with join events.
-	t.Run("Can change display name during partial state join", func(t * testing.T) {
+	t.Run("Can change display name during partial state join", func(t *testing.T) {
 		alice := deployment.RegisterUser(t, "hs1", "t45alice", "secret", false)
 
 		pdusChannel := make(chan *gomatrixserverlib.Event)
@@ -3398,9 +3398,9 @@ func TestPartialStateJoin(t *testing.T) {
 		case pdu := <-pdusChannel:
 			content := gjson.ParseBytes(pdu.Content())
 			if pdu.Type() != "m.room.member" ||
-			   *pdu.StateKey() != alice.UserID ||
-			   content.Get("membership").Str != "join" ||
-			   content.Get("displayname").Str != "alice 2" {
+				*pdu.StateKey() != alice.UserID ||
+				content.Get("membership").Str != "join" ||
+				content.Get("displayname").Str != "alice 2" {
 				t.Errorf("Did not receive expected display name change event: %s", pdu.JSON())
 			}
 		case <-time.After(1 * time.Second):

--- a/tests/federation_room_join_partial_state_test.go
+++ b/tests/federation_room_join_partial_state_test.go
@@ -3460,7 +3460,6 @@ func TestPartialStateJoin(t *testing.T) {
 	})
 
 	t.Run("Leaving a room immediately after joining does not wait for resync", func(t *testing.T) {
-		t.Skip("Not yet implemented (synapse#12802)")
 		// Prepare to listen for leave events from the HS under test.
 		// We're only expecting one leave event, but give the channel extra capacity
 		// to avoid deadlock if the HS does something silly.

--- a/tests/federation_room_join_partial_state_test.go
+++ b/tests/federation_room_join_partial_state_test.go
@@ -3745,7 +3745,7 @@ func TestPartialStateJoin(t *testing.T) {
 			)
 
 			t.Log("A resident server user bans Alice from the room.")
-			kickEvent := server.MustCreateEvent(t, serverRoom, b.Event{
+			banEvent := server.MustCreateEvent(t, serverRoom, b.Event{
 				Type:     "m.room.member",
 				StateKey: b.Ptr(alice.UserID),
 				Sender:   server.UserID("charlie"),
@@ -3757,10 +3757,10 @@ func TestPartialStateJoin(t *testing.T) {
 					serverRoom.CurrentState("m.room.member", server.UserID("charlie")),
 				}),
 			})
-			serverRoom.AddEvent(kickEvent)
-			server.MustSendTransaction(t, deployment, "hs1", []json.RawMessage{kickEvent.JSON()}, nil)
+			serverRoom.AddEvent(banEvent)
+			server.MustSendTransaction(t, deployment, "hs1", []json.RawMessage{banEvent.JSON()}, nil)
 
-			// The kick occurs mid-resync, because we have not yet called
+			// The ban occurs mid-resync, because we have not yet called
 			// psjResult.FinishStateRequest().
 			t.Log("Alice sees that she's been banned")
 			aliceNextBatch = alice.MustSyncUntil(

--- a/tests/federation_room_join_partial_state_test.go
+++ b/tests/federation_room_join_partial_state_test.go
@@ -3771,6 +3771,14 @@ func TestPartialStateJoin(t *testing.T) {
 				client.SyncLeftFrom(alice.UserID, serverRoom.RoomID),
 			)
 
+			t.Log("Alice tries to rejoin...")
+			queryParams := url.Values{}
+			queryParams.Add("server_name", server.ServerName())
+			response := alice.DoFunc(t, "POST", []string{"_matrix", "client", "v3", "join", serverRoom.RoomID}, client.WithQueries(queryParams))
+
+			t.Log("... but Alice was forbidden from rejoining")
+			must.MatchResponse(t, response, match.HTTPResponse{StatusCode: http.StatusForbidden})
+
 			// Cleanup.
 			psjResult.FinishStateRequest()
 		})

--- a/tests/federation_room_join_partial_state_test.go
+++ b/tests/federation_room_join_partial_state_test.go
@@ -3413,7 +3413,6 @@ func TestPartialStateJoin(t *testing.T) {
 		t.Run("is seen after the resync", func(t *testing.T) {
 			// Before testing that leaves during resyncs are seen during resyncs, sanity
 			// check that leaves during resyncs appear after the resync.
-			t.Log("Alice begins a partial join to a room")
 			alice := deployment.RegisterUser(t, "hs1", "t42alice", "secret", false)
 			handleTransactions := federation.HandleTransactionRequests(
 				// Accept all PDUs and EDUs
@@ -3480,7 +3479,6 @@ func TestPartialStateJoin(t *testing.T) {
 				func(e gomatrixserverlib.EDU) {},
 			)
 
-			t.Log("Alice begins a partial join to a room")
 			alice := deployment.RegisterUser(t, "hs1", "t43alice", "secret", false)
 			server := createTestServer(
 				t,
@@ -3491,6 +3489,7 @@ func TestPartialStateJoin(t *testing.T) {
 			defer cancel()
 
 			serverRoom := createTestRoom(t, server, alice.GetDefaultRoomVersion(t))
+			t.Log("Alice begins a partial join to a room")
 			psjResult := beginPartialStateJoin(t, server, serverRoom, alice)
 			defer psjResult.Destroy(t)
 

--- a/tests/federation_room_join_partial_state_test.go
+++ b/tests/federation_room_join_partial_state_test.go
@@ -3444,9 +3444,6 @@ func TestPartialStateJoin(t *testing.T) {
 				leaveCompleted.Finish()
 			}()
 
-			// We want Synapse to receive the leave before its resync completes.
-			// HACK: Use a sleep to try and ensure this.
-			time.Sleep(250 * time.Millisecond)
 			t.Log("The resync finishes")
 			psjResult.FinishStateRequest()
 

--- a/tests/federation_room_join_partial_state_test.go
+++ b/tests/federation_room_join_partial_state_test.go
@@ -3619,8 +3619,55 @@ func TestPartialStateJoin(t *testing.T) {
 			)
 
 		})
+
+		t.Run("succeeds, then another user can join without resync completing", func(t *testing.T) {
+			alice := deployment.RegisterUser(t, "hs1", "t49alice", "secret", false)
+			bob := deployment.RegisterUser(t, "hs1", "t49bob", "secret", false)
+			handleTransactions := federation.HandleTransactionRequests(
+				// Accept all PDUs and EDUs
+				func(e *gomatrixserverlib.Event) {},
+				func(e gomatrixserverlib.EDU) {},
+			)
+			server := createTestServer(t, deployment, handleTransactions)
+			cancel := server.Listen()
+			defer cancel()
+
+			serverRoom := createTestRoom(t, server, alice.GetDefaultRoomVersion(t))
+			t.Log("Alice partial-joins her room")
+			psjResult := beginPartialStateJoin(t, server, serverRoom, alice)
+			// At the end of the test, keep Bob in the room. Have him make a /members
+			// call to ensure the resync has completed.
+			psjResult.User = bob
+			defer psjResult.Destroy(t)
+
+			t.Log("Alice waits to see her join")
+			aliceNextBatch := alice.MustSyncUntil(
+				t,
+				client.SyncReq{Filter: buildLazyLoadingSyncFilter(nil)},
+				client.SyncJoinedTo(alice.UserID, serverRoom.RoomID),
+			)
+
+			t.Log("Alice leaves the room")
+			alice.LeaveRoom(t, serverRoom.RoomID)
+
+			t.Log("Alice sees Alice's leave")
+			aliceNextBatch = alice.MustSyncUntil(
+				t,
+				client.SyncReq{Since: aliceNextBatch, Filter: buildLazyLoadingSyncFilter(nil)},
+				client.SyncLeftFrom(alice.UserID, serverRoom.RoomID),
+			)
+
+			// The resync has not completed because we have not called psjResult.FinishStateRequest()
+			t.Log("Now Bob joins the room")
+			bob.JoinRoom(t, serverRoom.RoomID, []string{server.ServerName()})
+			bob.MustSyncUntil(
+				t,
+				client.SyncReq{Filter: buildLazyLoadingSyncFilter(nil)},
+				client.SyncJoinedTo(alice.UserID, serverRoom.RoomID),
+			)
+
+		})
 		// TODO: tests which assert that:
-		//   - Join+Leave+Join works
 		//   - Join + remote kick works
 		//   - Join + remote ban works, then cannot rejoin
 	})


### PR DESCRIPTION
This
- tests https://github.com/matrix-org/synapse/issues/12802 (which we seem to have got for free by solving https://github.com/matrix-org/synapse/issues/12801)
- Unskips https://github.com/matrix-org/complement/pull/581

Closes https://github.com/matrix-org/synapse/issues/12802