### PR TITLE
Tests for transaction ID semantics

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -269,7 +269,8 @@ func (c *CSAPI) SendEventUnsynced(t *testing.T, roomID string, e b.Event) string
 	return c.SendEventUnsyncedWithTxnID(t, roomID, e, strconv.Itoa(txnID))
 }
 
-// SendEventUnsynced sends `e` into the room.
+// SendEventUnsyncedWithTxnID sends `e` into the room with a prescribed transaction ID.
+// This is useful for writing tests that interrogate transaction semantics.
 // Returns the event ID of the sent event.
 func (c *CSAPI) SendEventUnsyncedWithTxnID(t *testing.T, roomID string, e b.Event, txnID string) string {
 	t.Helper()
@@ -459,7 +460,7 @@ func (c *CSAPI) LoginUser(t *testing.T, localpart, password string, opts ...Logi
 }
 
 // RegisterUser will register the user with given parameters and
-// return user ID & access token, and fail the test on network error
+// return user ID, access token and device ID. It fails the test on network error.
 func (c *CSAPI) RegisterUser(t *testing.T, localpart, password string) (userID, accessToken, deviceID string) {
 	t.Helper()
 	reqBody := map[string]interface{}{

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -264,6 +264,7 @@ func (c *CSAPI) SetPushRule(t *testing.T, scope string, kind string, ruleID stri
 // SendEventUnsynced sends `e` into the room.
 // Returns the event ID of the sent event.
 func (c *CSAPI) SendEventUnsynced(t *testing.T, roomID string, e b.Event) string {
+	t.Helper()
 	txnID := int(atomic.AddInt64(&c.txnID, 1))
 	return c.SendEventUnsyncedWithTxnID(t, roomID, e, txnID)
 }

--- a/tests/csapi/txnid_test.go
+++ b/tests/csapi/txnid_test.go
@@ -163,6 +163,9 @@ func TestTxnIdempotencyScopedToClientSession(t *testing.T) {
 
 // TestTxnIdempotency tests that PUT requests idempotency follows required semantics
 func TestTxnIdempotency(t *testing.T) {
+	// Conduit appears to be tracking transaction IDs individually rather than combined with the request URI/room ID
+	runtime.SkipIf(t, runtime.Conduit)
+
 	deployment := Deploy(t, b.BlueprintCleanHS)
 	defer deployment.Destroy(t)
 

--- a/tests/csapi/txnid_test.go
+++ b/tests/csapi/txnid_test.go
@@ -1,11 +1,12 @@
 package csapi_tests
 
 import (
+	"testing"
+
 	"github.com/matrix-org/complement/internal/b"
 	"github.com/matrix-org/complement/internal/client"
 	"github.com/matrix-org/complement/runtime"
 	"github.com/tidwall/gjson"
-	"testing"
 )
 
 // TestTxnInEvent checks that the transaction ID is present when getting the event from the /rooms/{roomID}/event/{eventID} endpoint.
@@ -37,5 +38,174 @@ func TestTxnInEvent(t *testing.T) {
 	result := gjson.ParseBytes(body)
 	if !result.Get("unsigned.transaction_id").Exists() {
 		t.Fatalf("Event did not have a 'transaction_id' on the GET /rooms/%s/event/%s response", roomID, eventID)
+	}
+}
+
+
+func mustHaveTransactionID(t *testing.T, roomID, eventID string) client.SyncCheckOpt {
+	return client.SyncTimelineHas(roomID, func(r gjson.Result) bool {
+		if r.Get("event_id").Str == eventID {
+			if !r.Get("unsigned.transaction_id").Exists() {
+				t.Fatalf("Event %s in room %s should have a 'transaction_id', but it did not", eventID, roomID)
+			}
+
+			return true
+		}
+
+		return false
+	})
+}
+
+func mustNotHaveTransactionID(t *testing.T, roomID, eventID string) client.SyncCheckOpt {
+	return client.SyncTimelineHas(roomID, func(r gjson.Result) bool {
+		if r.Get("event_id").Str == eventID {
+			res := r.Get("unsigned.transaction_id")
+			if res.Exists() {
+				t.Fatalf("Event %s in room %s should NOT have a 'transaction_id', but it did (%s)", eventID, roomID, res.Str)
+			}
+
+			return true
+		}
+
+		return false
+	})
+}
+
+// TestTxnScopeOnLocalEcho tests that transaction IDs are scoped to the access token, not the device
+// on the sync response
+func TestTxnScopeOnLocalEcho(t *testing.T) {
+	// Conduit scope transaction IDs to the device ID, not the access token.
+	runtime.SkipIf(t, runtime.Conduit)
+
+	deployment := Deploy(t, b.BlueprintCleanHS)
+	defer deployment.Destroy(t)
+
+	deployment.RegisterUser(t, "hs1", "alice", "password", false)
+
+	// Create a first client, which allocates a device ID.
+	c1 := deployment.Client(t, "hs1", "")
+	c1.UserID, c1.AccessToken, c1.DeviceID = c1.LoginUser(t, "alice", "password")
+
+	// Create a room where we can send events.
+	roomID := c1.CreateRoom(t, map[string]interface{}{})
+
+	// Let's send an event, and wait for it to appear in the timeline.
+	eventID := c1.SendEventUnsynced(t, roomID, b.Event{
+		Type: "m.room.message",
+		Content: map[string]interface{}{
+			"msgtype": "m.text",
+			"body":    "first",
+		},
+	})
+
+	// When syncing, we should find the event and it should have a transaction ID on the first client.
+	c1.MustSyncUntil(t, client.SyncReq{}, mustHaveTransactionID(t, roomID, eventID))
+
+	// Create a second client, inheriting the first device ID.
+	c2 := deployment.Client(t, "hs1", "")
+	c2.UserID, c2.AccessToken = c2.LoginUserWithDeviceID(t, "alice", "password", c1.DeviceID)
+	c2.DeviceID = c1.DeviceID
+
+	// When syncing, we should find the event and it should *not* have a transaction ID on the second client.
+	c2.MustSyncUntil(t, client.SyncReq{}, mustNotHaveTransactionID(t, roomID, eventID))
+}
+
+// TestTxnIdempotencyScopedToClientSession tests that transaction IDs are scoped to a "client session"
+// and behave as expected across multiple clients even if they use the same device ID
+func TestTxnIdempotencyScopedToClientSession(t *testing.T) {
+	// Conduit scope transaction IDs to the device ID, not the client session.
+	runtime.SkipIf(t, runtime.Conduit)
+
+	deployment := Deploy(t, b.BlueprintCleanHS)
+	defer deployment.Destroy(t)
+
+	deployment.RegisterUser(t, "hs1", "alice", "password", false)
+
+	// Create a first client, which allocates a device ID.
+	c1 := deployment.Client(t, "hs1", "")
+	c1.UserID, c1.AccessToken, c1.DeviceID = c1.LoginUser(t, "alice", "password")
+
+	// Create a room where we can send events.
+	roomID := c1.CreateRoom(t, map[string]interface{}{})
+
+	txnId := 1
+	event := b.Event{
+		Type: "m.room.message",
+		Content: map[string]interface{}{
+			"msgtype": "m.text",
+			"body":    "foo",
+		},
+	}
+	// send an event with set txnId
+	eventID1 := c1.SendEventUnsyncedWithTxnID(t, roomID, event, txnId)
+
+	// Create a second client, inheriting the first device ID.
+	c2 := deployment.Client(t, "hs1", "")
+	c2.UserID, c2.AccessToken = c2.LoginUserWithDeviceID(t, "alice", "password", c1.DeviceID)
+	c2.DeviceID = c1.DeviceID
+
+	// send another event with the same txnId
+	eventID2 := c2.SendEventUnsyncedWithTxnID(t, roomID, event, txnId)
+
+	// the two events should have different event IDs as they came from different clients
+	if eventID1 == eventID2 {
+		t.Fatalf("Expected event IDs to be different from two clients sharing the same device ID")
+	}
+}
+
+// TestTxnIdempotency tests that PUT requests idempotency follows required semantics
+func TestTxnIdempotency(t *testing.T) {
+	deployment := Deploy(t, b.BlueprintCleanHS)
+	defer deployment.Destroy(t)
+
+	deployment.RegisterUser(t, "hs1", "alice", "password", false)
+
+	// Create a first client, which allocates a device ID.
+	c1 := deployment.Client(t, "hs1", "")
+	c1.UserID, c1.AccessToken, c1.DeviceID = c1.LoginUser(t, "alice", "password")
+
+	// Create a room where we can send events.
+	roomID1 := c1.CreateRoom(t, map[string]interface{}{})
+	roomID2 := c1.CreateRoom(t, map[string]interface{}{})
+
+	// choose a transaction ID
+	txnId := 1
+	event1 := b.Event{
+		Type: "m.room.message",
+		Content: map[string]interface{}{
+			"msgtype": "m.text",
+			"body":    "first",
+		},
+	}
+	event2 := b.Event{
+		Type: "m.room.message",
+		Content: map[string]interface{}{
+			"msgtype": "m.text",
+			"body":    "second",
+		},
+	}
+
+	// we send the event and get an event ID back
+	eventID1 := c1.SendEventUnsyncedWithTxnID(t, roomID1, event1, txnId)
+
+	// we send the identical event again and should get back the same event ID
+	eventID2 := c1.SendEventUnsyncedWithTxnID(t, roomID1, event1, txnId)
+
+	if eventID1 != eventID2 {
+		t.Fatalf("Expected event IDs to be the same, but they were not")
+	}
+
+	// even if we change the content we should still get back the same event ID as transaction ID is the same
+	eventID3 := c1.SendEventUnsyncedWithTxnID(t, roomID1, event2, txnId)
+
+	if eventID1 != eventID3 {
+		t.Fatalf("Expected event IDs to be the same even with different content, but they were not")
+	}
+
+	// if we change the room ID we should be able to use the same transaction ID
+	eventID4 := c1.SendEventUnsyncedWithTxnID(t, roomID2, event1, txnId)
+
+	if eventID4 == eventID3 {
+		t.Fatalf("Expected event IDs to be the different, but they were not")
 	}
 }

--- a/tests/csapi/txnid_test.go
+++ b/tests/csapi/txnid_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/matrix-org/complement/internal/b"
 	"github.com/matrix-org/complement/internal/client"
+	"github.com/matrix-org/complement/internal/must"
 	"github.com/matrix-org/complement/runtime"
 	"github.com/tidwall/gjson"
 )
@@ -23,30 +24,43 @@ func TestTxnInEvent(t *testing.T) {
 	// Create a room where we can send events.
 	roomID := c.CreateRoom(t, map[string]interface{}{})
 
+	txnId := "abcdefg"
 	// Let's send an event, and wait for it to appear in the timeline.
-	eventID := c.SendEventSynced(t, roomID, b.Event{
+	eventID := c.SendEventUnsyncedWithTxnID(t, roomID, b.Event{
 		Type: "m.room.message",
 		Content: map[string]interface{}{
 			"msgtype": "m.text",
 			"body":    "first",
 		},
-	})
+	}, txnId)
 
 	// The transaction ID should be present on the GET /rooms/{roomID}/event/{eventID} response.
 	res := c.MustDoFunc(t, "GET", []string{"_matrix", "client", "v3", "rooms", roomID, "event", eventID})
 	body := client.ParseJSON(t, res)
 	result := gjson.ParseBytes(body)
 	if !result.Get("unsigned.transaction_id").Exists() {
-		t.Fatalf("Event did not have a 'transaction_id' on the GET /rooms/%s/event/%s response", roomID, eventID)
+		t.Fatalf("Event did not have a 'unsigned.transaction_id' on the GET /rooms/%s/event/%s response", roomID, eventID)
+	}
+
+	txnIdFromResult:= result.Get("unsigned.transaction_id").Str
+
+	if txnIdFromResult != txnId {
+		t.Fatalf("Event did not have a 'unsigned.transaction_id' of %s on GET /rooms/%s/event/%s response. Found %s instead", txnId, eventID, roomID, txnIdFromResult)
 	}
 }
 
 
-func mustHaveTransactionID(t *testing.T, roomID, eventID string) client.SyncCheckOpt {
+func mustHaveTransactionID(t *testing.T, roomID, eventID, expectedTxnId string) client.SyncCheckOpt {
 	return client.SyncTimelineHas(roomID, func(r gjson.Result) bool {
 		if r.Get("event_id").Str == eventID {
 			if !r.Get("unsigned.transaction_id").Exists() {
-				t.Fatalf("Event %s in room %s should have a 'transaction_id', but it did not", eventID, roomID)
+				t.Fatalf("Event %s in room %s should have a 'unsigned.transaction_id', but it did not", eventID, roomID)
+			}
+
+			txnIdFromSync := r.Get("unsigned.transaction_id").Str
+
+			if txnIdFromSync != expectedTxnId {
+				t.Fatalf("Event %s in room %s should have a 'unsigned.transaction_id' of %s but found %s", eventID, roomID, expectedTxnId, txnIdFromSync)
 			}
 
 			return true
@@ -61,7 +75,7 @@ func mustNotHaveTransactionID(t *testing.T, roomID, eventID string) client.SyncC
 		if r.Get("event_id").Str == eventID {
 			res := r.Get("unsigned.transaction_id")
 			if res.Exists() {
-				t.Fatalf("Event %s in room %s should NOT have a 'transaction_id', but it did (%s)", eventID, roomID, res.Str)
+				t.Fatalf("Event %s in room %s should NOT have a 'unsigned.transaction_id', but it did (%s)", eventID, roomID, res.Str)
 			}
 
 			return true
@@ -89,21 +103,22 @@ func TestTxnScopeOnLocalEcho(t *testing.T) {
 	// Create a room where we can send events.
 	roomID := c1.CreateRoom(t, map[string]interface{}{})
 
+	txnId := "abdefgh"
 	// Let's send an event, and wait for it to appear in the timeline.
-	eventID := c1.SendEventUnsynced(t, roomID, b.Event{
+	eventID := c1.SendEventUnsyncedWithTxnID(t, roomID, b.Event{
 		Type: "m.room.message",
 		Content: map[string]interface{}{
 			"msgtype": "m.text",
 			"body":    "first",
 		},
-	})
+	}, txnId)
 
 	// When syncing, we should find the event and it should have a transaction ID on the first client.
-	c1.MustSyncUntil(t, client.SyncReq{}, mustHaveTransactionID(t, roomID, eventID))
+	c1.MustSyncUntil(t, client.SyncReq{}, mustHaveTransactionID(t, roomID, eventID, txnId))
 
 	// Create a second client, inheriting the first device ID.
 	c2 := deployment.Client(t, "hs1", "")
-	c2.UserID, c2.AccessToken = c2.LoginUserWithDeviceID(t, "alice", "password", c1.DeviceID)
+	c2.UserID, c2.AccessToken, _ = c2.LoginUser(t, "alice", "password", client.WithDeviceID(c1.DeviceID))
 	c2.DeviceID = c1.DeviceID
 
 	// When syncing, we should find the event and it should *not* have a transaction ID on the second client.
@@ -128,7 +143,7 @@ func TestTxnIdempotencyScopedToClientSession(t *testing.T) {
 	// Create a room where we can send events.
 	roomID := c1.CreateRoom(t, map[string]interface{}{})
 
-	txnId := 1
+	txnId := "abcdef"
 	event := b.Event{
 		Type: "m.room.message",
 		Content: map[string]interface{}{
@@ -141,16 +156,14 @@ func TestTxnIdempotencyScopedToClientSession(t *testing.T) {
 
 	// Create a second client, inheriting the first device ID.
 	c2 := deployment.Client(t, "hs1", "")
-	c2.UserID, c2.AccessToken = c2.LoginUserWithDeviceID(t, "alice", "password", c1.DeviceID)
+	c2.UserID, c2.AccessToken, _ = c2.LoginUser(t, "alice", "password", client.WithDeviceID(c1.DeviceID))
 	c2.DeviceID = c1.DeviceID
 
 	// send another event with the same txnId
 	eventID2 := c2.SendEventUnsyncedWithTxnID(t, roomID, event, txnId)
 
 	// the two events should have different event IDs as they came from different clients
-	if eventID1 == eventID2 {
-		t.Fatalf("Expected event IDs to be different from two clients sharing the same device ID")
-	}
+	must.NotEqualStr(t, eventID2, eventID1, "Expected eventID1 and eventID2 to be different from two clients sharing the same device ID")
 }
 
 // TestTxnIdempotency tests that PUT requests idempotency follows required semantics
@@ -169,7 +182,7 @@ func TestTxnIdempotency(t *testing.T) {
 	roomID2 := c1.CreateRoom(t, map[string]interface{}{})
 
 	// choose a transaction ID
-	txnId := 1
+	txnId := "abc"
 	event1 := b.Event{
 		Type: "m.room.message",
 		Content: map[string]interface{}{
@@ -191,21 +204,15 @@ func TestTxnIdempotency(t *testing.T) {
 	// we send the identical event again and should get back the same event ID
 	eventID2 := c1.SendEventUnsyncedWithTxnID(t, roomID1, event1, txnId)
 
-	if eventID1 != eventID2 {
-		t.Fatalf("Expected event IDs to be the same, but they were not")
-	}
+	must.EqualStr(t, eventID2, eventID1, "Expected eventID1 and eventID2 to be the same, but they were not")
 
 	// even if we change the content we should still get back the same event ID as transaction ID is the same
 	eventID3 := c1.SendEventUnsyncedWithTxnID(t, roomID1, event2, txnId)
 
-	if eventID1 != eventID3 {
-		t.Fatalf("Expected event IDs to be the same even with different content, but they were not")
-	}
+	must.EqualStr(t, eventID3, eventID1, "Expected eventID3 and eventID2 to be the same even with different content, but they were not")
 
 	// if we change the room ID we should be able to use the same transaction ID
 	eventID4 := c1.SendEventUnsyncedWithTxnID(t, roomID2, event1, txnId)
 
-	if eventID4 == eventID3 {
-		t.Fatalf("Expected event IDs to be the different, but they were not")
-	}
+	must.NotEqualStr(t, eventID4, eventID3, "Expected eventID4 and eventID3 to be different, but they were not")
 }


### PR DESCRIPTION
This adds Client-Server API tests relation to transaction identifiers:

1. That requests are idempotent within a single client session
2. That transaction ID can be re-used across client sessions
3. That the transaction ID is present in /sync response to deal with "local echo"

Signed-off-by: Hugh Nimmo-Smith <hughns@element.io>
