### PR TITLE
Add /register/available tests

### DIFF
--- a/tests/csapi/apidoc_register_test.go
+++ b/tests/csapi/apidoc_register_test.go
@@ -301,23 +301,6 @@ func TestRegistration(t *testing.T) {
 				},
 			})
 		})
-		// Test that /_matrix/client/v3/register/available returns M_UNKNOWN for username containing non-ascii
-		t.Run("GET /register/available returns M_UNKNOWN for user name containing non-ascii", func(t *testing.T) {
-			t.Skipf("Test disabled because rate-limiting")
-			t.Parallel()
-			// testUserName gets encoded into http, is this right?
-			testUserName := "usérn@mé_should_not_bé_v@l!d_ch@r$"
-			res := unauthedClient.DoFunc(t, "GET", []string{"_matrix", "client", "v3", "register", "available"}, client.WithQueries(url.Values{
-					"username": []string{testUserName},
-				}))
-			must.MatchResponse(t, res, match.HTTPResponse{
-				StatusCode: 400,
-				JSON: []match.JSON{
-					match.JSONKeyEqual("errcode", "M_UNKNOWN"),
-					match.JSONKeyPresent("error"),
-				},
-			})
-		})
 	})
 }
 


### PR DESCRIPTION
Test `/register/available` endpoint for:
1. Available user name
2. Unavailable user name
3. Invalid user name
4. ~Unicode invalid name~ This didn't get past query sanitization, so removed.

[Spec](https://spec.matrix.org/v1.5/client-server-api/#get_matrixclientv3registeravailable)
Why I rubbed these sticks together:
* https://github.com/matrix-org/synapse/issues/15242
### Pull Request Checklist

- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)

Signed-off-by: Jason Little <realtyem@gmail.com>