### PR TITLE
Deflake leave-via-kick/ban faster joins tests

### DIFF
--- a/tests/federation_room_join_partial_state_test.go
+++ b/tests/federation_room_join_partial_state_test.go
@@ -3718,6 +3718,10 @@ func TestPartialStateJoin(t *testing.T) {
 
 			// Cleanup.
 			psjResult.FinishStateRequest()
+			// Dirty hack to allow the homeserver under test to finish making requests to the
+			// Complement homeserver as part of syncing the full state.
+			psjResult.AwaitStateIdsRequest(t)
+			time.Sleep(time.Second / 2)
 		})
 
 		t.Run("can be triggered by remote ban", func(t *testing.T) {
@@ -3781,6 +3785,10 @@ func TestPartialStateJoin(t *testing.T) {
 
 			// Cleanup.
 			psjResult.FinishStateRequest()
+			// Dirty hack to allow the homeserver under test to finish making requests to the
+			// Complement homeserver as part of syncing the full state.
+			psjResult.AwaitStateIdsRequest(t)
+			time.Sleep(time.Second / 2)
 		})
 	})
 


### PR DESCRIPTION
We need to allow the homeserver under test to finish making requests to
the Complement homeserver before tearing it down, otherwise the
homeserver under test may mark the hostname:port combination as down and
refuse to contact it in subsequent tests.

Signed-off-by: Sean Quah <seanq@matrix.org>

---

NB: you can tease out the flakes by forcing Complement to reuse ports whenever possible:
```diff
diff --git a/internal/federation/server.go b/internal/federation/server.go
index ed7974d..4c4ccbe 100644
--- a/internal/federation/server.go
+++ b/internal/federation/server.go
@@ -455,7 +455,10 @@ func (s *Server) Listen() (cancel func()) {
        var wg sync.WaitGroup
        wg.Add(1)

-       ln, err := net.Listen("tcp", ":0") //nolint
+       ln, err := net.Listen("tcp", ":63333") //nolint
+       if err != nil {
+               ln, err = net.Listen("tcp", ":63334") //nolint
+       }
        if err != nil {
                s.t.Fatalf("ListenFederationServer: net.Listen failed: %s", err)
        }
```