### PR TITLE
Gracefully stop containers

### DIFF
--- a/internal/docker/deployer.go
+++ b/internal/docker/deployer.go
@@ -147,24 +147,18 @@ func (d *Deployer) Deploy(ctx context.Context, blueprintName string) (*Deploymen
 	return dep, lastErr
 }
 
-// Destroy a deployment. This will kill all running containers.
+// Destroy a deployment. This will stop/kill all running containers.
 func (d *Deployer) Destroy(dep *Deployment, printServerLogs bool, testName string, failed bool) {
+	timeout := 1 * time.Second
 	for _, hsDep := range dep.HS {
+		// Stop the container gracefully, if it fails to do so after `timeout`, it
+		// will be forcibly killed.
+		err := d.Docker.ContainerStop(context.Background(), hsDep.ContainerID, &timeout)
+		if err != nil {
+			log.Printf("Destroy: Failed to destroy container %s : %s\n", hsDep.ContainerID, err)
+		}
 		if printServerLogs {
-			// If we want the logs we gracefully stop the containers to allow
-			// the logs to be flushed.
-			timeout := 1 * time.Second
-			err := d.Docker.ContainerStop(context.Background(), hsDep.ContainerID, &timeout)
-			if err != nil {
-				log.Printf("Destroy: Failed to destroy container %s : %s\n", hsDep.ContainerID, err)
-			}
-
 			printLogs(d.Docker, hsDep.ContainerID, hsDep.ContainerID)
-		} else {
-			err := d.Docker.ContainerKill(context.Background(), hsDep.ContainerID, "KILL")
-			if err != nil {
-				log.Printf("Destroy: Failed to destroy container %s : %s\n", hsDep.ContainerID, err)
-			}
 		}
 
 		result, err := d.executePostScript(hsDep, testName, failed)

--- a/internal/docker/deployer.go
+++ b/internal/docker/deployer.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/docker/docker/client"
 	"github.com/docker/go-connections/nat"
+	complementRuntime "github.com/matrix-org/complement/runtime"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
@@ -161,7 +162,7 @@ func (d *Deployer) Destroy(dep *Deployment, printServerLogs bool, testName strin
 
 			printLogs(d.Docker, hsDep.ContainerID, hsDep.ContainerID)
 		} else {
-			err := d.Docker.ContainerKill(context.Background(), hsDep.ContainerID, "KILL")
+			err := complementRuntime.ContainerKillFunc(d.Docker, hsDep.ContainerID)
 			if err != nil {
 				log.Printf("Destroy: Failed to destroy container %s : %s\n", hsDep.ContainerID, err)
 			}

--- a/runtime/hs.go
+++ b/runtime/hs.go
@@ -1,6 +1,11 @@
 package runtime
 
-import "testing"
+import (
+	"context"
+	"testing"
+
+	"github.com/docker/docker/client"
+)
 
 const (
 	Dendrite = "dendrite"
@@ -10,10 +15,18 @@ const (
 
 var Homeserver string
 
+// ContainerKillFunc is used to destroy a container, it can be overwritten by Homeserver implementations
+// to e.g. gracefully stop a container.
+var ContainerKillFunc = func(client *client.Client, containerID string) error {
+	return client.ContainerKill(context.Background(), containerID, "KILL")
+}
+
 // Skip the test (via t.Skipf) if the homeserver being tested matches one of the homeservers, else return.
 //
 // The homeserver being tested is detected via the presence of a `*_blacklist` tag e.g:
-//   go test -tags="dendrite_blacklist"
+//
+//	go test -tags="dendrite_blacklist"
+//
 // This means it is important to always specify this tag when running tests. Failure to do
 // so will result in a warning being printed to stdout, and the test will be run. When a new server
 // implementation is added, a respective `hs_$name.go` needs to be created in this directory. This

--- a/runtime/hs_dendrite.go
+++ b/runtime/hs_dendrite.go
@@ -1,7 +1,21 @@
+//go:build dendrite_blacklist
 // +build dendrite_blacklist
 
 package runtime
 
+import (
+	"context"
+	"time"
+
+	"github.com/docker/docker/client"
+)
+
 func init() {
 	Homeserver = Dendrite
+	// For Dendrite, we want to always stop the container gracefully, as this is needed to
+	// extract e.g. coverage reports.
+	ContainerKillFunc = func(client *client.Client, containerID string) error {
+		timeout := 1 * time.Second
+		return client.ContainerStop(context.Background(), containerID, &timeout)
+	}
 }


### PR DESCRIPTION
If we're running Dendrite with coverage enabled, we need to gracefully stop the containers, as otherwise the coverage data can't be written to disk. `ContainerStop` will still kill the container if it fails to stop within 1 second.

As this will be used for every homeserver implementation, an alternative could be to check `runtime.Homeserver` and only always gracefully stop containers if it is Dendrite.