### PR TITLE
Update dendrite	build used to check homerunner

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: "Run Homerunner tests" # use a simple static dendrite image to sanity check homerunner works
         run: |
           mkdir -p homeserver
-          wget -O - "https://github.com/matrix-org/dendrite/archive/v0.8.8.tar.gz" | tar -xz --strip-components=1 -C homeserver
+          wget -O - "https://github.com/matrix-org/dendrite/archive/v0.12.0.tar.gz" | tar -xz --strip-components=1 -C homeserver
           (cd homeserver && docker build -t complement-dendrite -f build/scripts/Complement.Dockerfile .)
           (cd cmd/homerunner/test && ./test.sh)
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,7 @@ jobs:
           DOCKER_BUILDKIT: 1
         run: |
           mkdir -p homeserver
+          # Latest official dendrite release is still using Debian Stretch as a base, hence the specific commit
           wget -O - "https://github.com/matrix-org/dendrite/archive/0489d16f95a3d9f1f5bc532e2060bd2482d7b156.tar.gz" | tar -xz --strip-components=1 -C homeserver
           (cd homeserver && docker build -t complement-dendrite -f build/scripts/Complement.Dockerfile .)
           (cd cmd/homerunner/test && ./test.sh)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: "Run Homerunner tests" # use a simple static dendrite image to sanity check homerunner works
         run: |
           mkdir -p homeserver
-          wget -O - "https://github.com/matrix-org/dendrite/archive/v0.12.0.tar.gz" | tar -xz --strip-components=1 -C homeserver
+          wget -O - "https://github.com/matrix-org/dendrite/archive/0489d16f95a3d9f1f5bc532e2060bd2482d7b156.tar.gz" | tar -xz --strip-components=1 -C homeserver
           (cd homeserver && docker build -t complement-dendrite -f build/scripts/Complement.Dockerfile .)
           (cd cmd/homerunner/test && ./test.sh)
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,8 @@ jobs:
         run: |
           go test ./internal/...
       - name: "Run Homerunner tests" # use a simple static dendrite image to sanity check homerunner works
+        env:
+          DOCKER_BUILDKIT: 1
         run: |
           mkdir -p homeserver
           wget -O - "https://github.com/matrix-org/dendrite/archive/0489d16f95a3d9f1f5bc532e2060bd2482d7b156.tar.gz" | tar -xz --strip-components=1 -C homeserver


### PR DESCRIPTION
Current version is really old and breaks the CI since Debian Strech is not available anymore.

cf failure [here.](https://github.com/matrix-org/complement/actions/runs/4952393175/jobs/8869014023)

### Pull Request Checklist

- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)

