### PR TITLE
unknown endpoints: allow PUT /_matrix/media/v3/upload

### DIFF
--- a/tests/unknown_endpoints_test.go
+++ b/tests/unknown_endpoints_test.go
@@ -81,6 +81,6 @@ func TestUnknownEndpoints(t *testing.T) {
 		// v3 should exist, but not v3/unknown.
 		queryUnknownEndpoint(t, alice, []string{"_matrix", "media", "v3", "unknown"})
 
-		queryUnknownMethod(t, alice, "PUT", []string{"_matrix", "media", "v3", "upload"})
+		queryUnknownMethod(t, alice, "PATCH", []string{"_matrix", "media", "v3", "upload"})
 	})
 }


### PR DESCRIPTION
As of [MSC2246](https://github.com/matrix-org/matrix-spec-proposals/pull/2246), the PUT method is allowed on the `/_matrix/media/v3/upload` endpoint.

See the spec documentation here: https://spec.matrix.org/v1.7/client-server-api/#put_matrixmediav3uploadservernamemediaid

Note that this blocks https://github.com/matrix-org/synapse/pull/15503

Signed-off-by: Sumner Evans <sumner@beeper.com>

### Pull Request Checklist

- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)

