### PR TITLE
Stabilize knock restricted tests (room v10).

### DIFF
--- a/tests/knock_restricted_test.go
+++ b/tests/knock_restricted_test.go
@@ -2,8 +2,7 @@
 // +build msc3787
 
 // This file contains tests for a join rule which mixes concepts of restricted joins
-// and knocking. This is currently experimental and defined by MSC3787, found here:
-// https://github.com/matrix-org/matrix-spec-proposals/pull/3787
+// and knocking. This is implemented in room version 10.
 //
 // Generally, this is a combination of knocking_test and restricted_rooms_test.
 
@@ -16,18 +15,18 @@ import (
 )
 
 var (
-	msc3787RoomVersion = "org.matrix.msc3787"
-	msc3787JoinRule    = "knock_restricted"
+	roomVersion = "10"
+	joinRule    = "knock_restricted"
 )
 
 // See TestKnocking
 func TestKnockingInMSC3787Room(t *testing.T) {
-	doTestKnocking(t, msc3787RoomVersion, msc3787JoinRule)
+	doTestKnocking(t, roomVersion, joinRule)
 }
 
 // See TestKnockRoomsInPublicRoomsDirectory
 func TestKnockRoomsInPublicRoomsDirectoryInMSC3787Room(t *testing.T) {
-	doTestKnockRoomsInPublicRoomsDirectory(t, msc3787RoomVersion, msc3787JoinRule)
+	doTestKnockRoomsInPublicRoomsDirectory(t, roomVersion, joinRule)
 }
 
 // See TestCannotSendKnockViaSendKnock
@@ -35,7 +34,7 @@ func TestCannotSendKnockViaSendKnockInMSC3787Room(t *testing.T) {
 	testValidationForSendMembershipEndpoint(t, "/_matrix/federation/v1/send_knock", "knock",
 		map[string]interface{}{
 			"preset":       "public_chat",
-			"room_version": msc3787RoomVersion,
+			"room_version": roomVersion,
 		},
 	)
 }
@@ -46,13 +45,13 @@ func TestRestrictedRoomsLocalJoinInMSC3787Room(t *testing.T) {
 	defer deployment.Destroy(t)
 
 	// Setup the user, allowed room, and restricted room.
-	alice, allowed_room, room := setupRestrictedRoom(t, deployment, msc3787RoomVersion, msc3787JoinRule)
+	alice, allowed_room, room := setupRestrictedRoom(t, deployment, roomVersion, joinRule)
 
 	// Create a second user on the same homeserver.
 	bob := deployment.Client(t, "hs1", "@bob:hs1")
 
 	// Execute the checks.
-	checkRestrictedRoom(t, alice, bob, allowed_room, room, msc3787JoinRule)
+	checkRestrictedRoom(t, alice, bob, allowed_room, room, joinRule)
 }
 
 // See TestRestrictedRoomsRemoteJoin
@@ -61,21 +60,21 @@ func TestRestrictedRoomsRemoteJoinInMSC3787Room(t *testing.T) {
 	defer deployment.Destroy(t)
 
 	// Setup the user, allowed room, and restricted room.
-	alice, allowed_room, room := setupRestrictedRoom(t, deployment, msc3787RoomVersion, msc3787JoinRule)
+	alice, allowed_room, room := setupRestrictedRoom(t, deployment, roomVersion, joinRule)
 
 	// Create a second user on a different homeserver.
 	bob := deployment.Client(t, "hs2", "@bob:hs2")
 
 	// Execute the checks.
-	checkRestrictedRoom(t, alice, bob, allowed_room, room, msc3787JoinRule)
+	checkRestrictedRoom(t, alice, bob, allowed_room, room, joinRule)
 }
 
 // See TestRestrictedRoomsRemoteJoinLocalUser
 func TestRestrictedRoomsRemoteJoinLocalUserInMSC3787Room(t *testing.T) {
-	doTestRestrictedRoomsRemoteJoinLocalUser(t, msc3787RoomVersion, msc3787JoinRule)
+	doTestRestrictedRoomsRemoteJoinLocalUser(t, roomVersion, joinRule)
 }
 
 // See TestRestrictedRoomsRemoteJoinFailOver
 func TestRestrictedRoomsRemoteJoinFailOverInMSC3787Room(t *testing.T) {
-	doTestRestrictedRoomsRemoteJoinFailOver(t, msc3787RoomVersion, msc3787JoinRule)
+	doTestRestrictedRoomsRemoteJoinFailOver(t, roomVersion, joinRule)
 }


### PR DESCRIPTION
These are disabled for Dendrite because they're not supported there.