### PR TITLE
Move knock restricted tests to Dendrite blacklist.

### DIFF
--- a/tests/knock_restricted_test.go
+++ b/tests/knock_restricted_test.go
@@ -1,5 +1,5 @@
-//go:build msc3787
-// +build msc3787
+//go:build !dendrite_blacklist
+// +build !dendrite_blacklist
 
 // This file contains tests for a join rule which mixes concepts of restricted joins
 // and knocking. This is implemented in room version 10.


### PR DESCRIPTION
I really thought I did this in #643, but I guess I missed it.

This removes the build flag for the room v10 tests since they're now standard.