### PR TITLE
Add empty request bodies to /forget calls in TestRoomForget

### DIFF
--- a/tests/csapi/apidoc_room_forget_test.go
+++ b/tests/csapi/apidoc_room_forget_test.go
@@ -26,7 +26,7 @@ func TestRoomForget(t *testing.T) {
 		t.Run("Can't forget room you're still in", func(t *testing.T) {
 			t.Parallel()
 			roomID := alice.CreateRoom(t, map[string]interface{}{"preset": "private_chat"})
-			res := alice.DoFunc(t, "POST", []string{"_matrix", "client", "v3", "rooms", roomID, "forget"})
+			res := alice.DoFunc(t, "POST", []string{"_matrix", "client", "v3", "rooms", roomID, "forget"}, client.WithJSONBody(t, struct{}{}))
 			must.MatchResponse(t, res, match.HTTPResponse{
 				StatusCode: http.StatusBadRequest,
 				JSON: []match.JSON{
@@ -47,7 +47,7 @@ func TestRoomForget(t *testing.T) {
 				},
 			})
 			alice.LeaveRoom(t, roomID)
-			alice.MustDoFunc(t, "POST", []string{"_matrix", "client", "v3", "rooms", roomID, "forget"})
+			alice.MustDoFunc(t, "POST", []string{"_matrix", "client", "v3", "rooms", roomID, "forget"}, client.WithJSONBody(t, struct{}{}))
 			res := alice.DoFunc(t, "GET", []string{"_matrix", "client", "v3", "rooms", roomID, "messages"})
 			must.MatchResponse(t, res, match.HTTPResponse{
 				StatusCode: http.StatusForbidden,
@@ -71,7 +71,7 @@ func TestRoomForget(t *testing.T) {
 			alice.LeaveRoom(t, roomID)
 			// Ensure Alice left the room
 			bob.MustSyncUntil(t, client.SyncReq{}, client.SyncLeftFrom(alice.UserID, roomID))
-			alice.MustDoFunc(t, "POST", []string{"_matrix", "client", "v3", "rooms", roomID, "forget"})
+			alice.MustDoFunc(t, "POST", []string{"_matrix", "client", "v3", "rooms", roomID, "forget"}, client.WithJSONBody(t, struct{}{}))
 			bob.SendEventSynced(t, roomID, b.Event{
 				Type: "m.room.message",
 				Content: map[string]interface{}{
@@ -117,7 +117,7 @@ func TestRoomForget(t *testing.T) {
 			alice.LeaveRoom(t, roomID)
 			// Ensure Alice left the room
 			bob.MustSyncUntil(t, client.SyncReq{}, client.SyncLeftFrom(alice.UserID, roomID))
-			alice.MustDoFunc(t, "POST", []string{"_matrix", "client", "v3", "rooms", roomID, "forget"})
+			alice.MustDoFunc(t, "POST", []string{"_matrix", "client", "v3", "rooms", roomID, "forget"}, client.WithJSONBody(t, struct{}{}))
 			bob.SendEventSynced(t, roomID, b.Event{
 				Type: "m.room.message",
 				Content: map[string]interface{}{
@@ -197,7 +197,7 @@ func TestRoomForget(t *testing.T) {
 			bob.LeaveRoom(t, roomID)
 			// Ensure Bob has really left the room
 			alice.MustSyncUntil(t, client.SyncReq{}, client.SyncLeftFrom(bob.UserID, roomID))
-			bob.MustDoFunc(t, "POST", []string{"_matrix", "client", "v3", "rooms", roomID, "forget"})
+			bob.MustDoFunc(t, "POST", []string{"_matrix", "client", "v3", "rooms", roomID, "forget"}, client.WithJSONBody(t, struct{}{}))
 			// Try to re-join
 			joinRes := bob.DoFunc(t, "POST", []string{"_matrix", "client", "v3", "join", roomID})
 			must.MatchResponse(t, joinRes, match.HTTPResponse{
@@ -251,11 +251,11 @@ func TestRoomForget(t *testing.T) {
 			// Bob rejects the invite
 			bob.LeaveRoom(t, roomID)
 			// Bob tries to forget about this room
-			bob.MustDoFunc(t, "POST", []string{"_matrix", "client", "v3", "rooms", roomID, "forget"})
+			bob.MustDoFunc(t, "POST", []string{"_matrix", "client", "v3", "rooms", roomID, "forget"}, client.WithJSONBody(t, struct{}{}))
 			// Alice also leaves the room
 			alice.LeaveRoom(t, roomID)
 			// Alice tries to forget about this room
-			alice.MustDoFunc(t, "POST", []string{"_matrix", "client", "v3", "rooms", roomID, "forget"})
+			alice.MustDoFunc(t, "POST", []string{"_matrix", "client", "v3", "rooms", roomID, "forget"}, client.WithJSONBody(t, struct{}{}))
 		})
 	})
 }

--- a/tests/csapi/apidoc_room_forget_test.go
+++ b/tests/csapi/apidoc_room_forget_test.go
@@ -199,7 +199,7 @@ func TestRoomForget(t *testing.T) {
 			alice.MustSyncUntil(t, client.SyncReq{}, client.SyncLeftFrom(bob.UserID, roomID))
 			bob.MustDoFunc(t, "POST", []string{"_matrix", "client", "v3", "rooms", roomID, "forget"}, client.WithJSONBody(t, struct{}{}))
 			// Try to re-join
-			joinRes := bob.DoFunc(t, "POST", []string{"_matrix", "client", "v3", "join", roomID})
+			joinRes := bob.DoFunc(t, "POST", []string{"_matrix", "client", "v3", "join", roomID}, client.WithJSONBody(t, struct{}{}))
 			must.MatchResponse(t, joinRes, match.HTTPResponse{
 				StatusCode: http.StatusForbidden,
 				JSON: []match.JSON{


### PR DESCRIPTION
These are meant to be required but it seems like they are not in practice...

c.f. https://github.com/matrix-org/synapse/issues/16366