### PR TITLE
Test content disposition against a content type with a parameter.

### DIFF
--- a/tests/media_filename_test.go
+++ b/tests/media_filename_test.go
@@ -137,6 +137,25 @@ func TestMediaFilenames(t *testing.T) {
 				}
 			})
 
+			t.Run("Will serve safe media types with parameters as inline", func(t *testing.T) {
+				if runtime.Homeserver != runtime.Synapse {
+					// We need to check that this security behaviour is being correctly run in
+					// Synapse, but since this is not part of the Matrix spec we do not assume
+					// other homeservers are doing so.
+					t.Skip("Skipping test of Content-Disposition header requirements on non-Synapse homeserver")
+				}
+				t.Parallel()
+
+				// Add parameters and upper-case, which should be parsed as text/plain.
+				mxcUri := alice.UploadContent(t, data.MatrixPng, "", "Text/Plain; charset=utf-8")
+
+				_, isAttachment := downloadForFilename(t, bob, mxcUri, "")
+
+				if isAttachment {
+					t.Fatal("Expected file to be served as inline")
+				}
+			})
+
 			t.Run("Will serve unsafe media types as attachments", func(t *testing.T) {
 				if runtime.Homeserver != runtime.Synapse {
 					// We need to check that this security behaviour is being correctly run in


### PR DESCRIPTION
See https://github.com/matrix-org/synapse/pull/16440