### PR TITLE
Add JSON keys to b.Event

### DIFF
--- a/b/blueprints.go
+++ b/b/blueprints.go
@@ -93,10 +93,10 @@ type ApplicationService struct {
 }
 
 type Event struct {
-	Type     string
-	Sender   string
-	StateKey *string
-	Content  map[string]interface{}
+	Type     string                 `json:"type"`
+	Sender   string                 `json:"sender"`
+	StateKey *string                `json:"state_key"`
+	Content  map[string]interface{} `json:"content"`
 }
 
 func MustValidate(bp Blueprint) Blueprint {

--- a/b/blueprints.go
+++ b/b/blueprints.go
@@ -94,8 +94,8 @@ type ApplicationService struct {
 
 type Event struct {
 	Type     string                 `json:"type"`
-	Sender   string                 `json:"sender"`
-	StateKey *string                `json:"state_key"`
+	Sender   string                 `json:"sender,omitempty"`
+	StateKey *string                `json:"state_key,omitempty"`
 	Content  map[string]interface{} `json:"content"`
 }
 


### PR DESCRIPTION
This is so people can use `b.Event` directly when setting `initial_state` in `/createRoom` - as used in sliding sync tests.