### PR TITLE
Standardise entry points for Complement tests

### DIFF
--- a/test_main.go
+++ b/test_main.go
@@ -1,4 +1,4 @@
-package helpers
+package complement
 
 import (
 	"fmt"

--- a/test_package.go
+++ b/test_package.go
@@ -1,4 +1,4 @@
-package helpers
+package complement
 
 import (
 	"context"

--- a/tests/csapi/account_change_password_pushers_test.go
+++ b/tests/csapi/account_change_password_pushers_test.go
@@ -6,8 +6,9 @@ package csapi_tests
 import (
 	"testing"
 
-	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
+	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 
@@ -15,7 +16,7 @@ import (
 )
 
 func TestChangePasswordPushers(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 	password1 := "superuser"
 	password2 := "my_new_password"

--- a/tests/csapi/account_change_password_test.go
+++ b/tests/csapi/account_change_password_test.go
@@ -4,8 +4,9 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
+	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/internal/docker"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
@@ -14,7 +15,7 @@ import (
 )
 
 func TestChangePassword(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 	password1 := "superuser"
 	password2 := "my_new_password"

--- a/tests/csapi/account_data_test.go
+++ b/tests/csapi/account_data_test.go
@@ -3,13 +3,14 @@ package csapi_tests
 import (
 	"testing"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
 
 func TestAddAccountData(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")

--- a/tests/csapi/account_deactivate_test.go
+++ b/tests/csapi/account_deactivate_test.go
@@ -6,14 +6,15 @@ import (
 
 	"github.com/tidwall/gjson"
 
-	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
+	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
 
 func TestDeactivateAccount(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 	password := "superuser"
 	authedClient := deployment.RegisterUser(t, "hs1", "test_deactivate_user", password, false)

--- a/tests/csapi/admin_test.go
+++ b/tests/csapi/admin_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/tidwall/gjson"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/match"
@@ -16,14 +17,14 @@ import (
 // Check if this homeserver supports Synapse-style admin registration.
 // Not all images support this currently.
 func TestCanRegisterAdmin(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 	deployment.RegisterUser(t, "hs1", "admin", "adminpassword", true)
 }
 
 // Test if the implemented /_synapse/admin/v1/send_server_notice behaves as expected
 func TestServerNotices(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 	admin := deployment.RegisterUser(t, "hs1", "admin", "adminpassword", true)
 	alice := deployment.Client(t, "hs1", "@alice:hs1")

--- a/tests/csapi/apidoc_content_test.go
+++ b/tests/csapi/apidoc_content_test.go
@@ -4,12 +4,13 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/internal/data"
 )
 
 func TestContent(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")

--- a/tests/csapi/apidoc_device_management_test.go
+++ b/tests/csapi/apidoc_device_management_test.go
@@ -5,14 +5,15 @@ import (
 
 	"github.com/tidwall/gjson"
 
-	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
+	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
 
 func TestDeviceManagement(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 	unauthedClient := deployment.Client(t, "hs1", "")
 	authedClient := deployment.RegisterUser(t, "hs1", "test_device_management_user", "superuser", false)

--- a/tests/csapi/apidoc_login_test.go
+++ b/tests/csapi/apidoc_login_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/tidwall/gjson"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/match"
@@ -14,7 +15,7 @@ import (
 )
 
 func TestLogin(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 	unauthedClient := deployment.Client(t, "hs1", "")
 	_ = deployment.RegisterUser(t, "hs1", "test_login_user", "superuser", false)

--- a/tests/csapi/apidoc_logout_test.go
+++ b/tests/csapi/apidoc_logout_test.go
@@ -7,13 +7,14 @@ import (
 
 	"github.com/tidwall/gjson"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
 
 func TestLogout(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	password := "superuser"

--- a/tests/csapi/apidoc_presence_test.go
+++ b/tests/csapi/apidoc_presence_test.go
@@ -10,14 +10,15 @@ import (
 
 	"github.com/tidwall/gjson"
 
-	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
+	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
 
 func TestPresence(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")

--- a/tests/csapi/apidoc_profile_avatar_url_test.go
+++ b/tests/csapi/apidoc_profile_avatar_url_test.go
@@ -3,14 +3,15 @@ package csapi_tests
 import (
 	"testing"
 
-	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
+	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
 
 func TestProfileAvatarURL(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 	unauthedClient := deployment.Client(t, "hs1", "")
 	authedClient := deployment.Client(t, "hs1", "@alice:hs1")

--- a/tests/csapi/apidoc_profile_displayname_test.go
+++ b/tests/csapi/apidoc_profile_displayname_test.go
@@ -3,14 +3,15 @@ package csapi_tests
 import (
 	"testing"
 
-	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
+	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
 
 func TestProfileDisplayName(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 	unauthedClient := deployment.Client(t, "hs1", "")
 	authedClient := deployment.Client(t, "hs1", "@alice:hs1")

--- a/tests/csapi/apidoc_register_test.go
+++ b/tests/csapi/apidoc_register_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/tidwall/gjson"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/match"
@@ -34,7 +35,7 @@ import (
 // Can register using an email address
 
 func TestRegistration(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 	unauthedClient := deployment.Client(t, "hs1", "")
 	t.Run("parallel", func(t *testing.T) {

--- a/tests/csapi/apidoc_request_encoding_test.go
+++ b/tests/csapi/apidoc_request_encoding_test.go
@@ -5,14 +5,15 @@ import (
 
 	"encoding/json"
 
-	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
+	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
 
 func TestRequestEncodingFails(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 	unauthedClient := deployment.Client(t, "hs1", "")
 	testString := `{ "test":"a` + "\x81" + `" }`

--- a/tests/csapi/apidoc_room_alias_test.go
+++ b/tests/csapi/apidoc_room_alias_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/tidwall/gjson"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/match"
@@ -59,7 +60,7 @@ func mustSetCanonicalAlias(t *testing.T, c *client.CSAPI, roomID string, roomAli
 }
 
 func TestRoomAlias(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
 	bob := deployment.Client(t, "hs1", "@bob:hs1")
@@ -185,7 +186,7 @@ func TestRoomAlias(t *testing.T) {
 }
 
 func TestRoomDeleteAlias(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
 	bob := deployment.Client(t, "hs1", "@bob:hs1")
@@ -456,7 +457,7 @@ func TestRoomDeleteAlias(t *testing.T) {
 }
 
 func TestRoomCanonicalAlias(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
 

--- a/tests/csapi/apidoc_room_create_test.go
+++ b/tests/csapi/apidoc_room_create_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/tidwall/gjson"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/match"
@@ -12,7 +13,7 @@ import (
 )
 
 func TestRoomCreate(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")

--- a/tests/csapi/apidoc_room_forget_test.go
+++ b/tests/csapi/apidoc_room_forget_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/tidwall/gjson"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/match"
@@ -16,7 +17,7 @@ import (
 
 // These tests ensure that forgetting about rooms works as intended
 func TestRoomForget(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")

--- a/tests/csapi/apidoc_room_history_visibility_test.go
+++ b/tests/csapi/apidoc_room_history_visibility_test.go
@@ -6,8 +6,9 @@ import (
 
 	"github.com/tidwall/gjson"
 
-	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
+	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
@@ -36,7 +37,7 @@ func createRoomWithVisibility(t *testing.T, c *client.CSAPI, visibility string) 
 // Fetches an event after join, and succeeds.
 // sytest: /event/ on joined room works
 func TestFetchEvent(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
@@ -82,7 +83,7 @@ func TestFetchEvent(t *testing.T) {
 // history_visibility: joined
 // sytest: /event/ does not allow access to events before the user joined
 func TestFetchHistoricalJoinedEventDenied(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
@@ -111,7 +112,7 @@ func TestFetchHistoricalJoinedEventDenied(t *testing.T) {
 // Tries to fetch an event before join, and succeeds.
 // history_visibility: shared
 func TestFetchHistoricalSharedEvent(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
@@ -155,7 +156,7 @@ func TestFetchHistoricalSharedEvent(t *testing.T) {
 // Tries to fetch an event between being invited and joined, and succeeds.
 // history_visibility: invited
 func TestFetchHistoricalInvitedEventFromBetweenInvite(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
@@ -202,7 +203,7 @@ func TestFetchHistoricalInvitedEventFromBetweenInvite(t *testing.T) {
 // Tries to fetch an event before being invited, and fails.
 // history_visibility: invited
 func TestFetchHistoricalInvitedEventFromBeforeInvite(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
@@ -235,7 +236,7 @@ func TestFetchHistoricalInvitedEventFromBeforeInvite(t *testing.T) {
 // history_visibility: shared
 // sytest: /event/ on non world readable room does not work
 func TestFetchEventNonWorldReadable(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
@@ -261,7 +262,7 @@ func TestFetchEventNonWorldReadable(t *testing.T) {
 // Tries to fetch an event without having joined, and succeeds.
 // history_visibility: world_readable
 func TestFetchEventWorldReadable(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")

--- a/tests/csapi/apidoc_room_members_test.go
+++ b/tests/csapi/apidoc_room_members_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/tidwall/gjson"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/match"
@@ -12,7 +13,7 @@ import (
 )
 
 func TestRoomMembers(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
 	bob := deployment.Client(t, "hs1", "@bob:hs1")

--- a/tests/csapi/apidoc_room_receipts_test.go
+++ b/tests/csapi/apidoc_room_receipts_test.go
@@ -3,8 +3,9 @@ package csapi_tests
 import (
 	"testing"
 
-	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
+	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/internal/docker"
 	"github.com/tidwall/gjson"
 )
@@ -36,7 +37,7 @@ func syncHasReadReceipt(roomID, userID, eventID string) client.SyncCheckOpt {
 
 // sytest: POST /rooms/:room_id/receipt can create receipts
 func TestRoomReceipts(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
 	roomID, eventID := createRoomForReadReceipts(t, alice, deployment)
@@ -49,7 +50,7 @@ func TestRoomReceipts(t *testing.T) {
 
 // sytest: POST /rooms/:room_id/read_markers can create read marker
 func TestRoomReadMarkers(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
 	roomID, eventID := createRoomForReadReceipts(t, alice, deployment)

--- a/tests/csapi/apidoc_room_state_test.go
+++ b/tests/csapi/apidoc_room_state_test.go
@@ -8,14 +8,15 @@ import (
 
 	"github.com/tidwall/gjson"
 
-	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
+	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
 
 func TestRoomState(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 	authedClient := deployment.Client(t, "hs1", "@alice:hs1")
 	t.Run("Parallel", func(t *testing.T) {

--- a/tests/csapi/apidoc_search_test.go
+++ b/tests/csapi/apidoc_search_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/tidwall/gjson"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/match"
@@ -17,7 +18,7 @@ import (
 // Note: In contrast to Sytest, we define a filter.rooms on each search request, this is to mimic
 // creating a new user and new room per test. This also allows us to run in parallel.
 func TestSearch(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")

--- a/tests/csapi/apidoc_server_capabilities_test.go
+++ b/tests/csapi/apidoc_server_capabilities_test.go
@@ -4,13 +4,14 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
 
 func TestServerCapabilities(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	unauthedClient := deployment.Client(t, "hs1", "")

--- a/tests/csapi/apidoc_version_test.go
+++ b/tests/csapi/apidoc_version_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/tidwall/gjson"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
@@ -21,7 +22,7 @@ const GlobalVersionRegex = `v[1-9]\d*\.\d+(?:-\S+)?`
 const r0Regex = `r0\.\d+\.\d+`
 
 func TestVersionStructure(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	client := deployment.Client(t, "hs1", "")

--- a/tests/csapi/device_lists_test.go
+++ b/tests/csapi/device_lists_test.go
@@ -5,8 +5,9 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
+	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/internal/docker"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
@@ -396,7 +397,7 @@ func TestDeviceListUpdates(t *testing.T) {
 	// Create two homeservers
 	// The users and rooms in the blueprint won't be used.
 	// Each test creates their own Alice and Bob users.
-	deployment := Deploy(t, b.BlueprintFederationOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintFederationOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	t.Run("when local user joins a room", func(t *testing.T) { testOtherUserJoin(t, deployment, "hs1", "hs1") })

--- a/tests/csapi/e2e_key_backup_test.go
+++ b/tests/csapi/e2e_key_backup_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/match"
@@ -23,7 +24,7 @@ type backupKey struct {
 //	if they have the same values for is_verified, then it will keep the key with a lower first_message_index;
 //	and finally, is is_verified and first_message_index are equal, then it will keep the key with a lower forwarded_count.
 func TestE2EKeyBackupReplaceRoomKeyRules(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 	userID := "@alice:hs1"
 	roomID := "!foo:hs1"

--- a/tests/csapi/ignored_users_test.go
+++ b/tests/csapi/ignored_users_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/tidwall/gjson"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/match"
@@ -27,7 +28,7 @@ import (
 // https://github.com/matrix-org/synapse/issues/11506
 // to ensure that Synapse complies with this part of the spec.
 func TestInviteFromIgnoredUsersDoesNotAppearInSync(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintCleanHS)
+	deployment := complement.Deploy(t, b.BlueprintCleanHS)
 	defer deployment.Destroy(t)
 	alice := deployment.RegisterUser(t, "hs1", "alice", "sufficiently_long_password_alice", false)
 	bob := deployment.RegisterUser(t, "hs1", "bob", "sufficiently_long_password_bob", false)

--- a/tests/csapi/invalid_test.go
+++ b/tests/csapi/invalid_test.go
@@ -4,15 +4,16 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
+	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 	"github.com/matrix-org/complement/runtime"
 )
 
 func TestJson(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
 	roomID := alice.MustCreateRoom(t, map[string]interface{}{
@@ -170,7 +171,7 @@ func getFilters() []map[string]interface{} {
 func TestFilter(t *testing.T) {
 	runtime.SkipIf(t, runtime.Dendrite) // FIXME: https://github.com/matrix-org/dendrite/issues/2067
 
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
 
@@ -187,7 +188,7 @@ func TestFilter(t *testing.T) {
 
 // sytest: Event size limits
 func TestEvent(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
 	roomID := alice.MustCreateRoom(t, map[string]interface{}{

--- a/tests/csapi/keychanges_test.go
+++ b/tests/csapi/keychanges_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/tidwall/gjson"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/match"
@@ -15,7 +16,7 @@ import (
 )
 
 func TestKeyChangesLocal(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")

--- a/tests/csapi/main_test.go
+++ b/tests/csapi/main_test.go
@@ -1,8 +1,6 @@
 package csapi_tests
 
 import (
-	"fmt"
-	"os"
 	"testing"
 
 	"github.com/matrix-org/complement/b"
@@ -10,29 +8,11 @@ import (
 	"github.com/matrix-org/complement/internal/docker"
 )
 
-var testPackage *helpers.TestPackage
-
-// TestMain is the main entry point for Complement.
-//
-// It will clean up any old containers/images/networks from the previous run, then run the tests, then clean up
-// again. No blueprints are made at this point as they are lazily made on demand.
 func TestMain(m *testing.M) {
-	var err error
-	testPackage, err = helpers.NewTestPackage("csapi")
-	if err != nil {
-		fmt.Printf("Error: %s", err)
-		os.Exit(1)
-	}
-	exitCode := m.Run()
-	testPackage.Cleanup()
-	os.Exit(exitCode)
+	helpers.TestMain(m, "csapi")
 }
 
-// Deploy will deploy the given blueprint or terminate the test.
-// It will construct the blueprint if it doesn't already exist in the docker image cache.
-// This function is the main setup function for all tests as it provides a deployment with
-// which tests can interact with.
 func Deploy(t *testing.T, blueprint b.Blueprint) *docker.Deployment {
 	t.Helper()
-	return testPackage.Deploy(t, blueprint)
+	return helpers.Deploy(t, blueprint)
 }

--- a/tests/csapi/main_test.go
+++ b/tests/csapi/main_test.go
@@ -4,15 +4,8 @@ import (
 	"testing"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
-	"github.com/matrix-org/complement/internal/docker"
 )
 
 func TestMain(m *testing.M) {
 	complement.TestMain(m, "csapi")
-}
-
-func Deploy(t *testing.T, blueprint b.Blueprint) *docker.Deployment {
-	t.Helper()
-	return complement.Deploy(t, blueprint)
 }

--- a/tests/csapi/main_test.go
+++ b/tests/csapi/main_test.go
@@ -3,16 +3,16 @@ package csapi_tests
 import (
 	"testing"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
-	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/internal/docker"
 )
 
 func TestMain(m *testing.M) {
-	helpers.TestMain(m, "csapi")
+	complement.TestMain(m, "csapi")
 }
 
 func Deploy(t *testing.T, blueprint b.Blueprint) *docker.Deployment {
 	t.Helper()
-	return helpers.Deploy(t, blueprint)
+	return complement.Deploy(t, blueprint)
 }

--- a/tests/csapi/media_misc_test.go
+++ b/tests/csapi/media_misc_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/tidwall/gjson"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/internal/data"
@@ -19,7 +20,7 @@ import (
 func TestRoomImageRoundtrip(t *testing.T) {
 	runtime.SkipIf(t, runtime.Dendrite) // FIXME: https://github.com/matrix-org/dendrite/issues/1303
 
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
@@ -61,7 +62,7 @@ func TestRoomImageRoundtrip(t *testing.T) {
 
 // sytest: Can read configuration endpoint
 func TestMediaConfig(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")

--- a/tests/csapi/power_levels_test.go
+++ b/tests/csapi/power_levels_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/tidwall/gjson"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/match"
@@ -16,7 +17,7 @@ import (
 // when that value is equal to the value of authorised user.
 // Regression test for https://github.com/matrix-org/gomatrixserverlib/pull/306
 func TestDemotingUsersViaUsersDefault(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
@@ -48,7 +49,7 @@ func TestDemotingUsersViaUsersDefault(t *testing.T) {
 }
 
 func TestPowerLevels(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")

--- a/tests/csapi/push_test.go
+++ b/tests/csapi/push_test.go
@@ -7,15 +7,16 @@ import (
 
 	"github.com/tidwall/gjson"
 
-	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
+	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
 
 // sytest: Getting push rules doesn't corrupt the cache SYN-390
 func TestPushRuleCacheHealth(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
@@ -33,7 +34,7 @@ func TestPushRuleCacheHealth(t *testing.T) {
 }
 
 func TestPushSync(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")

--- a/tests/csapi/room_ban_test.go
+++ b/tests/csapi/room_ban_test.go
@@ -3,8 +3,9 @@ package csapi_tests
 import (
 	"testing"
 
-	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
+	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
@@ -13,7 +14,7 @@ import (
 // but this will actually validate against a present user in the room.
 // sytest: Non-present room members cannot ban others
 func TestNotPresentUserCannotBanOthers(t *testing.T) {
-	deployment := Deploy(t, b.MustValidate(b.Blueprint{
+	deployment := complement.Deploy(t, b.MustValidate(b.Blueprint{
 		Name: "abc",
 		Homeservers: []b.Homeserver{
 			{

--- a/tests/csapi/room_kick_test.go
+++ b/tests/csapi/room_kick_test.go
@@ -3,15 +3,16 @@ package csapi_tests
 import (
 	"testing"
 
-	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
+	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
 
 // sytest: Users cannot kick users from a room they are not in
 func TestCannotKickNonPresentUser(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
@@ -35,7 +36,7 @@ func TestCannotKickNonPresentUser(t *testing.T) {
 
 // sytest: Users cannot kick users who have already left a room
 func TestCannotKickLeftUser(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")

--- a/tests/csapi/room_leave_test.go
+++ b/tests/csapi/room_leave_test.go
@@ -7,14 +7,15 @@ import (
 
 	"github.com/tidwall/gjson"
 
-	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
+	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
 
 func TestLeftRoomFixture(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")

--- a/tests/csapi/room_members_test.go
+++ b/tests/csapi/room_members_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/tidwall/gjson"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/match"
@@ -20,7 +21,7 @@ func typeToStateKeyMapper(result gjson.Result) interface{} {
 
 // sytest: Can get rooms/{roomId}/members
 func TestGetRoomMembers(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
@@ -59,7 +60,7 @@ func TestGetRoomMembers(t *testing.T) {
 // Utilize ?at= to get room members at a point in sync.
 // sytest: Can get rooms/{roomId}/members at a given point
 func TestGetRoomMembersAtPoint(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
@@ -119,7 +120,7 @@ func TestGetRoomMembersAtPoint(t *testing.T) {
 // sytest: Can filter rooms/{roomId}/members
 func TestGetFilteredRoomMembers(t *testing.T) {
 
-	deployment := Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")

--- a/tests/csapi/room_messages_test.go
+++ b/tests/csapi/room_messages_test.go
@@ -8,8 +8,9 @@ import (
 
 	"github.com/tidwall/gjson"
 
-	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
+	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 	"github.com/matrix-org/complement/runtime"
@@ -19,7 +20,7 @@ import (
 // sytest: GET /rooms/:room_id/messages returns a message
 func TestSendAndFetchMessage(t *testing.T) {
 	runtime.SkipIf(t, runtime.Dendrite) // flakey
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
@@ -62,7 +63,7 @@ func TestSendAndFetchMessage(t *testing.T) {
 // With a non-existent room_id, GET /rooms/:room_id/messages returns 403
 // forbidden ("You aren't a member of the room").
 func TestFetchMessagesFromNonExistentRoom(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
@@ -80,7 +81,7 @@ func TestFetchMessagesFromNonExistentRoom(t *testing.T) {
 // sytest: PUT /rooms/:room_id/send/:event_type/:txn_id sends a message
 // sytest: PUT /rooms/:room_id/send/:event_type/:txn_id deduplicates the same txn id
 func TestSendMessageWithTxn(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
@@ -107,7 +108,7 @@ func TestSendMessageWithTxn(t *testing.T) {
 }
 
 func TestRoomMessagesLazyLoading(t *testing.T) {
-	deployment := Deploy(t, b.MustValidate(b.Blueprint{
+	deployment := complement.Deploy(t, b.MustValidate(b.Blueprint{
 		Name: "alice_bob_and_charlie",
 		Homeservers: []b.Homeserver{
 			{
@@ -198,7 +199,7 @@ func TestRoomMessagesLazyLoading(t *testing.T) {
 //
 // sytest: GET /rooms/:room_id/messages lazy loads members correctly
 func TestRoomMessagesLazyLoadingLocalUser(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")

--- a/tests/csapi/room_profile_test.go
+++ b/tests/csapi/room_profile_test.go
@@ -5,8 +5,9 @@ import (
 
 	"github.com/tidwall/gjson"
 
-	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
+	"github.com/matrix-org/complement/client"
 )
 
 func TestAvatarUrlUpdate(t *testing.T) {
@@ -19,7 +20,7 @@ func TestDisplayNameUpdate(t *testing.T) {
 
 // sytest: $datum updates affect room member events
 func testProfileFieldUpdate(t *testing.T, field string) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	const bogusData = "LemurLover"

--- a/tests/csapi/room_relations_test.go
+++ b/tests/csapi/room_relations_test.go
@@ -8,15 +8,16 @@ import (
 
 	"github.com/tidwall/gjson"
 
-	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
+	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 	"github.com/matrix-org/complement/runtime"
 )
 
 func TestRelations(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
@@ -111,7 +112,7 @@ func TestRelations(t *testing.T) {
 }
 
 func TestRelationsPagination(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
@@ -210,7 +211,7 @@ func TestRelationsPagination(t *testing.T) {
 func TestRelationsPaginationSync(t *testing.T) {
 	runtime.SkipIf(t, runtime.Dendrite) // FIXME: https://github.com/matrix-org/dendrite/issues/2944
 
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")

--- a/tests/csapi/room_threads_test.go
+++ b/tests/csapi/room_threads_test.go
@@ -6,8 +6,9 @@ import (
 
 	"github.com/tidwall/gjson"
 
-	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
+	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 	"github.com/matrix-org/complement/runtime"
@@ -32,7 +33,7 @@ func checkResults(t *testing.T, body []byte, expected []string) {
 // Test the /threads endpoint.
 func TestThreadsEndpoint(t *testing.T) {
 	runtime.SkipIf(t, runtime.Dendrite) // not supported
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")

--- a/tests/csapi/room_typing_test.go
+++ b/tests/csapi/room_typing_test.go
@@ -3,13 +3,14 @@ package csapi_tests
 import (
 	"testing"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 )
 
 // sytest: PUT /rooms/:room_id/typing/:user_id sets typing notification
 func TestTyping(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
@@ -36,7 +37,7 @@ func TestTyping(t *testing.T) {
 
 // sytest: Typing notifications don't leak
 func TestLeakyTyping(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")

--- a/tests/csapi/rooms_invite_test.go
+++ b/tests/csapi/rooms_invite_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/match"
@@ -12,7 +13,7 @@ import (
 )
 
 func TestRoomsInvite(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")

--- a/tests/csapi/rooms_members_local_test.go
+++ b/tests/csapi/rooms_members_local_test.go
@@ -3,13 +3,14 @@ package csapi_tests
 import (
 	"testing"
 
-	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
+	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/runtime"
 )
 
 func TestMembersLocal(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")

--- a/tests/csapi/rooms_state_test.go
+++ b/tests/csapi/rooms_state_test.go
@@ -9,13 +9,14 @@ import (
 
 	"github.com/tidwall/gjson"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/must"
 )
 
 func TestRoomCreationReportsEventsToMyself(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	userID := "@alice:hs1"

--- a/tests/csapi/sync_archive_test.go
+++ b/tests/csapi/sync_archive_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/tidwall/gjson"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/runtime"
@@ -14,7 +15,7 @@ import (
 func TestSyncLeaveSection(t *testing.T) {
 	runtime.SkipIf(t, runtime.Dendrite) // FIXME: https://github.com/matrix-org/dendrite/issues/1323
 
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
@@ -75,7 +76,7 @@ func TestSyncLeaveSection(t *testing.T) {
 func TestGappedSyncLeaveSection(t *testing.T) {
 	runtime.SkipIf(t, runtime.Dendrite) // FIXME: https://github.com/matrix-org/dendrite/issues/1323
 
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
@@ -116,7 +117,7 @@ func TestGappedSyncLeaveSection(t *testing.T) {
 func TestArchivedRoomsHistory(t *testing.T) {
 	runtime.SkipIf(t, runtime.Dendrite) // FIXME: https://github.com/matrix-org/dendrite/issues/1323
 
-	deployment := Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
@@ -233,7 +234,7 @@ func TestArchivedRoomsHistory(t *testing.T) {
 func TestOlderLeftRoomsNotInLeaveSection(t *testing.T) {
 	runtime.SkipIf(t, runtime.Dendrite) // FIXME: https://github.com/matrix-org/dendrite/issues/1323
 
-	deployment := Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
@@ -315,7 +316,7 @@ func TestLeaveEventVisibility(t *testing.T) {
 	//  this user is only meant to keep the room alive,
 	//  as a room with no users may be purged by the server,
 	//  creating side effects that this test is not looking for.
-	deployment := Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
@@ -398,7 +399,7 @@ func TestLeaveEventVisibility(t *testing.T) {
 func TestLeaveEventInviteRejection(t *testing.T) {
 	runtime.SkipIf(t, runtime.Dendrite) // FIXME: https://github.com/matrix-org/dendrite/issues/1323
 
-	deployment := Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")

--- a/tests/csapi/sync_filter_test.go
+++ b/tests/csapi/sync_filter_test.go
@@ -6,14 +6,15 @@ import (
 
 	"github.com/tidwall/gjson"
 
-	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
+	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
 
 func TestSyncFilter(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 	authedClient := deployment.Client(t, "hs1", "@alice:hs1")
 	// sytest: Can create filter

--- a/tests/csapi/sync_test.go
+++ b/tests/csapi/sync_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/tidwall/gjson"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/internal/federation"
@@ -16,7 +17,7 @@ import (
 
 // Observes "first bug" from https://github.com/matrix-org/dendrite/pull/1394#issuecomment-687056673
 func TestCumulativeJoinLeaveJoinSync(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
@@ -54,7 +55,7 @@ func TestCumulativeJoinLeaveJoinSync(t *testing.T) {
 
 // Observes "second bug" from https://github.com/matrix-org/dendrite/pull/1394#issuecomment-687056673
 func TestTentativeEventualJoiningAfterRejecting(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
@@ -104,7 +105,7 @@ func TestTentativeEventualJoiningAfterRejecting(t *testing.T) {
 func TestSync(t *testing.T) {
 	runtime.SkipIf(t, runtime.Dendrite) // FIXME: https://github.com/matrix-org/dendrite/issues/1324
 	// sytest: Can sync
-	deployment := Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
 	bob := deployment.Client(t, "hs1", "@bob:hs1")
@@ -374,7 +375,7 @@ func TestSync(t *testing.T) {
 
 // Test presence from people in 2 different rooms in incremental sync
 func TestPresenceSyncDifferentRooms(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
@@ -435,7 +436,7 @@ func TestPresenceSyncDifferentRooms(t *testing.T) {
 
 func TestRoomSummary(t *testing.T) {
 	runtime.SkipIf(t, runtime.Synapse) // Currently more of a Dendrite test, so skip on Synapse
-	deployment := Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
 	bob := deployment.Client(t, "hs1", "@bob:hs1")

--- a/tests/csapi/thread_notifications_test.go
+++ b/tests/csapi/thread_notifications_test.go
@@ -6,8 +6,9 @@ import (
 
 	"github.com/tidwall/gjson"
 
-	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
+	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/runtime"
 )
 
@@ -71,7 +72,7 @@ func syncHasThreadedReadReceipt(roomID, userID, eventID, threadID string) client
 // Notification counts and receipts are handled by bob.
 func TestThreadedReceipts(t *testing.T) {
 	runtime.SkipIf(t, runtime.Dendrite) // not supported
-	deployment := Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	// Create a room with alice and bob.

--- a/tests/csapi/to_device_test.go
+++ b/tests/csapi/to_device_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/tidwall/gjson"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 )
@@ -14,7 +15,7 @@ import (
 // sytest: Can recv a device message using /sync
 // sytest: Can send a to-device message to two users which both receive it using /sync
 func TestToDeviceMessages(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")

--- a/tests/csapi/txnid_test.go
+++ b/tests/csapi/txnid_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/must"
@@ -17,7 +18,7 @@ func TestTxnInEvent(t *testing.T) {
 	// See https://github.com/matrix-org/dendrite/issues/3000
 	runtime.SkipIf(t, runtime.Dendrite)
 
-	deployment := Deploy(t, b.BlueprintCleanHS)
+	deployment := complement.Deploy(t, b.BlueprintCleanHS)
 	defer deployment.Destroy(t)
 
 	c := deployment.RegisterUser(t, "hs1", "alice", "password", false)
@@ -68,7 +69,7 @@ func mustHaveTransactionIDForEvent(t *testing.T, roomID, eventID, expectedTxnId 
 func TestTxnScopeOnLocalEcho(t *testing.T) {
 	runtime.SkipIf(t, runtime.Dendrite)
 
-	deployment := Deploy(t, b.BlueprintCleanHS)
+	deployment := complement.Deploy(t, b.BlueprintCleanHS)
 	defer deployment.Destroy(t)
 
 	deployment.RegisterUser(t, "hs1", "alice", "password", false)
@@ -107,7 +108,7 @@ func TestTxnScopeOnLocalEcho(t *testing.T) {
 func TestTxnIdempotencyScopedToDevice(t *testing.T) {
 	runtime.SkipIf(t, runtime.Dendrite)
 
-	deployment := Deploy(t, b.BlueprintCleanHS)
+	deployment := complement.Deploy(t, b.BlueprintCleanHS)
 	defer deployment.Destroy(t)
 
 	deployment.RegisterUser(t, "hs1", "alice", "password", false)
@@ -147,7 +148,7 @@ func TestTxnIdempotency(t *testing.T) {
 	// Conduit appears to be tracking transaction IDs individually rather than combined with the request URI/room ID
 	runtime.SkipIf(t, runtime.Conduit)
 
-	deployment := Deploy(t, b.BlueprintCleanHS)
+	deployment := complement.Deploy(t, b.BlueprintCleanHS)
 	defer deployment.Destroy(t)
 
 	deployment.RegisterUser(t, "hs1", "alice", "password", false)
@@ -202,7 +203,7 @@ func TestTxnIdWithRefreshToken(t *testing.T) {
 	// Dendrite and Conduit don't support refresh tokens yet.
 	runtime.SkipIf(t, runtime.Dendrite, runtime.Conduit)
 
-	deployment := Deploy(t, b.BlueprintCleanHS)
+	deployment := complement.Deploy(t, b.BlueprintCleanHS)
 	defer deployment.Destroy(t)
 
 	deployment.RegisterUser(t, "hs1", "alice", "password", false)

--- a/tests/csapi/upload_keys_test.go
+++ b/tests/csapi/upload_keys_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/tidwall/gjson"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/match"
@@ -16,7 +17,7 @@ import (
 )
 
 func TestUploadKey(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")

--- a/tests/csapi/url_preview_test.go
+++ b/tests/csapi/url_preview_test.go
@@ -44,7 +44,7 @@ func TestUrlPreview(t *testing.T) {
 	deployment := Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
-	webServer := web.NewServer(t, testPackage.Config, func(router *mux.Router) {
+	webServer := web.NewServer(t, deployment.Config, func(router *mux.Router) {
 		router.HandleFunc("/test.png", func(w http.ResponseWriter, req *http.Request) {
 			t.Log("/test.png fetched")
 

--- a/tests/csapi/url_preview_test.go
+++ b/tests/csapi/url_preview_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/tidwall/gjson"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/internal/data"
@@ -41,7 +42,7 @@ var oGraphHtml = fmt.Sprintf(`
 func TestUrlPreview(t *testing.T) {
 	runtime.SkipIf(t, runtime.Dendrite) // FIXME: https://github.com/matrix-org/dendrite/issues/621
 
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	webServer := web.NewServer(t, deployment.Config, func(router *mux.Router) {

--- a/tests/csapi/user_directory_display_names_test.go
+++ b/tests/csapi/user_directory_display_names_test.go
@@ -7,8 +7,9 @@ package csapi_tests
 import (
 	"testing"
 
-	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
+	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
@@ -38,7 +39,7 @@ func setupUsers(t *testing.T) (*client.CSAPI, *client.CSAPI, *client.CSAPI, func
 	// - Eve knows about Alice,
 	// - Alice reveals a private name to another friend Bob
 	// - Eve shouldn't be able to see that private name via the directory.
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	cleanup := func(t *testing.T) {
 		deployment.Destroy(t)
 	}

--- a/tests/csapi/user_query_keys_test.go
+++ b/tests/csapi/user_query_keys_test.go
@@ -3,8 +3,9 @@ package csapi_tests
 import (
 	"testing"
 
-	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
+	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
@@ -15,7 +16,7 @@ import (
 // like an array in Python and hence go un-noticed. In Go however it will result in a 400. The correct behaviour is
 // to return a 400. Element iOS uses this erroneous format.
 func TestKeysQueryWithDeviceIDAsObjectFails(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	userID := "@alice:hs1"

--- a/tests/direct_messaging_test.go
+++ b/tests/direct_messaging_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/internal/federation"
@@ -21,7 +22,7 @@ import (
 // Test that a client can write `m.direct` account data and get told about updates to that event.
 // Requires a functioning account data implementation.
 func TestWriteMDirectAccountData(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer func() {
 		// additional logging to debug https://github.com/matrix-org/synapse/issues/13334
 		t.Logf("%s: TestWriteMDirectAccountData complete: destroying HS deployment", time.Now())
@@ -69,7 +70,7 @@ func TestWriteMDirectAccountData(t *testing.T) {
 // Test that the `is_direct` flag on m.room.member invites propagate to the target user. Both users
 // are on the same homeserver.
 func TestIsDirectFlagLocal(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
@@ -102,7 +103,7 @@ func TestIsDirectFlagLocal(t *testing.T) {
 // Test that the `is_direct` flag on m.room.member invites propagate to the target user. Users
 // are on different homeservers.
 func TestIsDirectFlagFederation(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	srv := federation.NewServer(t, deployment,

--- a/tests/federation_acl_test.go
+++ b/tests/federation_acl_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"testing"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/match"
@@ -15,7 +16,7 @@ import (
 func TestACLs(t *testing.T) {
 	runtime.SkipIf(t, runtime.Dendrite) // needs https://github.com/matrix-org/dendrite/pull/3008
 	// 1. Prepare 3 or more servers. 1st will be room host, 2nd will be blocked with m.room.server_acl and 3rd server will be affected by this issue. 1st and 2nd servers don't have to be powered by dendrite.
-	deployment := Deploy(t, b.Blueprint{
+	deployment := complement.Deploy(t, b.Blueprint{
 		Name: "federation_three_homeservers",
 		Homeservers: []b.Homeserver{
 			{

--- a/tests/federation_event_auth_test.go
+++ b/tests/federation_event_auth_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/internal/federation"
@@ -28,7 +29,7 @@ import (
 //   - /event_auth for the latest join event returns the complete auth chain for Charlie (all the
 //     joins and leaves are included), without any extraneous events.
 func TestEventAuth(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")

--- a/tests/federation_keys_test.go
+++ b/tests/federation_keys_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/internal/docker"
 	"github.com/matrix-org/complement/match"
@@ -27,7 +28,7 @@ import (
 // https://matrix.org/docs/spec/server_server/latest#get-matrix-key-v2-server-keyid
 // sytest: Federation key API allows unsigned requests for keys
 func TestInboundFederationKeys(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	fedClient := &http.Client{

--- a/tests/federation_presence_test.go
+++ b/tests/federation_presence_test.go
@@ -5,12 +5,13 @@ import (
 
 	"github.com/tidwall/gjson"
 
-	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
+	"github.com/matrix-org/complement/client"
 )
 
 func TestRemotePresence(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintFederationOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintFederationOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")

--- a/tests/federation_query_profile_test.go
+++ b/tests/federation_query_profile_test.go
@@ -6,11 +6,12 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/matrix-org/gomatrixserverlib/spec"
 
-	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/b"
+	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/internal/federation"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
@@ -22,7 +23,7 @@ import (
 // Test that the server can make outbound federation profile requests
 // https://matrix.org/docs/spec/server_server/latest#get-matrix-federation-v1-query-profile
 func TestOutboundFederationProfile(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	srv := federation.NewServer(t, deployment,
@@ -70,7 +71,7 @@ func TestOutboundFederationProfile(t *testing.T) {
 }
 
 func TestInboundFederationProfile(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")

--- a/tests/federation_redaction_test.go
+++ b/tests/federation_redaction_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/internal/federation"
@@ -16,7 +17,7 @@ import (
 func TestFederationRedactSendsWithoutEvent(t *testing.T) {
 	runtime.SkipIf(t, runtime.Dendrite)
 
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")

--- a/tests/federation_room_alias_test.go
+++ b/tests/federation_room_alias_test.go
@@ -3,15 +3,16 @@ package tests
 import (
 	"testing"
 
-	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
+	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
 
 // sytest: Remote room alias queries can handle Unicode
 func TestRemoteAliasRequestsUnderstandUnicode(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintFederationOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintFederationOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")

--- a/tests/federation_room_ban_test.go
+++ b/tests/federation_room_ban_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"testing"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 )
@@ -11,7 +12,7 @@ import (
 // Create a federation room. Bob bans Alice. Bob unbans Alice. Bob invites Alice (unbanning her). Ensure the invite is
 // received and can be accepted.
 func TestUnbanViaInvite(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintFederationOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintFederationOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")

--- a/tests/federation_room_event_auth_test.go
+++ b/tests/federation_room_event_auth_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/matrix-org/gomatrixserverlib/spec"
@@ -72,7 +73,7 @@ func TestInboundFederationRejectsEventsWithRejectedAuthEvents(t *testing.T) {
 	 * /rooms/{roomID}/event. If it is rejected, we should get a 404.
 	 */
 
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 	srv := federation.NewServer(t, deployment,
 		federation.HandleKeyRequests(),

--- a/tests/federation_room_get_missing_events_test.go
+++ b/tests/federation_room_get_missing_events_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/matrix-org/gomatrixserverlib/spec"
@@ -41,7 +42,7 @@ func TestGetMissingEventsGapFilling(t *testing.T) {
 	// 4) Respond to /get_missing_events with the missing events if the request is well-formed.
 	// 5) Ensure the HS doesn't do /state_ids or /state
 	// 6) Ensure Alice sees all injected events in the correct order.
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	srv := federation.NewServer(t, deployment,
@@ -165,7 +166,7 @@ func TestGetMissingEventsGapFilling(t *testing.T) {
 //
 // sytest: Outbound federation will ignore a missing event with bad JSON for room version 6
 func TestOutboundFederationIgnoresMissingEventWithBadJSONForRoomVersion6(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
@@ -328,7 +329,7 @@ func TestOutboundFederationIgnoresMissingEventWithBadJSONForRoomVersion6(t *test
 }
 
 func TestInboundCanReturnMissingEvents(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")

--- a/tests/federation_room_invite_test.go
+++ b/tests/federation_room_invite_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/gomatrixserverlib"
 
 	"github.com/matrix-org/complement/b"
@@ -17,7 +18,7 @@ import (
 // alice sends an invite to charlie@hs2, which he rejects.
 // We check that delia sees the rejection.
 func TestFederationRejectInvite(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintFederationTwoLocalOneRemote)
+	deployment := complement.Deploy(t, b.BlueprintFederationTwoLocalOneRemote)
 	defer deployment.Destroy(t)
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
 	charlie := deployment.Client(t, "hs2", "@charlie:hs2")

--- a/tests/federation_room_join_test.go
+++ b/tests/federation_room_join_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/gomatrix"
 	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/matrix-org/gomatrixserverlib/spec"
@@ -37,7 +38,7 @@ import (
 // m.room.create event would pick that up. We also can't tear down the Complement
 // server because otherwise signing key lookups will fail.
 func TestJoinViaRoomIDAndServerName(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintFederationOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintFederationOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
@@ -85,7 +86,7 @@ func TestJoinViaRoomIDAndServerName(t *testing.T) {
 // This tests that joining a room with multiple ?server_name=s works correctly.
 // The join should succeed even if the first server is not in the room.
 func TestJoinFederatedRoomFailOver(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintFederationOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintFederationOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
@@ -125,7 +126,7 @@ func TestJoinFederatedRoomFailOver(t *testing.T) {
 // the properties listed above, then asking HS1 to join them and make sure that
 // they 200 OK.
 func TestJoinFederatedRoomWithUnverifiableEvents(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
@@ -291,7 +292,7 @@ func TestJoinFederatedRoomWithUnverifiableEvents(t *testing.T) {
 
 // This test checks that users cannot circumvent the auth checks via send_join.
 func TestBannedUserCannotSendJoin(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	srv := federation.NewServer(t, deployment,
@@ -390,7 +391,7 @@ func testValidationForSendMembershipEndpoint(t *testing.T, baseApiPath, expected
 		}
 	}
 
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	srv := federation.NewServer(t, deployment,
@@ -493,7 +494,7 @@ func testValidationForSendMembershipEndpoint(t *testing.T, baseApiPath, expected
 // Will be skipped if the server returns a full-state response.
 func TestSendJoinPartialStateResponse(t *testing.T) {
 	// start with a homeserver with two users
-	deployment := Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	srv := federation.NewServer(t, deployment,
@@ -581,7 +582,7 @@ func TestJoinFederatedRoomFromApplicationServiceBridgeUser(t *testing.T) {
 	// Dendrite doesn't read AS registration files from Complement yet
 	runtime.SkipIf(t, runtime.Dendrite) // FIXME: https://github.com/matrix-org/complement/issues/514
 
-	deployment := Deploy(t, b.BlueprintHSWithApplicationService)
+	deployment := complement.Deploy(t, b.BlueprintHSWithApplicationService)
 	defer deployment.Destroy(t)
 
 	// Create the application service bridge user to try to join the room from

--- a/tests/federation_room_send_test.go
+++ b/tests/federation_room_send_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/gomatrixserverlib"
 
 	"github.com/matrix-org/complement/b"
@@ -19,7 +20,7 @@ import (
 
 // Tests that the server is capable of making outbound /send requests
 func TestOutboundFederationSend(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")

--- a/tests/federation_room_typing_test.go
+++ b/tests/federation_room_typing_test.go
@@ -3,13 +3,14 @@ package tests
 import (
 	"testing"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 )
 
 // sytest: Typing notifications also sent to remote room members
 func TestRemoteTyping(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintFederationTwoLocalOneRemote)
+	deployment := complement.Deploy(t, b.BlueprintFederationTwoLocalOneRemote)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")

--- a/tests/federation_rooms_invite_test.go
+++ b/tests/federation_rooms_invite_test.go
@@ -3,17 +3,18 @@ package tests
 import (
 	"testing"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/gomatrixserverlib/spec"
 	"github.com/tidwall/gjson"
 
-	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/b"
+	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
 
 func TestFederationRoomsInvite(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintFederationOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintFederationOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")

--- a/tests/federation_unreject_rejected_test.go
+++ b/tests/federation_unreject_rejected_test.go
@@ -4,8 +4,9 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
+	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/internal/federation"
 )
 
@@ -17,7 +18,7 @@ import (
 // event B is unrejected on the second pass and will appear in
 // the /sync response AFTER event A.
 func TestUnrejectRejectedEvents(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
 

--- a/tests/federation_upload_keys_test.go
+++ b/tests/federation_upload_keys_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/tidwall/gjson"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/match"
@@ -15,7 +16,7 @@ import (
 )
 
 func TestFederationKeyUploadQuery(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintFederationOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintFederationOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")

--- a/tests/knock_restricted_test.go
+++ b/tests/knock_restricted_test.go
@@ -11,6 +11,7 @@ package tests
 import (
 	"testing"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 )
 
@@ -41,7 +42,7 @@ func TestCannotSendKnockViaSendKnockInMSC3787Room(t *testing.T) {
 
 // See TestRestrictedRoomsLocalJoin
 func TestRestrictedRoomsLocalJoinInMSC3787Room(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	// Setup the user, allowed room, and restricted room.
@@ -56,7 +57,7 @@ func TestRestrictedRoomsLocalJoinInMSC3787Room(t *testing.T) {
 
 // See TestRestrictedRoomsRemoteJoin
 func TestRestrictedRoomsRemoteJoinInMSC3787Room(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintFederationOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintFederationOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	// Setup the user, allowed room, and restricted room.

--- a/tests/knocking_test.go
+++ b/tests/knocking_test.go
@@ -16,6 +16,7 @@ import (
 
 	"net/http"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/tidwall/gjson"
 
@@ -39,7 +40,7 @@ func TestKnocking(t *testing.T) {
 }
 
 func doTestKnocking(t *testing.T, roomVersion string, joinRule string) {
-	deployment := Deploy(t, b.BlueprintFederationTwoLocalOneRemote)
+	deployment := complement.Deploy(t, b.BlueprintFederationTwoLocalOneRemote)
 	defer deployment.Destroy(t)
 
 	// Create a client for one local user
@@ -341,7 +342,7 @@ func TestKnockRoomsInPublicRoomsDirectory(t *testing.T) {
 }
 
 func doTestKnockRoomsInPublicRoomsDirectory(t *testing.T, roomVersion string, joinRule string) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	// Create a client for a local user

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -4,15 +4,8 @@ import (
 	"testing"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
-	"github.com/matrix-org/complement/internal/docker"
 )
 
 func TestMain(m *testing.M) {
 	complement.TestMain(m, "fed")
-}
-
-func Deploy(t *testing.T, blueprint b.Blueprint) *docker.Deployment {
-	t.Helper()
-	return complement.Deploy(t, blueprint)
 }

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -1,8 +1,6 @@
 package tests
 
 import (
-	"fmt"
-	"os"
 	"testing"
 
 	"github.com/matrix-org/complement/b"
@@ -10,29 +8,11 @@ import (
 	"github.com/matrix-org/complement/internal/docker"
 )
 
-var testPackage *helpers.TestPackage
-
-// TestMain is the main entry point for Complement.
-//
-// It will clean up any old containers/images/networks from the previous run, then run the tests, then clean up
-// again. No blueprints are made at this point as they are lazily made on demand.
 func TestMain(m *testing.M) {
-	var err error
-	testPackage, err = helpers.NewTestPackage("fed")
-	if err != nil {
-		fmt.Printf("Error: %s", err)
-		os.Exit(1)
-	}
-	exitCode := m.Run()
-	testPackage.Cleanup()
-	os.Exit(exitCode)
+	helpers.TestMain(m, "fed")
 }
 
-// Deploy will deploy the given blueprint or terminate the test.
-// It will construct the blueprint if it doesn't already exist in the docker image cache.
-// This function is the main setup function for all tests as it provides a deployment with
-// which tests can interact with.
 func Deploy(t *testing.T, blueprint b.Blueprint) *docker.Deployment {
 	t.Helper()
-	return testPackage.Deploy(t, blueprint)
+	return helpers.Deploy(t, blueprint)
 }

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -3,16 +3,16 @@ package tests
 import (
 	"testing"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
-	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/internal/docker"
 )
 
 func TestMain(m *testing.M) {
-	helpers.TestMain(m, "fed")
+	complement.TestMain(m, "fed")
 }
 
 func Deploy(t *testing.T, blueprint b.Blueprint) *docker.Deployment {
 	t.Helper()
-	return helpers.Deploy(t, blueprint)
+	return complement.Deploy(t, blueprint)
 }

--- a/tests/media_filename_test.go
+++ b/tests/media_filename_test.go
@@ -5,8 +5,9 @@ import (
 	"mime"
 	"testing"
 
-	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
+	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/internal/data"
 	"github.com/matrix-org/complement/runtime"
 )
@@ -15,7 +16,7 @@ const asciiFileName = "ascii"
 const unicodeFileName = "\xf0\x9f\x90\x94"
 
 func TestMediaFilenames(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintFederationOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintFederationOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")

--- a/tests/media_nofilename_test.go
+++ b/tests/media_nofilename_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/internal/federation"
 	"github.com/matrix-org/complement/must"
@@ -13,7 +14,7 @@ import (
 
 // Can handle uploads and remote/local downloads without a file name
 func TestMediaWithoutFileName(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")

--- a/tests/media_thumbnail_test.go
+++ b/tests/media_thumbnail_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/internal/data"
@@ -18,7 +19,7 @@ import (
 
 // sytest: POSTed media can be thumbnailed
 func TestLocalPngThumbnail(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
@@ -33,7 +34,7 @@ func TestLocalPngThumbnail(t *testing.T) {
 
 // sytest: Remote media can be thumbnailed
 func TestRemotePngThumbnail(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintFederationOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintFederationOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")

--- a/tests/msc2836/main_test.go
+++ b/tests/msc2836/main_test.go
@@ -4,15 +4,8 @@ import (
 	"testing"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
-	"github.com/matrix-org/complement/internal/docker"
 )
 
 func TestMain(m *testing.M) {
 	complement.TestMain(m, "msc2836")
-}
-
-func Deploy(t *testing.T, blueprint b.Blueprint) *docker.Deployment {
-	t.Helper()
-	return complement.Deploy(t, blueprint)
 }

--- a/tests/msc2836/main_test.go
+++ b/tests/msc2836/main_test.go
@@ -3,16 +3,16 @@ package tests
 import (
 	"testing"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
-	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/internal/docker"
 )
 
 func TestMain(m *testing.M) {
-	helpers.TestMain(m, "msc2836")
+	complement.TestMain(m, "msc2836")
 }
 
 func Deploy(t *testing.T, blueprint b.Blueprint) *docker.Deployment {
 	t.Helper()
-	return helpers.Deploy(t, blueprint)
+	return complement.Deploy(t, blueprint)
 }

--- a/tests/msc2836/msc2836_test.go
+++ b/tests/msc2836/msc2836_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/gomatrixserverlib/spec"
 	"github.com/tidwall/gjson"
@@ -39,7 +40,7 @@ import (
 // an event which the server does have, event B, to ensure that this request also works and also does
 // federated hits to return missing events (A,C).
 func TestEventRelationships(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintFederationOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintFederationOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	// Create the room and send events A,B,C,D
@@ -191,7 +192,7 @@ func TestEventRelationships(t *testing.T) {
 // We then check that B, which wasn't on the return path on the previous request, was persisted by calling
 // /event_relationships again with event ID 'A' and direction 'down'.
 func TestFederatedEventRelationships(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")

--- a/tests/msc3391/main_test.go
+++ b/tests/msc3391/main_test.go
@@ -3,16 +3,16 @@ package tests
 import (
 	"testing"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
-	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/internal/docker"
 )
 
 func TestMain(m *testing.M) {
-	helpers.TestMain(m, "msc3391")
+	complement.TestMain(m, "msc3391")
 }
 
 func Deploy(t *testing.T, blueprint b.Blueprint) *docker.Deployment {
 	t.Helper()
-	return helpers.Deploy(t, blueprint)
+	return complement.Deploy(t, blueprint)
 }

--- a/tests/msc3391/main_test.go
+++ b/tests/msc3391/main_test.go
@@ -4,15 +4,8 @@ import (
 	"testing"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
-	"github.com/matrix-org/complement/internal/docker"
 )
 
 func TestMain(m *testing.M) {
 	complement.TestMain(m, "msc3391")
-}
-
-func Deploy(t *testing.T, blueprint b.Blueprint) *docker.Deployment {
-	t.Helper()
-	return complement.Deploy(t, blueprint)
 }

--- a/tests/msc3391/msc3391_test.go
+++ b/tests/msc3391/msc3391_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/match"
@@ -21,7 +22,7 @@ const testAccountDataType = "org.example.test"
 var testAccountDataContent = map[string]interface{}{"test_data": 1}
 
 func TestRemovingAccountData(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	// Create a user to manipulate the account data of

--- a/tests/msc3874/main_test.go
+++ b/tests/msc3874/main_test.go
@@ -3,16 +3,16 @@ package tests
 import (
 	"testing"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
-	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/internal/docker"
 )
 
 func TestMain(m *testing.M) {
-	helpers.TestMain(m, "msc3874")
+	complement.TestMain(m, "msc3874")
 }
 
 func Deploy(t *testing.T, blueprint b.Blueprint) *docker.Deployment {
 	t.Helper()
-	return helpers.Deploy(t, blueprint)
+	return complement.Deploy(t, blueprint)
 }

--- a/tests/msc3874/main_test.go
+++ b/tests/msc3874/main_test.go
@@ -4,15 +4,8 @@ import (
 	"testing"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
-	"github.com/matrix-org/complement/internal/docker"
 )
 
 func TestMain(m *testing.M) {
 	complement.TestMain(m, "msc3874")
-}
-
-func Deploy(t *testing.T, blueprint b.Blueprint) *docker.Deployment {
-	t.Helper()
-	return complement.Deploy(t, blueprint)
 }

--- a/tests/msc3874/room_messages_relation_filter_test.go
+++ b/tests/msc3874/room_messages_relation_filter_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/tidwall/gjson"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/match"
@@ -16,7 +17,7 @@ import (
 
 func TestFilterMessagesByRelType(t *testing.T) {
 	runtime.SkipIf(t, runtime.Dendrite) // flakey
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")

--- a/tests/msc3890/main_test.go
+++ b/tests/msc3890/main_test.go
@@ -4,15 +4,8 @@ import (
 	"testing"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
-	"github.com/matrix-org/complement/internal/docker"
 )
 
 func TestMain(m *testing.M) {
 	complement.TestMain(m, "msc3890")
-}
-
-func Deploy(t *testing.T, blueprint b.Blueprint) *docker.Deployment {
-	t.Helper()
-	return complement.Deploy(t, blueprint)
 }

--- a/tests/msc3890/main_test.go
+++ b/tests/msc3890/main_test.go
@@ -3,16 +3,16 @@ package tests
 import (
 	"testing"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
-	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/internal/docker"
 )
 
 func TestMain(m *testing.M) {
-	helpers.TestMain(m, "msc3890")
+	complement.TestMain(m, "msc3890")
 }
 
 func Deploy(t *testing.T, blueprint b.Blueprint) *docker.Deployment {
 	t.Helper()
-	return helpers.Deploy(t, blueprint)
+	return complement.Deploy(t, blueprint)
 }

--- a/tests/msc3890/msc3890_test.go
+++ b/tests/msc3890/msc3890_test.go
@@ -7,6 +7,7 @@ package tests
 import (
 	"testing"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/match"
@@ -16,7 +17,7 @@ import (
 
 func TestDeletingDeviceRemovesDeviceLocalNotificationSettings(t *testing.T) {
 	// Create a deployment with a single user
-	deployment := Deploy(t, b.BlueprintCleanHS)
+	deployment := complement.Deploy(t, b.BlueprintCleanHS)
 	defer deployment.Destroy(t)
 
 	// Create a user which we can log in to multiple times

--- a/tests/msc3902/federation_room_join_partial_state_test.go
+++ b/tests/msc3902/federation_room_join_partial_state_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/runtime"
 
@@ -220,7 +221,7 @@ func TestPartialStateJoin(t *testing.T) {
 		return syncToken
 	}
 
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	// Test that an eager (i.e. NOT lazy-loading members) /sync request made during a
@@ -496,7 +497,7 @@ func TestPartialStateJoin(t *testing.T) {
 
 	// we should be able to receive typing EDU over federation during the resync
 	t.Run("CanReceiveTypingDuringPartialStateJoin", func(t *testing.T) {
-		deployment := Deploy(t, b.BlueprintAlice)
+		deployment := complement.Deploy(t, b.BlueprintAlice)
 		defer deployment.Destroy(t)
 		alice := deployment.Client(t, "hs1", "@alice:hs1")
 
@@ -566,7 +567,7 @@ func TestPartialStateJoin(t *testing.T) {
 	t.Run("CanReceivePresenceDuringPartialStateJoin", func(t *testing.T) {
 		// See https://github.com/matrix-org/synapse/issues/13008")
 		t.Skip("Presence EDUs are currently dropped during a resync")
-		deployment := Deploy(t, b.BlueprintAlice)
+		deployment := complement.Deploy(t, b.BlueprintAlice)
 		defer deployment.Destroy(t)
 		alice := deployment.Client(t, "hs1", "@alice:hs1")
 
@@ -613,7 +614,7 @@ func TestPartialStateJoin(t *testing.T) {
 
 	// we should be able to receive to_device EDU over federation during the resync
 	t.Run("CanReceiveToDeviceDuringPartialStateJoin", func(t *testing.T) {
-		deployment := Deploy(t, b.BlueprintAlice)
+		deployment := complement.Deploy(t, b.BlueprintAlice)
 		defer deployment.Destroy(t)
 		alice := deployment.Client(t, "hs1", "@alice:hs1")
 
@@ -663,7 +664,7 @@ func TestPartialStateJoin(t *testing.T) {
 
 	// we should be able to receive receipt EDU over federation during the resync
 	t.Run("CanReceiveReceiptDuringPartialStateJoin", func(t *testing.T) {
-		deployment := Deploy(t, b.BlueprintAlice)
+		deployment := complement.Deploy(t, b.BlueprintAlice)
 		defer deployment.Destroy(t)
 		alice := deployment.Client(t, "hs1", "@alice:hs1")
 
@@ -716,7 +717,7 @@ func TestPartialStateJoin(t *testing.T) {
 
 	// we should be able to receive device list update EDU over federation during the resync
 	t.Run("CanReceiveDeviceListUpdateDuringPartialStateJoin", func(t *testing.T) {
-		deployment := Deploy(t, b.BlueprintAlice)
+		deployment := complement.Deploy(t, b.BlueprintAlice)
 		defer deployment.Destroy(t)
 		alice := deployment.Client(t, "hs1", "@alice:hs1")
 
@@ -767,7 +768,7 @@ func TestPartialStateJoin(t *testing.T) {
 
 	// we should be able to receive signing key update EDU over federation during the resync
 	t.Run("CanReceiveSigningKeyUpdateDuringPartialStateJoin", func(t *testing.T) {
-		deployment := Deploy(t, b.BlueprintAlice)
+		deployment := complement.Deploy(t, b.BlueprintAlice)
 		defer deployment.Destroy(t)
 		alice := deployment.Client(t, "hs1", "@alice:hs1")
 
@@ -1208,7 +1209,7 @@ func TestPartialStateJoin(t *testing.T) {
 	// partial state.
 	t.Run("PartialStateJoinSyncsUsingOtherHomeservers", func(t *testing.T) {
 		// set up 3 homeservers: hs1, hs2 and complement
-		deployment := Deploy(t, b.BlueprintFederationTwoLocalOneRemote)
+		deployment := complement.Deploy(t, b.BlueprintFederationTwoLocalOneRemote)
 		defer deployment.Destroy(t)
 		alice := deployment.Client(t, "hs1", "@alice:hs1")
 		charlie := deployment.Client(t, "hs2", "@charlie:hs2")

--- a/tests/msc3902/main_test.go
+++ b/tests/msc3902/main_test.go
@@ -4,15 +4,8 @@ import (
 	"testing"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
-	"github.com/matrix-org/complement/internal/docker"
 )
 
 func TestMain(m *testing.M) {
 	complement.TestMain(m, "msc3902")
-}
-
-func Deploy(t *testing.T, blueprint b.Blueprint) *docker.Deployment {
-	t.Helper()
-	return complement.Deploy(t, blueprint)
 }

--- a/tests/msc3902/main_test.go
+++ b/tests/msc3902/main_test.go
@@ -3,16 +3,16 @@ package tests
 import (
 	"testing"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
-	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/internal/docker"
 )
 
 func TestMain(m *testing.M) {
-	helpers.TestMain(m, "msc3902")
+	complement.TestMain(m, "msc3902")
 }
 
 func Deploy(t *testing.T, blueprint b.Blueprint) *docker.Deployment {
 	t.Helper()
-	return helpers.Deploy(t, blueprint)
+	return complement.Deploy(t, blueprint)
 }

--- a/tests/msc3930/main_test.go
+++ b/tests/msc3930/main_test.go
@@ -3,16 +3,16 @@ package tests
 import (
 	"testing"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
-	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/internal/docker"
 )
 
 func TestMain(m *testing.M) {
-	helpers.TestMain(m, "msc3930")
+	complement.TestMain(m, "msc3930")
 }
 
 func Deploy(t *testing.T, blueprint b.Blueprint) *docker.Deployment {
 	t.Helper()
-	return helpers.Deploy(t, blueprint)
+	return complement.Deploy(t, blueprint)
 }

--- a/tests/msc3930/main_test.go
+++ b/tests/msc3930/main_test.go
@@ -4,15 +4,8 @@ import (
 	"testing"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
-	"github.com/matrix-org/complement/internal/docker"
 )
 
 func TestMain(m *testing.M) {
 	complement.TestMain(m, "msc3930")
-}
-
-func Deploy(t *testing.T, blueprint b.Blueprint) *docker.Deployment {
-	t.Helper()
-	return complement.Deploy(t, blueprint)
 }

--- a/tests/msc3930/msc3930_test.go
+++ b/tests/msc3930/msc3930_test.go
@@ -14,6 +14,7 @@ import (
 	"math"
 	"testing"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
@@ -26,7 +27,7 @@ const pollStartRuleID = ".org.matrix.msc3930.rule.poll_start"
 const pollEndRuleID = ".org.matrix.msc3930.rule.poll_end"
 
 func TestPollsLocalPushRules(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	// Create a user to poll the push rules of.

--- a/tests/restricted_room_hierarchy_test.go
+++ b/tests/restricted_room_hierarchy_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/tidwall/gjson"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/match"
@@ -35,7 +36,7 @@ func requestAndAssertSummary(t *testing.T, user *client.CSAPI, space string, exp
 // The user should be unable to see the room in the spaces summary unless they
 // are a member of the space.
 func TestRestrictedRoomsSpacesSummaryLocal(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	// Create the rooms
@@ -116,7 +117,7 @@ func TestRestrictedRoomsSpacesSummaryLocal(t *testing.T) {
 // different homeservers, and one might not have the proper information needed to
 // decide if a user is in a room.
 func TestRestrictedRoomsSpacesSummaryFederation(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintFederationTwoLocalOneRemote)
+	deployment := complement.Deploy(t, b.BlueprintFederationTwoLocalOneRemote)
 	defer deployment.Destroy(t)
 
 	// Create the rooms

--- a/tests/restricted_rooms_test.go
+++ b/tests/restricted_rooms_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/tidwall/gjson"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/internal/docker"
@@ -176,7 +177,7 @@ func checkRestrictedRoom(t *testing.T, alice *client.CSAPI, bob *client.CSAPI, a
 
 // Test joining a room with join rules restricted to membership in another room.
 func TestRestrictedRoomsLocalJoin(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	// Setup the user, allowed room, and restricted room.
@@ -191,7 +192,7 @@ func TestRestrictedRoomsLocalJoin(t *testing.T) {
 
 // Test joining a room with join rules restricted to membership in another room.
 func TestRestrictedRoomsRemoteJoin(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintFederationOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintFederationOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	// Setup the user, allowed room, and restricted room.
@@ -213,7 +214,7 @@ func TestRestrictedRoomsRemoteJoinLocalUser(t *testing.T) {
 func doTestRestrictedRoomsRemoteJoinLocalUser(t *testing.T, roomVersion string, joinRule string) {
 	runtime.SkipIf(t, runtime.Dendrite) // FIXME: https://github.com/matrix-org/dendrite/issues/2801
 
-	deployment := Deploy(t, b.BlueprintFederationTwoLocalOneRemote)
+	deployment := complement.Deploy(t, b.BlueprintFederationTwoLocalOneRemote)
 	defer deployment.Destroy(t)
 
 	// Charlie sets up the allowed room so it is on the other server.
@@ -332,7 +333,7 @@ func TestRestrictedRoomsRemoteJoinFailOver(t *testing.T) {
 func doTestRestrictedRoomsRemoteJoinFailOver(t *testing.T, roomVersion string, joinRule string) {
 	runtime.SkipIf(t, runtime.Dendrite) // FIXME: https://github.com/matrix-org/dendrite/issues/2801
 
-	deployment := Deploy(t, b.Blueprint{
+	deployment := complement.Deploy(t, b.Blueprint{
 		Name: "federation_three_homeservers",
 		Homeservers: []b.Homeserver{
 			{

--- a/tests/room_hierarchy_test.go
+++ b/tests/room_hierarchy_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/tidwall/gjson"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/match"
@@ -53,16 +54,19 @@ func roomToChildrenMapper(r gjson.Result) interface{} {
 }
 
 // Tests that the CS API for MSC2946 works correctly. Creates a space directory like:
-//     Root
-//      |
+//
+//	Root
+//	 |
+//
 // _____|________
 // |    |       |
 // R1  SS1      R2
-//      |       |
-//     SS2      R5
-//      |________
-//      |       |
-//      R3      R4
+//
+//	 |       |
+//	SS2      R5
+//	 |________
+//	 |       |
+//	 R3      R4
 //
 // Where:
 // - the user is joined to all rooms except R4.
@@ -78,7 +82,7 @@ func roomToChildrenMapper(r gjson.Result) interface{} {
 // - Events are returned correctly.
 // - Redacting links works correctly.
 func TestClientSpacesSummary(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	roomNames := make(map[string]string)
@@ -369,14 +373,17 @@ func TestClientSpacesSummary(t *testing.T) {
 }
 
 // Tests that the CS API for MSC2946 correctly handles join rules. Creates a space directory like:
-//     Root
-//      |
+//
+//	Root
+//	 |
+//
 // _____|
 // |    |
 // R1  SS1
-//      |________
-//      |       |
-//      R2      R3
+//
+//	|________
+//	|       |
+//	R2      R3
 //
 // Where:
 // - All rooms and spaces are invite-only, except R2 (which is public)
@@ -385,7 +392,7 @@ func TestClientSpacesSummary(t *testing.T) {
 // Tests that:
 // - Rooms/spaces the user is not invited to should not appear.
 func TestClientSpacesSummaryJoinRules(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	// create the rooms
@@ -515,22 +522,25 @@ func TestClientSpacesSummaryJoinRules(t *testing.T) {
 }
 
 // Tests that MSC2946 works over federation. Creates a space directory like:
-//     ROOT
-//      |
+//
+//	ROOT
+//	 |
+//
 // _____|________
 // |    |       |
 // R1  SS1      r2
-//      |________
-//      |        |
-//     ss2      r3
-//      |
-//      R4
+//
+//	 |________
+//	 |        |
+//	ss2      r3
+//	 |
+//	 R4
 //
 // Where R/SS = on hs1, and r/ss = on hs2. Links are space children state events only.
 // Tests that:
 // - Querying from root returns the entire graph
 func TestFederatedClientSpaces(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintFederationOneToOneRoom)
+	deployment := complement.Deploy(t, b.BlueprintFederationOneToOneRoom)
 	defer deployment.Destroy(t)
 
 	worldReadable := map[string]interface{}{

--- a/tests/room_timestamp_to_event_test.go
+++ b/tests/room_timestamp_to_event_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/match"
@@ -24,7 +25,7 @@ import (
 )
 
 func TestJumpToDateEndpoint(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintHSWithApplicationService)
+	deployment := complement.Deploy(t, b.BlueprintHSWithApplicationService)
 	defer deployment.Destroy(t)
 
 	// Create the normal user which will send messages in the room

--- a/tests/unknown_endpoints_test.go
+++ b/tests/unknown_endpoints_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/match"
@@ -37,7 +38,7 @@ func queryUnknownMethod(t *testing.T, user *client.CSAPI, method string, paths [
 // Homeservers should return a 404 for unknown endpoints and 405 for incorrect
 // methods to known endpoints.
 func TestUnknownEndpoints(t *testing.T) {
-	deployment := Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")


### PR DESCRIPTION
Every test package that wants to use Complement needs some bootstrapping boilerplate code to do things like read the env vars and clean up old containers in case of an ungraceful shutdown. There is a convenient `TestMain` function which is part of standard Go tests which we can use for this.

We also had a helper function called `Deploy` which would deploy a set of containers and return the `docker.Deployment` for tests to use. This helper function is actually boilerplate as well, but has still historically been defined for each test package unnecessarily.

This PR cleans up these entry points in the following way:
 - Always use the helper functions when writing entry points. Previously, only MSC packages did this. This was just an omission from #666 
 - Moves entry point functions from the `helpers` package to the top-level `complement` package. Why: this signals to test writers where to look when they want to hook into Complement machinery as it serves as the entry point functions. This ends up reading very nicely as `deployment := complement.Deploy(t, b.BlueprintAlice)`.
 - Remove the useless proxy function `Deploy(...)` which just called the previous line.

This now means that out-of-repo tests (which need to call `somepackage.Deploy`) and in-repo tests look identical, and bootstrapping boilerplate is as small as possible:
```
package tests

import (
	"testing"

	"github.com/matrix-org/complement"
)

func TestMain(m *testing.M) {
	complement.TestMain(m, "package-name-goes-here")
}
```