### PR TITLE
Add a complement.Deployment interface

### DIFF
--- a/internal/docker/deployment.go
+++ b/internal/docker/deployment.go
@@ -1,6 +1,7 @@
 package docker
 
 import (
+	"net/http"
 	"sync"
 	"testing"
 	"time"
@@ -51,6 +52,14 @@ func (d *Deployment) Destroy(t *testing.T) {
 	d.Deployer.Destroy(d, d.Deployer.config.AlwaysPrintServerLogs || t.Failed(), t.Name(), t.Failed())
 }
 
+func (d *Deployment) GetConfig() *config.Complement {
+	return d.Config
+}
+
+func (d *Deployment) RoundTripper() http.RoundTripper {
+	return &RoundTripper{Deployment: d}
+}
+
 // Client returns a CSAPI client targeting the given hsName, using the access token for the given userID.
 // Fails the test if the hsName is not found. Returns an unauthenticated client if userID is "", fails the test
 // if the userID is otherwise not found.
@@ -91,7 +100,7 @@ func (d *Deployment) Client(t *testing.T, hsName, userID string) *client.CSAPI {
 
 // NewUser creates a new user as a convenience method to RegisterUser.
 //
-//It registers the user with a deterministic password, and without admin privileges.
+// It registers the user with a deterministic password, and without admin privileges.
 func (d *Deployment) NewUser(t *testing.T, localpart, hs string) *client.CSAPI {
 	return d.RegisterUser(t, hs, localpart, "complement_meets_min_pasword_req_"+localpart, false)
 }

--- a/internal/federation/server_test.go
+++ b/internal/federation/server_test.go
@@ -7,14 +7,26 @@ import (
 	"testing"
 
 	"github.com/matrix-org/complement/internal/config"
-	"github.com/matrix-org/complement/internal/docker"
 )
+
+type fedDeploy struct {
+	cfg     *config.Complement
+	tripper http.RoundTripper
+}
+
+func (d *fedDeploy) GetConfig() *config.Complement {
+	return d.cfg
+}
+func (d *fedDeploy) RoundTripper() http.RoundTripper {
+	return d.tripper
+}
 
 func TestComplementServerIsSigned(t *testing.T) {
 	cfg := config.NewConfigFromEnvVars("test", "unimportant")
 	cfg.HostnameRunningComplement = "localhost"
-	srv := NewServer(t, &docker.Deployment{
-		Config: cfg,
+	srv := NewServer(t, &fedDeploy{
+		cfg:     cfg,
+		tripper: http.DefaultClient.Transport,
 	})
 	srv.UnexpectedRequestsAreErrors = false
 	cancel := srv.Listen()

--- a/test_main.go
+++ b/test_main.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/matrix-org/complement/b"
-	"github.com/matrix-org/complement/internal/docker"
 )
 
 var testPackage *TestPackage
@@ -35,7 +34,7 @@ func TestMain(m *testing.M, namespace string) {
 // It will construct the blueprint if it doesn't already exist in the docker image cache.
 // This function is the main setup function for all tests as it provides a deployment with
 // which tests can interact with.
-func Deploy(t *testing.T, blueprint b.Blueprint) *docker.Deployment {
+func Deploy(t *testing.T, blueprint b.Blueprint) Deployment {
 	t.Helper()
 	if testPackage == nil {
 		t.Fatalf("Deploy: testPackage not set, did you forget to call complement.TestMain?")

--- a/test_package.go
+++ b/test_package.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// Deployment provides a way for tests to interact with a set of homeservers.
 type Deployment interface {
 	// Client returns a CSAPI client targeting the given hsName, using the access token for the given userID.
 	// Fails the test if the hsName is not found. Returns an unauthenticated client if userID is "", fails the test

--- a/tests/csapi/account_change_password_test.go
+++ b/tests/csapi/account_change_password_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
-	"github.com/matrix-org/complement/internal/docker"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 
@@ -121,7 +120,7 @@ func changePassword(t *testing.T, passwordClient *client.CSAPI, oldPassword stri
 	})
 }
 
-func createSession(t *testing.T, deployment *docker.Deployment, userID, password string) (deviceID string, authedClient *client.CSAPI) {
+func createSession(t *testing.T, deployment complement.Deployment, userID, password string) (deviceID string, authedClient *client.CSAPI) {
 	authedClient = deployment.Client(t, "hs1", "")
 	reqBody := client.WithJSONBody(t, map[string]interface{}{
 		"identifier": map[string]interface{}{

--- a/tests/csapi/apidoc_room_receipts_test.go
+++ b/tests/csapi/apidoc_room_receipts_test.go
@@ -6,13 +6,12 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
-	"github.com/matrix-org/complement/internal/docker"
 	"github.com/tidwall/gjson"
 )
 
 // tests/10apidoc/37room-receipts.pl
 
-func createRoomForReadReceipts(t *testing.T, c *client.CSAPI, deployment *docker.Deployment) (string, string) {
+func createRoomForReadReceipts(t *testing.T, c *client.CSAPI, deployment complement.Deployment) (string, string) {
 	roomID := c.MustCreateRoom(t, map[string]interface{}{"preset": "public_chat"})
 
 	c.MustSyncUntil(t, client.SyncReq{}, client.SyncJoinedTo(c.UserID, roomID))

--- a/tests/csapi/device_lists_test.go
+++ b/tests/csapi/device_lists_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
-	"github.com/matrix-org/complement/internal/docker"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 	"github.com/matrix-org/complement/runtime"
@@ -112,7 +111,7 @@ func TestDeviceListUpdates(t *testing.T) {
 	// updates and queries before the barrier do not appear in `/sync` responses after the barrier.
 	makeBarrier := func(
 		t *testing.T,
-		deployment *docker.Deployment,
+		deployment complement.Deployment,
 		observingUser *client.CSAPI,
 		otherHSName string,
 	) func(t *testing.T, nextBatch string) string {
@@ -142,7 +141,7 @@ func TestDeviceListUpdates(t *testing.T) {
 	// We only care about what Alice sees.
 
 	// testOtherUserJoin tests another user joining a room Alice is already in.
-	testOtherUserJoin := func(t *testing.T, deployment *docker.Deployment, hsName string, otherHSName string) {
+	testOtherUserJoin := func(t *testing.T, deployment complement.Deployment, hsName string, otherHSName string) {
 		alice := deployment.RegisterUser(t, hsName, generateLocalpart("alice"), "password", false)
 		bob := deployment.RegisterUser(t, otherHSName, generateLocalpart("bob"), "password", false)
 		barrier := makeBarrier(t, deployment, alice, otherHSName)
@@ -188,7 +187,7 @@ func TestDeviceListUpdates(t *testing.T) {
 
 	// testJoin tests Alice joining a room another user is already in.
 	testJoin := func(
-		t *testing.T, deployment *docker.Deployment, hsName string, otherHSName string,
+		t *testing.T, deployment complement.Deployment, hsName string, otherHSName string,
 	) {
 		alice := deployment.RegisterUser(t, hsName, generateLocalpart("alice"), "password", false)
 		bob := deployment.RegisterUser(t, otherHSName, generateLocalpart("bob"), "password", false)
@@ -234,7 +233,7 @@ func TestDeviceListUpdates(t *testing.T) {
 	}
 
 	// testOtherUserLeave tests another user leaving a room Alice is in.
-	testOtherUserLeave := func(t *testing.T, deployment *docker.Deployment, hsName string, otherHSName string) {
+	testOtherUserLeave := func(t *testing.T, deployment complement.Deployment, hsName string, otherHSName string) {
 		alice := deployment.RegisterUser(t, hsName, generateLocalpart("alice"), "password", false)
 		bob := deployment.RegisterUser(t, otherHSName, generateLocalpart("bob"), "password", false)
 		barrier := makeBarrier(t, deployment, alice, otherHSName)
@@ -285,7 +284,7 @@ func TestDeviceListUpdates(t *testing.T) {
 	}
 
 	// testLeave tests Alice leaving a room another user is in.
-	testLeave := func(t *testing.T, deployment *docker.Deployment, hsName string, otherHSName string) {
+	testLeave := func(t *testing.T, deployment complement.Deployment, hsName string, otherHSName string) {
 		alice := deployment.RegisterUser(t, hsName, generateLocalpart("alice"), "password", false)
 		bob := deployment.RegisterUser(t, otherHSName, generateLocalpart("bob"), "password", false)
 		barrier := makeBarrier(t, deployment, alice, otherHSName)
@@ -336,7 +335,7 @@ func TestDeviceListUpdates(t *testing.T) {
 	}
 
 	// testOtherUserRejoin tests another user leaving and rejoining a room Alice is in.
-	testOtherUserRejoin := func(t *testing.T, deployment *docker.Deployment, hsName string, otherHSName string) {
+	testOtherUserRejoin := func(t *testing.T, deployment complement.Deployment, hsName string, otherHSName string) {
 		alice := deployment.RegisterUser(t, hsName, generateLocalpart("alice"), "password", false)
 		bob := deployment.RegisterUser(t, otherHSName, generateLocalpart("bob"), "password", false)
 		barrier := makeBarrier(t, deployment, alice, otherHSName)

--- a/tests/csapi/url_preview_test.go
+++ b/tests/csapi/url_preview_test.go
@@ -45,7 +45,7 @@ func TestUrlPreview(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
-	webServer := web.NewServer(t, deployment.Config, func(router *mux.Router) {
+	webServer := web.NewServer(t, deployment.GetConfig(), func(router *mux.Router) {
 		router.HandleFunc("/test.png", func(w http.ResponseWriter, req *http.Request) {
 			t.Log("/test.png fetched")
 

--- a/tests/federation_keys_test.go
+++ b/tests/federation_keys_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
-	"github.com/matrix-org/complement/internal/docker"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
@@ -33,7 +32,7 @@ func TestInboundFederationKeys(t *testing.T) {
 
 	fedClient := &http.Client{
 		Timeout:   10 * time.Second,
-		Transport: &docker.RoundTripper{Deployment: deployment},
+		Transport: deployment.RoundTripper(),
 	}
 
 	res, err := fedClient.Get("https://hs1/_matrix/key/v2/server")

--- a/tests/federation_room_join_test.go
+++ b/tests/federation_room_join_test.go
@@ -183,7 +183,7 @@ func TestJoinFederatedRoomWithUnverifiableEvents(t *testing.T) {
 			},
 		})
 		newSignaturesBlock := map[string]interface{}{
-			deployment.Config.HostnameRunningComplement: map[string]string{
+			deployment.GetConfig().HostnameRunningComplement: map[string]string{
 				string(srv.KeyID): "/3z+pJjiJXWhwfqIEzmNksvBHCoXTktK/y0rRuWJXw6i1+ygRG/suDCKhFuuz6gPapRmEMPVILi2mJqHHXPKAg",
 			},
 		}
@@ -214,7 +214,7 @@ func TestJoinFederatedRoomWithUnverifiableEvents(t *testing.T) {
 			},
 		})
 		newSignaturesBlock := map[string]interface{}{
-			deployment.Config.HostnameRunningComplement: map[string]string{
+			deployment.GetConfig().HostnameRunningComplement: map[string]string{
 				string(srv.KeyID) + "bogus": "/3z+pJjiJXWhwfqIEzmNksvBHCoXTktK/y0rRuWJXw6i1+ygRG/suDCKhFuuz6gPapRmEMPVILi2mJqHHXPKAg",
 			},
 		}
@@ -249,7 +249,7 @@ func TestJoinFederatedRoomWithUnverifiableEvents(t *testing.T) {
 			},
 		}).JSON()
 		rawSig, err := json.Marshal(map[string]interface{}{
-			deployment.Config.HostnameRunningComplement: map[string]string{
+			deployment.GetConfig().HostnameRunningComplement: map[string]string{
 				string(srv.KeyID): "/3z+pJjiJXWhwfqIEzmNksvBHCoXTktK/y0rRuWJXw6i1+ygRG/suDCKhFuuz6gPapRmEMPVILi2mJqHHXPKAg",
 			},
 		})

--- a/tests/federation_room_send_test.go
+++ b/tests/federation_room_send_test.go
@@ -54,7 +54,7 @@ func TestOutboundFederationSend(t *testing.T) {
 	roomAlias := srv.MakeAliasMapping("flibble", serverRoom.RoomID)
 
 	// the local homeserver joins the room
-	alice.MustJoinRoom(t, roomAlias, []string{deployment.Config.HostnameRunningComplement})
+	alice.MustJoinRoom(t, roomAlias, []string{deployment.GetConfig().HostnameRunningComplement})
 
 	// the local homeserver sends an event into the room
 	alice.SendEventSynced(t, serverRoom.RoomID, b.Event{

--- a/tests/msc2836/msc2836_test.go
+++ b/tests/msc2836/msc2836_test.go
@@ -197,7 +197,7 @@ func TestFederatedEventRelationships(t *testing.T) {
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
 
-	srv := federation.NewServer(t, deployment,
+	srv := federation.NewServer(t, deployment.GetConfig(), deployment.RoundTripper(),
 		federation.HandleKeyRequests(),
 		federation.HandleMakeSendJoinRequests(),
 		federation.HandleTransactionRequests(nil, nil),

--- a/tests/msc3902/federation_room_join_partial_state_test.go
+++ b/tests/msc3902/federation_room_join_partial_state_test.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
-	"github.com/matrix-org/complement/internal/docker"
 	"github.com/matrix-org/complement/internal/federation"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
@@ -51,7 +50,7 @@ type server struct {
 //
 // The `federation.HandleTransactionRequests` handler must not be used.
 // Instead, `AddPDUHandler` and `AddEDUHandler` should be used.
-func createTestServer(t *testing.T, deployment *docker.Deployment, opts ...func(*federation.Server)) *server {
+func createTestServer(t *testing.T, deployment complement.Deployment, opts ...func(*federation.Server)) *server {
 	t.Helper()
 
 	server := &server{
@@ -2043,7 +2042,7 @@ func TestPartialStateJoin(t *testing.T) {
 		// Returns channels for device list updates arriving at the complement homeservers, which
 		// can be used with `mustReceiveDeviceListUpdate` and `mustNotReceiveDeviceListUpdate`.
 		setupOutgoingDeviceListUpdateTest := func(
-			t *testing.T, deployment *docker.Deployment, aliceLocalpart string,
+			t *testing.T, deployment complement.Deployment, aliceLocalpart string,
 			opts ...func(*federation.Server),
 		) (
 			alice *client.CSAPI, server1 *server, server2 *server,
@@ -2057,7 +2056,7 @@ func TestPartialStateJoin(t *testing.T) {
 			deviceListUpdateChannel2 = make(chan gomatrixserverlib.DeviceListUpdateEvent, 10)
 
 			createDeviceListUpdateTestServer := func(
-				t *testing.T, deployment *docker.Deployment,
+				t *testing.T, deployment complement.Deployment,
 				deviceListUpdateChannel chan gomatrixserverlib.DeviceListUpdateEvent,
 				opts ...func(*federation.Server),
 			) *server {
@@ -2292,7 +2291,7 @@ func TestPartialStateJoin(t *testing.T) {
 		// As a side effect, @derek is promoted to admin and leaves the room before the homeserver
 		// under test joins.
 		setupIncorrectlyAcceptedKick := func(
-			t *testing.T, deployment *docker.Deployment, alice *client.CSAPI,
+			t *testing.T, deployment complement.Deployment, alice *client.CSAPI,
 			server1 *server, server2 *server,
 			deviceListUpdateChannel1 chan gomatrixserverlib.DeviceListUpdateEvent,
 			deviceListUpdateChannel2 chan gomatrixserverlib.DeviceListUpdateEvent,
@@ -2365,7 +2364,7 @@ func TestPartialStateJoin(t *testing.T) {
 		// the public room, then leave the partial state room.
 		// Returns @alice:hs1's sync token after @elsie:server2 has left the partial state room.
 		setupAnotherSharedRoomThenLeave := func(
-			t *testing.T, deployment *docker.Deployment, alice *client.CSAPI,
+			t *testing.T, deployment complement.Deployment, alice *client.CSAPI,
 			server1 *server, server2 *server,
 			partialStateRoom *federation.ServerRoom, syncToken string,
 		) (nextSyncToken string, leaveSharedRoom func()) {
@@ -2405,7 +2404,7 @@ func TestPartialStateJoin(t *testing.T) {
 		// believes @elsie:server2 not to be present and tests that server2 receives missed device
 		// list updates once hs1's partial state join has completed.
 		testMissedDeviceListUpdateSentOncePartialJoinCompletes := func(
-			t *testing.T, deployment *docker.Deployment, alice *client.CSAPI,
+			t *testing.T, deployment complement.Deployment, alice *client.CSAPI,
 			server1 *server, server2 *server,
 			deviceListUpdateChannel1 chan gomatrixserverlib.DeviceListUpdateEvent,
 			deviceListUpdateChannel2 chan gomatrixserverlib.DeviceListUpdateEvent,
@@ -2568,7 +2567,7 @@ func TestPartialStateJoin(t *testing.T) {
 		// can be used with `mustQueryKeysWithFederationRequest` and
 		// `mustQueryKeysWithoutFederationRequest`.
 		setupDeviceListCachingTest := func(
-			t *testing.T, deployment *docker.Deployment, aliceLocalpart string,
+			t *testing.T, deployment complement.Deployment, aliceLocalpart string,
 		) (
 			alice *client.CSAPI, server *server, userDevicesQueryChannel chan string,
 			room *federation.ServerRoom, sendDeviceListUpdate func(string), cleanup func(),
@@ -3101,7 +3100,7 @@ func TestPartialStateJoin(t *testing.T) {
 		// in the room when they have really been kicked. Once the partial state join completes,
 		// @elsie will be discovered to be no longer in the room.
 		setupUserIncorrectlyInRoom := func(
-			t *testing.T, deployment *docker.Deployment, alice *client.CSAPI,
+			t *testing.T, deployment complement.Deployment, alice *client.CSAPI,
 			server *server, room *federation.ServerRoom,
 		) (syncToken string, psjResult partialStateJoinResult) {
 			charlie := server.UserID("charlie")
@@ -4064,7 +4063,7 @@ func TestPartialStateJoin(t *testing.T) {
 // sends the given event to the homeserver under test, checks that a client can see it and checks
 // the state at the event. returns the new sync token after the event.
 func testReceiveEventDuringPartialStateJoin(
-	t *testing.T, deployment *docker.Deployment, alice *client.CSAPI, psjResult partialStateJoinResult, event gomatrixserverlib.PDU, syncToken string,
+	t *testing.T, deployment complement.Deployment, alice *client.CSAPI, psjResult partialStateJoinResult, event gomatrixserverlib.PDU, syncToken string,
 ) string {
 	// send the event to the homeserver
 	psjResult.Server.MustSendTransaction(t, deployment, "hs1", []json.RawMessage{event.JSON()}, nil)

--- a/tests/restricted_rooms_test.go
+++ b/tests/restricted_rooms_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
-	"github.com/matrix-org/complement/internal/docker"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 	"github.com/matrix-org/complement/runtime"
@@ -18,7 +17,7 @@ import (
 
 // Creates two rooms on room version 8 and sets the second room to have
 // restricted join rules with allow set to the first room.
-func setupRestrictedRoom(t *testing.T, deployment *docker.Deployment, roomVersion string, joinRule string) (*client.CSAPI, string, string) {
+func setupRestrictedRoom(t *testing.T, deployment complement.Deployment, roomVersion string, joinRule string) (*client.CSAPI, string, string) {
 	t.Helper()
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")


### PR DESCRIPTION
The `docker` package is internal, meaning that it's hard for out-of-repo tests to make use of the `*docker.Deployment`. Instead, hide the concrete impl behind an interface `complement.Deployment`, which also conveniently only exposes the functions used by real tests. Pepper this API with TODOs. Add a `FederationDeployment` which is a subset of `complement.Deployment` required by the complement-fed-server.

This is the first step to enabling dirty runs. Now that the deployment API is defined, this opens up the ability to:
 - specify a general "give me a CSAPI" function with functional options for passwords/etc, which will replace `NewUser`, `LoginUser`, `RegisterUser`, `Client`). This function will _not allow the full user ID to be specified_, so dirty runs can add a prefix/suffix to the localpart.
 - add `complement.DirtyDeploy` which can have the newly desired function signature of `deployment := complement.Deploy(t, numHomeservers)`. Swap some tests over to this to get a feel for what works/doesn't work. This means tests _will not be able to specify blueprints_. This is fine because the new "give me a CSAPI" function will handle the typical `alice := deployment.Client(t, "hs1", "@alice:hs1")` calls.
 - replace `complement.Deploy` with `complement.DirtyDeploy` (and remove `Dirty`), updating all tests to the new format.

At that point, containers are still made once for each test, but all tests are now ignorant of the user ID / blueprint, meaning we can then swap out the concrete `Deployment` impl for one which re-uses containers, and add an env var to control it e.g `COMPLEMENT_DIRTY=1`.

Long term, I want dirty runs to be enabled _by default_, to encourage test writers to write isolated tests which don't pollute other tests.  
