### PR TITLE
Refactor Deployment Register/Login functions

### DIFF
--- a/helpers/clientopts.go
+++ b/helpers/clientopts.go
@@ -1,0 +1,12 @@
+package helpers
+
+type RegistrationOpts struct {
+	Localpart string // default '' (don't care)
+	DeviceID  string // default '' (generate new)
+	Password  string // default 'complement_meets_min_password_requirement'
+	IsAdmin   bool   // default false
+}
+
+type LoginOpts struct {
+	Password string // default 'complement_meets_min_password_requirement'
+}

--- a/internal/docker/deployment.go
+++ b/internal/docker/deployment.go
@@ -85,7 +85,10 @@ func (d *Deployment) Register(t *testing.T, hsName string, opts helpers.Registra
 	if password == "" {
 		password = "complement_meets_min_password_req"
 	}
-	localpart := fmt.Sprintf("user-%v-%v", d.localpartCounter.Add(1), opts.Localpart)
+	localpart := opts.Localpart
+	if localpart == "" {
+		localpart = fmt.Sprintf("user-%v", d.localpartCounter.Add(1))
+	}
 	var userID, accessToken, deviceID string
 	if opts.IsAdmin {
 		userID, accessToken, deviceID = client.RegisterSharedSecret(t, localpart, password, opts.IsAdmin)

--- a/test_package.go
+++ b/test_package.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/internal/config"
 	"github.com/matrix-org/complement/internal/docker"
 	"github.com/sirupsen/logrus"
@@ -22,16 +23,11 @@ type Deployment interface {
 	// Fails the test if the hsName is not found. Returns an unauthenticated client if userID is "", fails the test
 	// if the userID is otherwise not found.
 	Client(t *testing.T, serverName, userID string) *client.CSAPI
-	// RegisterUser within a homeserver and return an authenticatedClient, Fails the test if the hsName is not found.
-	RegisterUser(t *testing.T, hsName, localpart, password string, isAdmin bool) *client.CSAPI
-	// NewUser creates a new user as a convenience method to RegisterUser. TODO REMOVE
-	//
-	// It registers the user with a deterministic password, and without admin privileges.
-	NewUser(t *testing.T, localpart, hs string) *client.CSAPI
-	// TODO remove this, only used in 1 test in msc3890
-	// LoginUser within a homeserver and return an authenticatedClient. Fails the test if the hsName is not found.
-	// Note that this will not change the access token of the client that is returned by `deployment.Client`.
-	LoginUser(t *testing.T, hsName, localpart, password string) *client.CSAPI
+	// Register a new user on the given server.
+	Register(t *testing.T, hsName string, opts helpers.RegistrationOpts) *client.CSAPI
+	// Login to an existing user account on the given server. In order to make tests not hardcode full user IDs,
+	// an existing logged in client must be supplied.
+	Login(t *testing.T, hsName string, existing *client.CSAPI, opts helpers.LoginOpts) *client.CSAPI
 	// Restart a deployment.
 	Restart(t *testing.T) error
 	// Destroy the entire deployment. Destroys all running containers. If `printServerLogs` is true,

--- a/tests/csapi/account_change_password_pushers_test.go
+++ b/tests/csapi/account_change_password_pushers_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 
@@ -20,7 +21,10 @@ func TestChangePasswordPushers(t *testing.T) {
 	defer deployment.Destroy(t)
 	password1 := "superuser"
 	password2 := "my_new_password"
-	passwordClient := deployment.RegisterUser(t, "hs1", "test_change_password_pusher_user", password1, false)
+	passwordClient := deployment.Register(t, "hs1", helpers.RegistrationOpts{
+		Localpart: "test_change_password_pusher_user",
+		Password:  password1,
+	})
 
 	// sytest: Pushers created with a different access token are deleted on password change
 	t.Run("Pushers created with a different access token are deleted on password change", func(t *testing.T) {

--- a/tests/csapi/account_change_password_test.go
+++ b/tests/csapi/account_change_password_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 
@@ -18,7 +19,10 @@ func TestChangePassword(t *testing.T) {
 	defer deployment.Destroy(t)
 	password1 := "superuser"
 	password2 := "my_new_password"
-	passwordClient := deployment.RegisterUser(t, "hs1", "test_change_password_user", password1, false)
+	passwordClient := deployment.Register(t, "hs1", helpers.RegistrationOpts{
+		Localpart: "test_change_password_user",
+		Password:  password1,
+	})
 	unauthedClient := deployment.Client(t, "hs1", "")
 	_, sessionTest := createSession(t, deployment, "test_change_password_user", "superuser")
 	// sytest: After changing password, can't log in with old password

--- a/tests/csapi/account_deactivate_test.go
+++ b/tests/csapi/account_deactivate_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
@@ -17,7 +18,10 @@ func TestDeactivateAccount(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 	password := "superuser"
-	authedClient := deployment.RegisterUser(t, "hs1", "test_deactivate_user", password, false)
+	authedClient := deployment.Register(t, "hs1", helpers.RegistrationOpts{
+		Localpart: "test_deactivate_user",
+		Password:  password,
+	})
 	unauthedClient := deployment.Client(t, "hs1", "")
 
 	// Ensure that the first step, in which the client queries the server's user-interactive auth flows, returns

--- a/tests/csapi/admin_test.go
+++ b/tests/csapi/admin_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
@@ -19,14 +20,22 @@ import (
 func TestCanRegisterAdmin(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
-	deployment.RegisterUser(t, "hs1", "admin", "adminpassword", true)
+	deployment.Register(t, "hs1", helpers.RegistrationOpts{
+		Localpart: "admin",
+		Password:  "adminpassword",
+		IsAdmin:   true,
+	})
 }
 
 // Test if the implemented /_synapse/admin/v1/send_server_notice behaves as expected
 func TestServerNotices(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
-	admin := deployment.RegisterUser(t, "hs1", "admin", "adminpassword", true)
+	admin := deployment.Register(t, "hs1", helpers.RegistrationOpts{
+		Localpart: "admin",
+		Password:  "adminpassword",
+		IsAdmin:   true,
+	})
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
 
 	reqBody := client.WithJSONBody(t, map[string]interface{}{

--- a/tests/csapi/apidoc_device_management_test.go
+++ b/tests/csapi/apidoc_device_management_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
@@ -16,7 +17,10 @@ func TestDeviceManagement(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 	unauthedClient := deployment.Client(t, "hs1", "")
-	authedClient := deployment.RegisterUser(t, "hs1", "test_device_management_user", "superuser", false)
+	authedClient := deployment.Register(t, "hs1", helpers.RegistrationOpts{
+		Localpart: "test_device_management_user",
+		Password:  "superuser",
+	})
 
 	// sytest: GET /device/{deviceId}
 	t.Run("GET /device/{deviceId}", func(t *testing.T) {
@@ -194,7 +198,10 @@ func TestDeviceManagement(t *testing.T) {
 	})
 	// sytest: DELETE /device/{deviceId} requires UI auth user to match device owner
 	t.Run("DELETE /device/{deviceId} requires UI auth user to match device owner", func(t *testing.T) {
-		bob := deployment.RegisterUser(t, "hs1", "bob", "bobspassword", false)
+		bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{
+			Localpart: "bob",
+			Password:  "bobspassword",
+		})
 
 		newDeviceID, session2 := createSession(t, deployment, authedClient.UserID, "superuser")
 		session2.MustSync(t, client.SyncReq{})

--- a/tests/csapi/apidoc_login_test.go
+++ b/tests/csapi/apidoc_login_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
@@ -18,7 +19,10 @@ func TestLogin(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 	unauthedClient := deployment.Client(t, "hs1", "")
-	_ = deployment.RegisterUser(t, "hs1", "test_login_user", "superuser", false)
+	deployment.Register(t, "hs1", helpers.RegistrationOpts{
+		Localpart: "test_login_user",
+		Password:  "superuser",
+	})
 	t.Run("parallel", func(t *testing.T) {
 		// sytest: GET /login yields a set of flows
 		t.Run("GET /login yields a set of flows", func(t *testing.T) {

--- a/tests/csapi/apidoc_logout_test.go
+++ b/tests/csapi/apidoc_logout_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
@@ -18,7 +19,10 @@ func TestLogout(t *testing.T) {
 	defer deployment.Destroy(t)
 
 	password := "superuser"
-	verifyClientUser := deployment.RegisterUser(t, "hs1", "testuser", password, false)
+	verifyClientUser := deployment.Register(t, "hs1", helpers.RegistrationOpts{
+		Localpart: "testuser",
+		Password:  password,
+	})
 
 	// sytest: Can logout current device
 	t.Run("Can logout current device", func(t *testing.T) {

--- a/tests/csapi/apidoc_register_test.go
+++ b/tests/csapi/apidoc_register_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
@@ -181,7 +182,10 @@ func TestRegistration(t *testing.T) {
 			for x := range testChars {
 				localpart := fmt.Sprintf("chrtestuser%s", string(testChars[x]))
 				t.Run(string(testChars[x]), func(t *testing.T) {
-					deployment.RegisterUser(t, "hs1", localpart, "sUp3rs3kr1t", false)
+					deployment.Register(t, "hs1", helpers.RegistrationOpts{
+						Localpart: localpart,
+						Password:  "sUp3rs3kr1t",
+					})
 				})
 			}
 		})
@@ -275,7 +279,7 @@ func TestRegistration(t *testing.T) {
 			t.Parallel()
 			testUserName := "username_not_available"
 			// Don't need the return value here, just need a user to be registered to test against
-			_ = deployment.NewUser(t, testUserName, "hs1")
+			deployment.Register(t, "hs1", helpers.RegistrationOpts{Localpart: testUserName})
 			res := unauthedClient.Do(t, "GET", []string{"_matrix", "client", "v3", "register", "available"}, client.WithQueries(url.Values{
 				"username": []string{testUserName},
 			}))

--- a/tests/csapi/device_lists_test.go
+++ b/tests/csapi/device_lists_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 	"github.com/matrix-org/complement/runtime"
@@ -117,7 +118,10 @@ func TestDeviceListUpdates(t *testing.T) {
 	) func(t *testing.T, nextBatch string) string {
 		t.Helper()
 
-		barry := deployment.RegisterUser(t, otherHSName, generateLocalpart("barry"), "password", false)
+		barry := deployment.Register(t, otherHSName, helpers.RegistrationOpts{
+			Localpart: generateLocalpart("barry"),
+			Password:  "password",
+		})
 
 		// The observing user must share a room with the dummy barrier user.
 		roomID := barry.MustCreateRoom(t, map[string]interface{}{"preset": "public_chat"})
@@ -142,8 +146,14 @@ func TestDeviceListUpdates(t *testing.T) {
 
 	// testOtherUserJoin tests another user joining a room Alice is already in.
 	testOtherUserJoin := func(t *testing.T, deployment complement.Deployment, hsName string, otherHSName string) {
-		alice := deployment.RegisterUser(t, hsName, generateLocalpart("alice"), "password", false)
-		bob := deployment.RegisterUser(t, otherHSName, generateLocalpart("bob"), "password", false)
+		alice := deployment.Register(t, hsName, helpers.RegistrationOpts{
+			Localpart: generateLocalpart("alice"),
+			Password:  "password",
+		})
+		bob := deployment.Register(t, otherHSName, helpers.RegistrationOpts{
+			Localpart: generateLocalpart("bob"),
+			Password:  "password",
+		})
 		barrier := makeBarrier(t, deployment, alice, otherHSName)
 		checkBobKeys := uploadNewKeys(t, bob)
 
@@ -189,8 +199,14 @@ func TestDeviceListUpdates(t *testing.T) {
 	testJoin := func(
 		t *testing.T, deployment complement.Deployment, hsName string, otherHSName string,
 	) {
-		alice := deployment.RegisterUser(t, hsName, generateLocalpart("alice"), "password", false)
-		bob := deployment.RegisterUser(t, otherHSName, generateLocalpart("bob"), "password", false)
+		alice := deployment.Register(t, hsName, helpers.RegistrationOpts{
+			Localpart: generateLocalpart("alice"),
+			Password:  "password",
+		})
+		bob := deployment.Register(t, otherHSName, helpers.RegistrationOpts{
+			Localpart: generateLocalpart("bob"),
+			Password:  "password",
+		})
 		barrier := makeBarrier(t, deployment, alice, otherHSName)
 		checkBobKeys := uploadNewKeys(t, bob)
 
@@ -234,8 +250,14 @@ func TestDeviceListUpdates(t *testing.T) {
 
 	// testOtherUserLeave tests another user leaving a room Alice is in.
 	testOtherUserLeave := func(t *testing.T, deployment complement.Deployment, hsName string, otherHSName string) {
-		alice := deployment.RegisterUser(t, hsName, generateLocalpart("alice"), "password", false)
-		bob := deployment.RegisterUser(t, otherHSName, generateLocalpart("bob"), "password", false)
+		alice := deployment.Register(t, hsName, helpers.RegistrationOpts{
+			Localpart: generateLocalpart("alice"),
+			Password:  "password",
+		})
+		bob := deployment.Register(t, otherHSName, helpers.RegistrationOpts{
+			Localpart: generateLocalpart("bob"),
+			Password:  "password",
+		})
 		barrier := makeBarrier(t, deployment, alice, otherHSName)
 		checkBobKeys := uploadNewKeys(t, bob)
 
@@ -285,8 +307,14 @@ func TestDeviceListUpdates(t *testing.T) {
 
 	// testLeave tests Alice leaving a room another user is in.
 	testLeave := func(t *testing.T, deployment complement.Deployment, hsName string, otherHSName string) {
-		alice := deployment.RegisterUser(t, hsName, generateLocalpart("alice"), "password", false)
-		bob := deployment.RegisterUser(t, otherHSName, generateLocalpart("bob"), "password", false)
+		alice := deployment.Register(t, hsName, helpers.RegistrationOpts{
+			Localpart: generateLocalpart("alice"),
+			Password:  "password",
+		})
+		bob := deployment.Register(t, otherHSName, helpers.RegistrationOpts{
+			Localpart: generateLocalpart("bob"),
+			Password:  "password",
+		})
 		barrier := makeBarrier(t, deployment, alice, otherHSName)
 		checkBobKeys := uploadNewKeys(t, bob)
 
@@ -336,8 +364,14 @@ func TestDeviceListUpdates(t *testing.T) {
 
 	// testOtherUserRejoin tests another user leaving and rejoining a room Alice is in.
 	testOtherUserRejoin := func(t *testing.T, deployment complement.Deployment, hsName string, otherHSName string) {
-		alice := deployment.RegisterUser(t, hsName, generateLocalpart("alice"), "password", false)
-		bob := deployment.RegisterUser(t, otherHSName, generateLocalpart("bob"), "password", false)
+		alice := deployment.Register(t, hsName, helpers.RegistrationOpts{
+			Localpart: generateLocalpart("alice"),
+			Password:  "password",
+		})
+		bob := deployment.Register(t, otherHSName, helpers.RegistrationOpts{
+			Localpart: generateLocalpart("bob"),
+			Password:  "password",
+		})
 		barrier := makeBarrier(t, deployment, alice, otherHSName)
 		checkBobKeys := uploadNewKeys(t, bob)
 

--- a/tests/csapi/ignored_users_test.go
+++ b/tests/csapi/ignored_users_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
@@ -30,9 +31,9 @@ import (
 func TestInviteFromIgnoredUsersDoesNotAppearInSync(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintCleanHS)
 	defer deployment.Destroy(t)
-	alice := deployment.RegisterUser(t, "hs1", "alice", "sufficiently_long_password_alice", false)
-	bob := deployment.RegisterUser(t, "hs1", "bob", "sufficiently_long_password_bob", false)
-	chris := deployment.RegisterUser(t, "hs1", "chris", "sufficiently_long_password_chris", false)
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{Localpart: "alice"})
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{Localpart: "bob"})
+	chris := deployment.Register(t, "hs1", helpers.RegistrationOpts{Localpart: "chris"})
 
 	// Alice creates a room for herself.
 	publicRoom := alice.MustCreateRoom(t, map[string]interface{}{

--- a/tests/csapi/keychanges_test.go
+++ b/tests/csapi/keychanges_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
@@ -21,7 +22,10 @@ func TestKeyChangesLocal(t *testing.T) {
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
 	password := "$uperSecretPassword"
-	bob := deployment.RegisterUser(t, "hs1", "bob", password, false)
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{
+		Localpart: "bob",
+		Password:  password,
+	})
 	unauthedClient := deployment.Client(t, "hs1", "")
 
 	t.Run("New login should create a device_lists.changed entry", func(t *testing.T) {

--- a/tests/csapi/room_leave_test.go
+++ b/tests/csapi/room_leave_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
@@ -20,7 +21,10 @@ func TestLeftRoomFixture(t *testing.T) {
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
 	bob := deployment.Client(t, "hs1", "@bob:hs1")
-	charlie := deployment.RegisterUser(t, "hs1", "charlie", "sufficiently_long_password_charlie", false)
+	charlie := deployment.Register(t, "hs1", helpers.RegistrationOpts{
+		Localpart: "charlie",
+		Password:  "sufficiently_long_password_charlie",
+	})
 
 	roomID := alice.MustCreateRoom(t, map[string]interface{}{
 		"initial_state": []map[string]interface{}{

--- a/tests/csapi/room_typing_test.go
+++ b/tests/csapi/room_typing_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 )
 
 // sytest: PUT /rooms/:room_id/typing/:user_id sets typing notification
@@ -42,7 +43,10 @@ func TestLeakyTyping(t *testing.T) {
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
 	bob := deployment.Client(t, "hs1", "@bob:hs1")
-	charlie := deployment.RegisterUser(t, "hs1", "charlie", "charliepassword", false)
+	charlie := deployment.Register(t, "hs1", helpers.RegistrationOpts{
+		Localpart: "charlie",
+		Password:  "charliepassword",
+	})
 
 	// Alice creates a room. Bob joins it.
 	roomID := alice.MustCreateRoom(t, map[string]interface{}{"preset": "public_chat"})

--- a/tests/csapi/rooms_members_local_test.go
+++ b/tests/csapi/rooms_members_local_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/runtime"
 )
 
@@ -16,7 +17,10 @@ func TestMembersLocal(t *testing.T) {
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
 	// Here we don't use the BlueprintOneToOneRoom because else Bob would be able to see Alice's presence changes through
 	// that pre-existing one-on-one DM room. So we exclude that here.
-	bob := deployment.RegisterUser(t, "hs1", "bob", "bobspassword", false)
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{
+		Localpart: "bob",
+		Password:  "bobspassword",
+	})
 	roomID := alice.MustCreateRoom(t, map[string]interface{}{"preset": "public_chat"})
 
 	bob.MustDo(

--- a/tests/csapi/rooms_state_test.go
+++ b/tests/csapi/rooms_state_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/must"
 )
 
@@ -21,7 +22,10 @@ func TestRoomCreationReportsEventsToMyself(t *testing.T) {
 
 	userID := "@alice:hs1"
 	alice := deployment.Client(t, "hs1", userID)
-	bob := deployment.RegisterUser(t, "hs1", "bob", "bobpassword", false)
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{
+		Localpart: "bob",
+		Password:  "bobpassword",
+	})
 	roomID := alice.MustCreateRoom(t, map[string]interface{}{})
 
 	t.Run("parallel", func(t *testing.T) {

--- a/tests/csapi/sync_test.go
+++ b/tests/csapi/sync_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/internal/federation"
 	"github.com/matrix-org/complement/runtime"
 )
@@ -381,7 +382,9 @@ func TestPresenceSyncDifferentRooms(t *testing.T) {
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
 	bob := deployment.Client(t, "hs1", "@bob:hs1")
 
-	charlie := deployment.NewUser(t, "charlie", "hs1")
+	charlie := deployment.Register(t, "hs1", helpers.RegistrationOpts{
+		Localpart: "charlie",
+	})
 
 	// Alice creates two rooms: one with her and Bob, and a second with her and Charlie.
 	bobRoomID := alice.MustCreateRoom(t, map[string]interface{}{})

--- a/tests/csapi/to_device_test.go
+++ b/tests/csapi/to_device_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 )
 
 // sytest: Can send a message directly to a device using PUT /sendToDevice
@@ -20,7 +21,10 @@ func TestToDeviceMessages(t *testing.T) {
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
 	bob := deployment.Client(t, "hs1", "@bob:hs1")
-	charlie := deployment.RegisterUser(t, "hs1", "charlie", "charliepassword", false)
+	charlie := deployment.Register(t, "hs1", helpers.RegistrationOpts{
+		Localpart: "charlie",
+		Password:  "charliepassword",
+	})
 
 	_, bobSince := bob.MustSync(t, client.SyncReq{TimeoutMillis: "0"})
 	_, charlieSince := charlie.MustSync(t, client.SyncReq{TimeoutMillis: "0"})

--- a/tests/csapi/txnid_test.go
+++ b/tests/csapi/txnid_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/must"
 	"github.com/matrix-org/complement/runtime"
 	"github.com/tidwall/gjson"
@@ -21,7 +22,10 @@ func TestTxnInEvent(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintCleanHS)
 	defer deployment.Destroy(t)
 
-	c := deployment.RegisterUser(t, "hs1", "alice", "password", false)
+	c := deployment.Register(t, "hs1", helpers.RegistrationOpts{
+		Localpart: "alice",
+		Password:  "password",
+	})
 
 	// Create a room where we can send events.
 	roomID := c.MustCreateRoom(t, map[string]interface{}{})
@@ -72,7 +76,10 @@ func TestTxnScopeOnLocalEcho(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintCleanHS)
 	defer deployment.Destroy(t)
 
-	deployment.RegisterUser(t, "hs1", "alice", "password", false)
+	deployment.Register(t, "hs1", helpers.RegistrationOpts{
+		Localpart: "alice",
+		Password:  "password",
+	})
 
 	// Create a first client, which allocates a device ID.
 	c1 := deployment.Client(t, "hs1", "")
@@ -111,7 +118,10 @@ func TestTxnIdempotencyScopedToDevice(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintCleanHS)
 	defer deployment.Destroy(t)
 
-	deployment.RegisterUser(t, "hs1", "alice", "password", false)
+	deployment.Register(t, "hs1", helpers.RegistrationOpts{
+		Localpart: "alice",
+		Password:  "password",
+	})
 
 	// Create a first client, which allocates a device ID.
 	c1 := deployment.Client(t, "hs1", "")
@@ -151,7 +161,10 @@ func TestTxnIdempotency(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintCleanHS)
 	defer deployment.Destroy(t)
 
-	deployment.RegisterUser(t, "hs1", "alice", "password", false)
+	deployment.Register(t, "hs1", helpers.RegistrationOpts{
+		Localpart: "alice",
+		Password:  "password",
+	})
 
 	// Create a first client, which allocates a device ID.
 	c1 := deployment.Client(t, "hs1", "")
@@ -206,7 +219,10 @@ func TestTxnIdWithRefreshToken(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintCleanHS)
 	defer deployment.Destroy(t)
 
-	deployment.RegisterUser(t, "hs1", "alice", "password", false)
+	deployment.Register(t, "hs1", helpers.RegistrationOpts{
+		Localpart: "alice",
+		Password:  "password",
+	})
 
 	c := deployment.Client(t, "hs1", "")
 

--- a/tests/csapi/user_directory_display_names_test.go
+++ b/tests/csapi/user_directory_display_names_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
@@ -45,8 +46,14 @@ func setupUsers(t *testing.T) (*client.CSAPI, *client.CSAPI, *client.CSAPI, func
 	}
 
 	alice := deployment.Client(t, "hs1", aliceUserID)
-	bob := deployment.RegisterUser(t, "hs1", "bob", "bob-has-a-very-secret-pw", false)
-	eve := deployment.RegisterUser(t, "hs1", "eve", "eve-has-a-very-secret-pw", false)
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{
+		Localpart: "bob",
+		Password:  "bob-has-a-very-secret-pw",
+	})
+	eve := deployment.Register(t, "hs1", helpers.RegistrationOpts{
+		Localpart: "eve",
+		Password:  "eve-has-a-very-secret-pw",
+	})
 
 	// Alice sets her profile displayname. This ensures that her
 	// public name, private name and userid localpart are all

--- a/tests/msc3890/msc3890_test.go
+++ b/tests/msc3890/msc3890_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 	"github.com/tidwall/gjson"
@@ -23,8 +24,13 @@ func TestDeletingDeviceRemovesDeviceLocalNotificationSettings(t *testing.T) {
 	t.Log("Alice registers on device 1 and logs in to device 2.")
 	aliceLocalpart := "alice"
 	alicePassword := "hunter2"
-	aliceDeviceOne := deployment.RegisterUser(t, "hs1", aliceLocalpart, alicePassword, false)
-	aliceDeviceTwo := deployment.LoginUser(t, "hs1", aliceLocalpart, alicePassword)
+	aliceDeviceOne := deployment.Register(t, "hs1", helpers.RegistrationOpts{
+		Localpart: aliceLocalpart,
+		Password:  alicePassword,
+	})
+	aliceDeviceTwo := deployment.Login(t, "hs1", aliceDeviceOne, helpers.LoginOpts{
+		Password: alicePassword,
+	})
 
 	accountDataType := "org.matrix.msc3890.local_notification_settings." + aliceDeviceTwo.DeviceID
 	accountDataContent := map[string]interface{}{"is_silenced": true}


### PR DESCRIPTION
Define just 2 functions which can be used universally. By having this as an interface, this also means we keep the door open for matrix-authentication-service to swap out the impl for one which registers with MAS.

The `Login` function requires an _existing_ CSAPI client to work. This is by design to force tests to not hardcode "login as localpart `alice`".

The `Register` function does not do this, and exposes a literal `Localpart` field to set. This will change to a prefix/suffix, but is more involved e.g a test may call `Register("chris")` then later on assert `@chris:hs1` is present somewhere, so all tests need to be sanity checked for this before swapping to prefixes/suffixes). Hence this will be up next in another PR.

