### PR TITLE
Replace Localpart with LocalpartSuffix 

### DIFF
--- a/helpers/clientopts.go
+++ b/helpers/clientopts.go
@@ -1,10 +1,10 @@
 package helpers
 
 type RegistrationOpts struct {
-	Localpart string // default '' (don't care)
-	DeviceID  string // default '' (generate new)
-	Password  string // default 'complement_meets_min_password_requirement'
-	IsAdmin   bool   // default false
+	LocalpartSuffix string // default '' (don't care)
+	DeviceID        string // default '' (generate new)
+	Password        string // default 'complement_meets_min_password_requirement'
+	IsAdmin         bool   // default false
 }
 
 type LoginOpts struct {

--- a/internal/docker/deployment.go
+++ b/internal/docker/deployment.go
@@ -85,10 +85,7 @@ func (d *Deployment) Register(t *testing.T, hsName string, opts helpers.Registra
 	if password == "" {
 		password = "complement_meets_min_password_req"
 	}
-	localpart := opts.Localpart
-	if localpart == "" {
-		localpart = fmt.Sprintf("user-%v", d.localpartCounter.Add(1))
-	}
+	localpart := fmt.Sprintf("user-%v-%v", d.localpartCounter.Add(1), opts.LocalpartSuffix)
 	var userID, accessToken, deviceID string
 	if opts.IsAdmin {
 		userID, accessToken, deviceID = client.RegisterSharedSecret(t, localpart, password, opts.IsAdmin)

--- a/tests/csapi/account_change_password_pushers_test.go
+++ b/tests/csapi/account_change_password_pushers_test.go
@@ -22,8 +22,7 @@ func TestChangePasswordPushers(t *testing.T) {
 	password1 := "superuser"
 	password2 := "my_new_password"
 	passwordClient := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-		Localpart: "test_change_password_pusher_user",
-		Password:  password1,
+		Password: password1,
 	})
 
 	// sytest: Pushers created with a different access token are deleted on password change

--- a/tests/csapi/account_change_password_test.go
+++ b/tests/csapi/account_change_password_test.go
@@ -1,7 +1,7 @@
 package csapi_tests
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/matrix-org/complement"
@@ -20,11 +20,10 @@ func TestChangePassword(t *testing.T) {
 	password1 := "superuser"
 	password2 := "my_new_password"
 	passwordClient := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-		Localpart: "test_change_password_user",
-		Password:  password1,
+		Password: password1,
 	})
 	unauthedClient := deployment.Client(t, "hs1", "")
-	_, sessionTest := createSession(t, deployment, "test_change_password_user", "superuser")
+	_, sessionTest := createSession(t, deployment, passwordClient.UserID, "superuser")
 	// sytest: After changing password, can't log in with old password
 	t.Run("After changing password, can't log in with old password", func(t *testing.T) {
 
@@ -82,7 +81,7 @@ func TestChangePassword(t *testing.T) {
 
 	// sytest: After changing password, different sessions can optionally be kept
 	t.Run("After changing password, different sessions can optionally be kept", func(t *testing.T) {
-		_, sessionOptional := createSession(t, deployment, "test_change_password_user", password2)
+		_, sessionOptional := createSession(t, deployment, passwordClient.UserID, password2)
 		reqBody := client.WithJSONBody(t, map[string]interface{}{
 			"auth": map[string]interface{}{
 				"type":     "m.login.password",
@@ -135,7 +134,7 @@ func createSession(t *testing.T, deployment complement.Deployment, userID, passw
 		"password": password,
 	})
 	res := authedClient.Do(t, "POST", []string{"_matrix", "client", "v3", "login"}, reqBody)
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		t.Fatalf("unable to read response body: %v", err)
 	}

--- a/tests/csapi/account_deactivate_test.go
+++ b/tests/csapi/account_deactivate_test.go
@@ -19,8 +19,7 @@ func TestDeactivateAccount(t *testing.T) {
 	defer deployment.Destroy(t)
 	password := "superuser"
 	authedClient := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-		Localpart: "test_deactivate_user",
-		Password:  password,
+		Password: password,
 	})
 	unauthedClient := deployment.Client(t, "hs1", "")
 

--- a/tests/csapi/admin_test.go
+++ b/tests/csapi/admin_test.go
@@ -21,9 +21,7 @@ func TestCanRegisterAdmin(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 	deployment.Register(t, "hs1", helpers.RegistrationOpts{
-		Localpart: "admin",
-		Password:  "adminpassword",
-		IsAdmin:   true,
+		IsAdmin: true,
 	})
 }
 
@@ -32,9 +30,7 @@ func TestServerNotices(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 	admin := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-		Localpart: "admin",
-		Password:  "adminpassword",
-		IsAdmin:   true,
+		IsAdmin: true,
 	})
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
 

--- a/tests/csapi/apidoc_device_management_test.go
+++ b/tests/csapi/apidoc_device_management_test.go
@@ -18,8 +18,7 @@ func TestDeviceManagement(t *testing.T) {
 	defer deployment.Destroy(t)
 	unauthedClient := deployment.Client(t, "hs1", "")
 	authedClient := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-		Localpart: "test_device_management_user",
-		Password:  "superuser",
+		Password: "superuser",
 	})
 
 	// sytest: GET /device/{deviceId}
@@ -199,8 +198,8 @@ func TestDeviceManagement(t *testing.T) {
 	// sytest: DELETE /device/{deviceId} requires UI auth user to match device owner
 	t.Run("DELETE /device/{deviceId} requires UI auth user to match device owner", func(t *testing.T) {
 		bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "bob",
-			Password:  "bobspassword",
+			LocalpartSuffix: "bob",
+			Password:        "bobspassword",
 		})
 
 		newDeviceID, session2 := createSession(t, deployment, authedClient.UserID, "superuser")

--- a/tests/csapi/apidoc_login_test.go
+++ b/tests/csapi/apidoc_login_test.go
@@ -108,7 +108,7 @@ func TestLogin(t *testing.T) {
 		// sytest: POST /login as non-existing user is rejected
 		t.Run("POST /login as non-existing user is rejected", func(t *testing.T) {
 			t.Parallel()
-			res := unauthedClient.MustDo(t, "POST", []string{"_matrix", "client", "v3", "login"}, client.WithJSONBody(t, map[string]interface{}{
+			res := unauthedClient.Do(t, "POST", []string{"_matrix", "client", "v3", "login"}, client.WithJSONBody(t, map[string]interface{}{
 				"type": "m.login.password",
 				"identifier": map[string]interface{}{
 					"type": "m.id.user",
@@ -123,7 +123,7 @@ func TestLogin(t *testing.T) {
 		// sytest: POST /login wrong password is rejected
 		t.Run("POST /login wrong password is rejected", func(t *testing.T) {
 			t.Parallel()
-			res := unauthedClient.MustDo(t, "POST", []string{"_matrix", "client", "v3", "login"}, client.WithJSONBody(t, map[string]interface{}{
+			res := unauthedClient.Do(t, "POST", []string{"_matrix", "client", "v3", "login"}, client.WithJSONBody(t, map[string]interface{}{
 				"type": "m.login.password",
 				"identifier": map[string]interface{}{
 					"type": "m.id.user",

--- a/tests/csapi/apidoc_login_test.go
+++ b/tests/csapi/apidoc_login_test.go
@@ -3,6 +3,7 @@ package csapi_tests
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/tidwall/gjson"
@@ -13,15 +14,15 @@ import (
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
+	"github.com/matrix-org/gomatrixserverlib"
 )
 
 func TestLogin(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 	unauthedClient := deployment.Client(t, "hs1", "")
-	deployment.Register(t, "hs1", helpers.RegistrationOpts{
-		Localpart: "test_login_user",
-		Password:  "superuser",
+	testClient := deployment.Register(t, "hs1", helpers.RegistrationOpts{
+		Password: "superuser",
 	})
 	t.Run("parallel", func(t *testing.T) {
 		// sytest: GET /login yields a set of flows
@@ -48,14 +49,14 @@ func TestLogin(t *testing.T) {
 		// sytest: POST /login can log in as a user
 		t.Run("POST /login can login as user", func(t *testing.T) {
 			t.Parallel()
-			res := unauthedClient.MustDo(t, "POST", []string{"_matrix", "client", "v3", "login"}, client.WithRawBody(json.RawMessage(`{
+			res := unauthedClient.MustDo(t, "POST", []string{"_matrix", "client", "v3", "login"}, client.WithJSONBody(t, map[string]interface{}{
 				"type": "m.login.password",
-				"identifier": {
+				"identifier": map[string]interface{}{
 					"type": "m.id.user",
-					"user": "@test_login_user:hs1"
+					"user": testClient.UserID,
 				},
-				"password": "superuser"
-			}`)))
+				"password": "superuser",
+			}))
 
 			must.MatchResponse(t, res, match.HTTPResponse{
 				JSON: []match.JSON{
@@ -67,15 +68,15 @@ func TestLogin(t *testing.T) {
 		t.Run("POST /login returns the same device_id as that in the request", func(t *testing.T) {
 			t.Parallel()
 			deviceID := "test_device_id"
-			res := unauthedClient.MustDo(t, "POST", []string{"_matrix", "client", "v3", "login"}, client.WithRawBody(json.RawMessage(`{
+			res := unauthedClient.MustDo(t, "POST", []string{"_matrix", "client", "v3", "login"}, client.WithJSONBody(t, map[string]interface{}{
 				"type": "m.login.password",
-				"identifier": {
+				"identifier": map[string]interface{}{
 					"type": "m.id.user",
-					"user": "@test_login_user:hs1"
+					"user": testClient.UserID,
 				},
-				"password": "superuser",
-				"device_id": "`+deviceID+`"
-			}`)))
+				"password":  "superuser",
+				"device_id": deviceID,
+			}))
 
 			must.MatchResponse(t, res, match.HTTPResponse{
 				JSON: []match.JSON{
@@ -87,15 +88,16 @@ func TestLogin(t *testing.T) {
 		// sytest: POST /login can log in as a user with just the local part of the id
 		t.Run("POST /login can log in as a user with just the local part of the id", func(t *testing.T) {
 			t.Parallel()
-
-			res := unauthedClient.MustDo(t, "POST", []string{"_matrix", "client", "v3", "login"}, client.WithRawBody(json.RawMessage(`{
+			localpart, _, err := gomatrixserverlib.SplitID('@', testClient.UserID)
+			must.NotError(t, "failed to get localpart from user ID", err)
+			res := unauthedClient.MustDo(t, "POST", []string{"_matrix", "client", "v3", "login"}, client.WithJSONBody(t, map[string]interface{}{
 				"type": "m.login.password",
-				"identifier": {
+				"identifier": map[string]interface{}{
 					"type": "m.id.user",
-					"user": "test_login_user"
+					"user": localpart,
 				},
-				"password": "superuser"
-			}`)))
+				"password": "superuser",
+			}))
 
 			must.MatchResponse(t, res, match.HTTPResponse{
 				JSON: []match.JSON{
@@ -106,14 +108,14 @@ func TestLogin(t *testing.T) {
 		// sytest: POST /login as non-existing user is rejected
 		t.Run("POST /login as non-existing user is rejected", func(t *testing.T) {
 			t.Parallel()
-			res := unauthedClient.Do(t, "POST", []string{"_matrix", "client", "v3", "login"}, client.WithRawBody(json.RawMessage(`{
+			res := unauthedClient.MustDo(t, "POST", []string{"_matrix", "client", "v3", "login"}, client.WithJSONBody(t, map[string]interface{}{
 				"type": "m.login.password",
-				"identifier": {
+				"identifier": map[string]interface{}{
 					"type": "m.id.user",
-					"user": "i-dont-exist"
+					"user": "i-dont-exist",
 				},
-				"password": "superuser"
-			}`)))
+				"password": "superuser",
+			}))
 			must.MatchResponse(t, res, match.HTTPResponse{
 				StatusCode: 403,
 			})
@@ -121,14 +123,14 @@ func TestLogin(t *testing.T) {
 		// sytest: POST /login wrong password is rejected
 		t.Run("POST /login wrong password is rejected", func(t *testing.T) {
 			t.Parallel()
-			res := unauthedClient.Do(t, "POST", []string{"_matrix", "client", "v3", "login"}, client.WithRawBody(json.RawMessage(`{
+			res := unauthedClient.MustDo(t, "POST", []string{"_matrix", "client", "v3", "login"}, client.WithJSONBody(t, map[string]interface{}{
 				"type": "m.login.password",
-				"identifier": {
+				"identifier": map[string]interface{}{
 					"type": "m.id.user",
-					"user": "@test_login_user:hs1"
+					"user": testClient.UserID,
 				},
-				"password": "wrong_password"
-			}`)))
+				"password": "wrong_password",
+			}))
 			must.MatchResponse(t, res, match.HTTPResponse{
 				StatusCode: 403,
 				JSON: []match.JSON{
@@ -141,14 +143,17 @@ func TestLogin(t *testing.T) {
 		t.Run("Login with uppercase username works and GET /whoami afterwards also", func(t *testing.T) {
 			t.Parallel()
 			// login should be possible with uppercase username
-			res := unauthedClient.MustDo(t, "POST", []string{"_matrix", "client", "v3", "login"}, client.WithRawBody(json.RawMessage(`{
+			localpart, domain, err := gomatrixserverlib.SplitID('@', testClient.UserID)
+			must.NotError(t, "failed to get localpart from user ID", err)
+
+			res := unauthedClient.MustDo(t, "POST", []string{"_matrix", "client", "v3", "login"}, client.WithJSONBody(t, map[string]interface{}{
 				"type": "m.login.password",
-				"identifier": {
+				"identifier": map[string]interface{}{
 					"type": "m.id.user",
-					"user": "@Test_login_user:hs1"
+					"user": fmt.Sprintf("@%s:%s", strings.ToUpper(localpart), domain),
 				},
-				"password": "superuser"
-			}`)))
+				"password": "superuser",
+			}))
 			// extract access_token
 			js := must.ParseJSON(t, res.Body)
 			defer res.Body.Close()

--- a/tests/csapi/apidoc_logout_test.go
+++ b/tests/csapi/apidoc_logout_test.go
@@ -20,8 +20,7 @@ func TestLogout(t *testing.T) {
 
 	password := "superuser"
 	verifyClientUser := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-		Localpart: "testuser",
-		Password:  password,
+		Password: password,
 	})
 
 	// sytest: Can logout current device

--- a/tests/csapi/device_lists_test.go
+++ b/tests/csapi/device_lists_test.go
@@ -2,7 +2,6 @@ package csapi_tests
 
 import (
 	"fmt"
-	"sync/atomic"
 	"testing"
 
 	"github.com/matrix-org/complement"
@@ -21,13 +20,6 @@ import (
 //  1. `/sync`'s `device_lists.changed/left` contain the correct user IDs.
 //  2. `/keys/query` returns the correct information after device list updates.
 func TestDeviceListUpdates(t *testing.T) {
-	var localpartIndex int64 = 0
-	// generateLocalpart generates a unique localpart based on the given name.
-	generateLocalpart := func(localpart string) string {
-		index := atomic.AddInt64(&localpartIndex, 1)
-		return fmt.Sprintf("%s%d", localpart, index)
-	}
-
 	// uploadNewKeys uploads a new set of keys for a given client.
 	// Returns a check function that can be passed to mustQueryKeys.
 	uploadNewKeys := func(t *testing.T, user *client.CSAPI) []match.JSON {
@@ -119,8 +111,8 @@ func TestDeviceListUpdates(t *testing.T) {
 		t.Helper()
 
 		barry := deployment.Register(t, otherHSName, helpers.RegistrationOpts{
-			Localpart: generateLocalpart("barry"),
-			Password:  "password",
+			LocalpartSuffix: "barry",
+			Password:        "password",
 		})
 
 		// The observing user must share a room with the dummy barrier user.
@@ -147,12 +139,12 @@ func TestDeviceListUpdates(t *testing.T) {
 	// testOtherUserJoin tests another user joining a room Alice is already in.
 	testOtherUserJoin := func(t *testing.T, deployment complement.Deployment, hsName string, otherHSName string) {
 		alice := deployment.Register(t, hsName, helpers.RegistrationOpts{
-			Localpart: generateLocalpart("alice"),
-			Password:  "password",
+			LocalpartSuffix: "alice",
+			Password:        "password",
 		})
 		bob := deployment.Register(t, otherHSName, helpers.RegistrationOpts{
-			Localpart: generateLocalpart("bob"),
-			Password:  "password",
+			LocalpartSuffix: "bob",
+			Password:        "password",
 		})
 		barrier := makeBarrier(t, deployment, alice, otherHSName)
 		checkBobKeys := uploadNewKeys(t, bob)
@@ -200,12 +192,12 @@ func TestDeviceListUpdates(t *testing.T) {
 		t *testing.T, deployment complement.Deployment, hsName string, otherHSName string,
 	) {
 		alice := deployment.Register(t, hsName, helpers.RegistrationOpts{
-			Localpart: generateLocalpart("alice"),
-			Password:  "password",
+			LocalpartSuffix: "alice",
+			Password:        "password",
 		})
 		bob := deployment.Register(t, otherHSName, helpers.RegistrationOpts{
-			Localpart: generateLocalpart("bob"),
-			Password:  "password",
+			LocalpartSuffix: "bob",
+			Password:        "password",
 		})
 		barrier := makeBarrier(t, deployment, alice, otherHSName)
 		checkBobKeys := uploadNewKeys(t, bob)
@@ -251,12 +243,12 @@ func TestDeviceListUpdates(t *testing.T) {
 	// testOtherUserLeave tests another user leaving a room Alice is in.
 	testOtherUserLeave := func(t *testing.T, deployment complement.Deployment, hsName string, otherHSName string) {
 		alice := deployment.Register(t, hsName, helpers.RegistrationOpts{
-			Localpart: generateLocalpart("alice"),
-			Password:  "password",
+			LocalpartSuffix: "alice",
+			Password:        "password",
 		})
 		bob := deployment.Register(t, otherHSName, helpers.RegistrationOpts{
-			Localpart: generateLocalpart("bob"),
-			Password:  "password",
+			LocalpartSuffix: "bob",
+			Password:        "password",
 		})
 		barrier := makeBarrier(t, deployment, alice, otherHSName)
 		checkBobKeys := uploadNewKeys(t, bob)
@@ -308,12 +300,12 @@ func TestDeviceListUpdates(t *testing.T) {
 	// testLeave tests Alice leaving a room another user is in.
 	testLeave := func(t *testing.T, deployment complement.Deployment, hsName string, otherHSName string) {
 		alice := deployment.Register(t, hsName, helpers.RegistrationOpts{
-			Localpart: generateLocalpart("alice"),
-			Password:  "password",
+			LocalpartSuffix: "alice",
+			Password:        "password",
 		})
 		bob := deployment.Register(t, otherHSName, helpers.RegistrationOpts{
-			Localpart: generateLocalpart("bob"),
-			Password:  "password",
+			LocalpartSuffix: "bob",
+			Password:        "password",
 		})
 		barrier := makeBarrier(t, deployment, alice, otherHSName)
 		checkBobKeys := uploadNewKeys(t, bob)
@@ -365,12 +357,12 @@ func TestDeviceListUpdates(t *testing.T) {
 	// testOtherUserRejoin tests another user leaving and rejoining a room Alice is in.
 	testOtherUserRejoin := func(t *testing.T, deployment complement.Deployment, hsName string, otherHSName string) {
 		alice := deployment.Register(t, hsName, helpers.RegistrationOpts{
-			Localpart: generateLocalpart("alice"),
-			Password:  "password",
+			LocalpartSuffix: "alice",
+			Password:        "password",
 		})
 		bob := deployment.Register(t, otherHSName, helpers.RegistrationOpts{
-			Localpart: generateLocalpart("bob"),
-			Password:  "password",
+			LocalpartSuffix: "bob",
+			Password:        "password",
 		})
 		barrier := makeBarrier(t, deployment, alice, otherHSName)
 		checkBobKeys := uploadNewKeys(t, bob)

--- a/tests/csapi/ignored_users_test.go
+++ b/tests/csapi/ignored_users_test.go
@@ -31,9 +31,9 @@ import (
 func TestInviteFromIgnoredUsersDoesNotAppearInSync(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintCleanHS)
 	defer deployment.Destroy(t)
-	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{Localpart: "alice"})
-	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{Localpart: "bob"})
-	chris := deployment.Register(t, "hs1", helpers.RegistrationOpts{Localpart: "chris"})
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{LocalpartSuffix: "alice"})
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{LocalpartSuffix: "bob"})
+	chris := deployment.Register(t, "hs1", helpers.RegistrationOpts{LocalpartSuffix: "chris"})
 
 	// Alice creates a room for herself.
 	publicRoom := alice.MustCreateRoom(t, map[string]interface{}{

--- a/tests/csapi/keychanges_test.go
+++ b/tests/csapi/keychanges_test.go
@@ -23,8 +23,8 @@ func TestKeyChangesLocal(t *testing.T) {
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
 	password := "$uperSecretPassword"
 	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-		Localpart: "bob",
-		Password:  password,
+		LocalpartSuffix: "bob",
+		Password:        password,
 	})
 	unauthedClient := deployment.Client(t, "hs1", "")
 

--- a/tests/csapi/room_leave_test.go
+++ b/tests/csapi/room_leave_test.go
@@ -22,8 +22,8 @@ func TestLeftRoomFixture(t *testing.T) {
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
 	bob := deployment.Client(t, "hs1", "@bob:hs1")
 	charlie := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-		Localpart: "charlie",
-		Password:  "sufficiently_long_password_charlie",
+		LocalpartSuffix: "charlie",
+		Password:        "sufficiently_long_password_charlie",
 	})
 
 	roomID := alice.MustCreateRoom(t, map[string]interface{}{

--- a/tests/csapi/room_typing_test.go
+++ b/tests/csapi/room_typing_test.go
@@ -44,8 +44,8 @@ func TestLeakyTyping(t *testing.T) {
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
 	bob := deployment.Client(t, "hs1", "@bob:hs1")
 	charlie := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-		Localpart: "charlie",
-		Password:  "charliepassword",
+		LocalpartSuffix: "charlie",
+		Password:        "charliepassword",
 	})
 
 	// Alice creates a room. Bob joins it.

--- a/tests/csapi/rooms_members_local_test.go
+++ b/tests/csapi/rooms_members_local_test.go
@@ -18,8 +18,8 @@ func TestMembersLocal(t *testing.T) {
 	// Here we don't use the BlueprintOneToOneRoom because else Bob would be able to see Alice's presence changes through
 	// that pre-existing one-on-one DM room. So we exclude that here.
 	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-		Localpart: "bob",
-		Password:  "bobspassword",
+		LocalpartSuffix: "bob",
+		Password:        "bobspassword",
 	})
 	roomID := alice.MustCreateRoom(t, map[string]interface{}{"preset": "public_chat"})
 

--- a/tests/csapi/rooms_state_test.go
+++ b/tests/csapi/rooms_state_test.go
@@ -23,8 +23,8 @@ func TestRoomCreationReportsEventsToMyself(t *testing.T) {
 	userID := "@alice:hs1"
 	alice := deployment.Client(t, "hs1", userID)
 	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-		Localpart: "bob",
-		Password:  "bobpassword",
+		LocalpartSuffix: "bob",
+		Password:        "bobpassword",
 	})
 	roomID := alice.MustCreateRoom(t, map[string]interface{}{})
 

--- a/tests/csapi/sync_test.go
+++ b/tests/csapi/sync_test.go
@@ -383,7 +383,7 @@ func TestPresenceSyncDifferentRooms(t *testing.T) {
 	bob := deployment.Client(t, "hs1", "@bob:hs1")
 
 	charlie := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-		Localpart: "charlie",
+		LocalpartSuffix: "charlie",
 	})
 
 	// Alice creates two rooms: one with her and Bob, and a second with her and Charlie.
@@ -407,7 +407,7 @@ func TestPresenceSyncDifferentRooms(t *testing.T) {
 		"presence": "online",
 	})
 	bob.Do(t, "PUT", []string{"_matrix", "client", "v3", "presence", "@bob:hs1", "status"}, reqBody)
-	charlie.Do(t, "PUT", []string{"_matrix", "client", "v3", "presence", "@charlie:hs1", "status"}, reqBody)
+	charlie.Do(t, "PUT", []string{"_matrix", "client", "v3", "presence", charlie.UserID, "status"}, reqBody)
 
 	// Alice should see that Bob and Charlie are online. She may see this happen
 	// simultaneously in one /sync response, or separately in two /sync

--- a/tests/csapi/to_device_test.go
+++ b/tests/csapi/to_device_test.go
@@ -22,8 +22,8 @@ func TestToDeviceMessages(t *testing.T) {
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
 	bob := deployment.Client(t, "hs1", "@bob:hs1")
 	charlie := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-		Localpart: "charlie",
-		Password:  "charliepassword",
+		LocalpartSuffix: "charlie",
+		Password:        "charliepassword",
 	})
 
 	_, bobSince := bob.MustSync(t, client.SyncReq{TimeoutMillis: "0"})

--- a/tests/csapi/txnid_test.go
+++ b/tests/csapi/txnid_test.go
@@ -104,7 +104,7 @@ func TestTxnScopeOnLocalEcho(t *testing.T) {
 
 	// Create a second client, inheriting the first device ID.
 	c2 := deployment.Client(t, "hs1", "")
-	c2.UserID, c2.AccessToken, c2.DeviceID = c2.LoginUser(t, "alice", "password", client.WithDeviceID(c1.DeviceID))
+	c2.UserID, c2.AccessToken, c2.DeviceID = c2.LoginUser(t, alice.UserID, "password", client.WithDeviceID(c1.DeviceID))
 	must.Equal(t, c1.DeviceID, c2.DeviceID, "Device ID should be the same")
 
 	// When syncing, we should find the event and it should have the same transaction ID on the second client.
@@ -144,7 +144,7 @@ func TestTxnIdempotencyScopedToDevice(t *testing.T) {
 
 	// Create a second client, inheriting the first device ID.
 	c2 := deployment.Client(t, "hs1", "")
-	c2.UserID, c2.AccessToken, c2.DeviceID = c2.LoginUser(t, "alice", "password", client.WithDeviceID(c1.DeviceID))
+	c2.UserID, c2.AccessToken, c2.DeviceID = c2.LoginUser(t, alice.UserID, "password", client.WithDeviceID(c1.DeviceID))
 	must.Equal(t, c1.DeviceID, c2.DeviceID, "Device ID should be the same")
 
 	// send another event with the same txnId via the second client

--- a/tests/csapi/user_directory_display_names_test.go
+++ b/tests/csapi/user_directory_display_names_test.go
@@ -47,12 +47,10 @@ func setupUsers(t *testing.T) (*client.CSAPI, *client.CSAPI, *client.CSAPI, func
 
 	alice := deployment.Client(t, "hs1", aliceUserID)
 	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-		Localpart: "bob",
-		Password:  "bob-has-a-very-secret-pw",
+		LocalpartSuffix: "bob",
 	})
 	eve := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-		Localpart: "eve",
-		Password:  "eve-has-a-very-secret-pw",
+		LocalpartSuffix: "eve",
 	})
 
 	// Alice sets her profile displayname. This ensures that her

--- a/tests/msc3890/msc3890_test.go
+++ b/tests/msc3890/msc3890_test.go
@@ -25,8 +25,8 @@ func TestDeletingDeviceRemovesDeviceLocalNotificationSettings(t *testing.T) {
 	aliceLocalpart := "alice"
 	alicePassword := "hunter2"
 	aliceDeviceOne := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-		Localpart: aliceLocalpart,
-		Password:  alicePassword,
+		LocalpartSuffix: aliceLocalpart,
+		Password:        alicePassword,
 	})
 	aliceDeviceTwo := deployment.Login(t, "hs1", aliceDeviceOne, helpers.LoginOpts{
 		Password: alicePassword,

--- a/tests/msc3902/federation_room_join_partial_state_test.go
+++ b/tests/msc3902/federation_room_join_partial_state_test.go
@@ -246,7 +246,7 @@ func TestPartialStateJoin(t *testing.T) {
 
 	eagerSyncDuringPartialStateJoinTest := func(t *testing.T, usernameSuffix string, incremental bool) {
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t1alice_" + usernameSuffix,
+			LocalpartSuffix: "t1alice_" + usernameSuffix,
 		})
 
 		// Maintain two sync tokens: once for the eager syncs under test, and another
@@ -376,7 +376,7 @@ func TestPartialStateJoin(t *testing.T) {
 	// resync completes. This test does exactly that.
 	t.Run("EagerLongPollingSyncWokenWhenResyncCompletes", func(t *testing.T) {
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t1alice_long_polling",
+			LocalpartSuffix: "t1alice_long_polling",
 		})
 
 		t.Log("Alice partial-joins a remote room.")
@@ -441,7 +441,7 @@ func TestPartialStateJoin(t *testing.T) {
 	// when Alice does a lazy-loading sync, she should see the room immediately
 	t.Run("CanLazyLoadingSyncDuringPartialStateJoin", func(t *testing.T) {
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t2alice",
+			LocalpartSuffix: "t2alice",
 		})
 
 		server := createTestServer(t, deployment)
@@ -463,7 +463,7 @@ func TestPartialStateJoin(t *testing.T) {
 	// we should be able to send events in the room, during the resync
 	t.Run("CanSendEventsDuringPartialStateJoin", func(t *testing.T) {
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t3alice",
+			LocalpartSuffix: "t3alice",
 		})
 
 		server := createTestServer(t, deployment)
@@ -805,7 +805,7 @@ func TestPartialStateJoin(t *testing.T) {
 	// we should be able to receive events over federation during the resync
 	t.Run("CanReceiveEventsDuringPartialStateJoin", func(t *testing.T) {
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t4alice",
+			LocalpartSuffix: "t4alice",
 		})
 		syncToken := getSyncToken(t, alice)
 
@@ -829,7 +829,7 @@ func TestPartialStateJoin(t *testing.T) {
 	// we should be able to receive events with a missing prev event over federation during the resync
 	t.Run("CanReceiveEventsWithMissingParentsDuringPartialStateJoin", func(t *testing.T) {
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t5alice",
+			LocalpartSuffix: "t5alice",
 		})
 		syncToken := getSyncToken(t, alice)
 
@@ -869,7 +869,7 @@ func TestPartialStateJoin(t *testing.T) {
 	// we should be able to receive events with partially missing prev events over federation during the resync
 	t.Run("CanReceiveEventsWithHalfMissingParentsDuringPartialStateJoin", func(t *testing.T) {
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t6alice",
+			LocalpartSuffix: "t6alice",
 		})
 		syncToken := getSyncToken(t, alice)
 
@@ -912,7 +912,7 @@ func TestPartialStateJoin(t *testing.T) {
 	// over federation during the resync
 	t.Run("CanReceiveEventsWithHalfMissingGrandparentsDuringPartialStateJoin", func(t *testing.T) {
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t7alice",
+			LocalpartSuffix: "t7alice",
 		})
 		syncToken := getSyncToken(t, alice)
 
@@ -959,7 +959,7 @@ func TestPartialStateJoin(t *testing.T) {
 	// partial room state.
 	t.Run("Lazy-loading initial sync includes remote memberships during partial state join", func(t *testing.T) {
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t8alice",
+			LocalpartSuffix: "t8alice",
 		})
 
 		server := createTestServer(t, deployment)
@@ -1000,7 +1000,7 @@ func TestPartialStateJoin(t *testing.T) {
 	// partial room state.
 	t.Run("Lazy-loading gappy sync includes remote memberships during partial state join", func(t *testing.T) {
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t9alice",
+			LocalpartSuffix: "t9alice",
 		})
 		syncToken := getSyncToken(t, alice)
 
@@ -1072,7 +1072,7 @@ func TestPartialStateJoin(t *testing.T) {
 	// the partial room state.
 	t.Run("Lazy-loading incremental sync includes remote memberships during partial state join", func(t *testing.T) {
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t10alice",
+			LocalpartSuffix: "t10alice",
 		})
 		syncToken := getSyncToken(t, alice)
 
@@ -1122,7 +1122,7 @@ func TestPartialStateJoin(t *testing.T) {
 	// TODO(faster_joins): also need to test /state, and /members without an `at`, which follow a different path
 	t.Run("MembersRequestBlocksDuringPartialStateJoin", func(t *testing.T) {
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t11alice",
+			LocalpartSuffix: "t11alice",
 		})
 
 		server := createTestServer(t, deployment)
@@ -1184,7 +1184,7 @@ func TestPartialStateJoin(t *testing.T) {
 	// eager-syncing, and doesn't send a message to the partial-state room.)
 	t.Run("PartialStateJoinContinuesAfterRestart", func(t *testing.T) {
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t12alice",
+			LocalpartSuffix: "t12alice",
 		})
 
 		server := createTestServer(t, deployment)
@@ -1311,7 +1311,7 @@ func TestPartialStateJoin(t *testing.T) {
 	// since it was not sent on the previous sync.
 	t.Run("GappySyncAfterPartialStateSynced", func(t *testing.T) {
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t13alice",
+			LocalpartSuffix: "t13alice",
 		})
 
 		server := createTestServer(t, deployment)
@@ -1407,7 +1407,7 @@ func TestPartialStateJoin(t *testing.T) {
 	// an infinite loop of de-partial-stating.
 	t.Run("Resync completes even when events arrive before their prev_events", func(t *testing.T) {
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t14alice",
+			LocalpartSuffix: "t14alice",
 		})
 		syncToken := getSyncToken(t, alice)
 
@@ -1521,7 +1521,7 @@ func TestPartialStateJoin(t *testing.T) {
 	// do not suddenly become un-rejected during the resync
 	t.Run("Rejected events remain rejected after resync", func(t *testing.T) {
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t15alice",
+			LocalpartSuffix: "t15alice",
 		})
 		syncToken := getSyncToken(t, alice)
 
@@ -1592,7 +1592,7 @@ func TestPartialStateJoin(t *testing.T) {
 
 	t.Run("State accepted incorrectly", func(t *testing.T) {
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t16alice",
+			LocalpartSuffix: "t16alice",
 		})
 		syncToken := getSyncToken(t, alice)
 		server := createTestServer(t, deployment)
@@ -1672,7 +1672,7 @@ func TestPartialStateJoin(t *testing.T) {
 
 	t.Run("State rejected incorrectly", func(t *testing.T) {
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t17alice",
+			LocalpartSuffix: "t17alice",
 		})
 		syncToken := getSyncToken(t, alice)
 		server := createTestServer(t, deployment)
@@ -1799,7 +1799,7 @@ func TestPartialStateJoin(t *testing.T) {
 		//   testServer2 (another Complement test server) with @charlie:<server name>
 		//     This is the server that will try to make a join via testServer1.
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t18alice",
+			LocalpartSuffix: "t18alice",
 		})
 
 		testServer1 := createTestServer(t, deployment)
@@ -1850,7 +1850,7 @@ func TestPartialStateJoin(t *testing.T) {
 		//     of being able to build a request to /send_join)
 		//
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t19alice",
+			LocalpartSuffix: "t19alice",
 		})
 
 		testServer1 := createTestServer(t, deployment)
@@ -1910,7 +1910,7 @@ func TestPartialStateJoin(t *testing.T) {
 	// request blocks until the state is correctly synced.
 	t.Run("joined_members blocks during partial state join", func(t *testing.T) {
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t20alice",
+			LocalpartSuffix: "t20alice",
 		})
 
 		server := createTestServer(t, deployment)
@@ -1977,7 +1977,7 @@ func TestPartialStateJoin(t *testing.T) {
 		//   testServer2 (another Complement test server) with @charlie:<server name>
 		//     This is the server that will try to make a knock via testServer1.
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t21alice",
+			LocalpartSuffix: "t21alice",
 		})
 
 		testServer1 := createTestServer(t, deployment)
@@ -2028,7 +2028,7 @@ func TestPartialStateJoin(t *testing.T) {
 		//     of being able to build a request to /send_knock)
 		//
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t22alice",
+			LocalpartSuffix: "t22alice",
 		})
 
 		testServer1 := createTestServer(t, deployment)
@@ -2098,7 +2098,7 @@ func TestPartialStateJoin(t *testing.T) {
 			room *federation.ServerRoom, cleanup func(),
 		) {
 			alice = deployment.Register(t, "hs1", helpers.RegistrationOpts{
-				Localpart: aliceLocalpart,
+				LocalpartSuffix: aliceLocalpart,
 			})
 
 			deviceListUpdateChannel1 = make(chan gomatrixserverlib.DeviceListUpdateEvent, 10)
@@ -2622,8 +2622,8 @@ func TestPartialStateJoin(t *testing.T) {
 			room *federation.ServerRoom, sendDeviceListUpdate func(string), cleanup func(),
 		) {
 			alice = deployment.Register(t, "hs1", helpers.RegistrationOpts{
-				Localpart: aliceLocalpart,
-				Password:  "secret",
+				LocalpartSuffix: aliceLocalpart,
+				Password:        "secret",
 			})
 
 			userDevicesQueryChannel = make(chan string, 1)
@@ -3414,8 +3414,8 @@ func TestPartialStateJoin(t *testing.T) {
 	t.Run("Room aliases can be added and queried during a resync", func(t *testing.T) {
 		// Alice begins a partial join to a room.
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t40alice",
-			Password:  "secret",
+			LocalpartSuffix: "t40alice",
+			Password:        "secret",
 		})
 		server := createTestServer(t, deployment)
 		cancel := server.Listen()
@@ -3468,8 +3468,8 @@ func TestPartialStateJoin(t *testing.T) {
 	t.Run("Room aliases can be added and deleted during a resync", func(t *testing.T) {
 		// Alice begins a partial join to a room.
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t41alice",
-			Password:  "secret",
+			LocalpartSuffix: "t41alice",
+			Password:        "secret",
 		})
 		server := createTestServer(t, deployment)
 		cancel := server.Listen()
@@ -3508,10 +3508,10 @@ func TestPartialStateJoin(t *testing.T) {
 	// we should be able to join a room that is already joined & resyncing
 	t.Run("CanFastJoinDuringPartialStateJoin", func(t *testing.T) {
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t44alice",
+			LocalpartSuffix: "t44alice",
 		})
 		bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t44bob",
+			LocalpartSuffix: "t44bob",
 		})
 
 		server := createTestServer(t, deployment)
@@ -3545,7 +3545,7 @@ func TestPartialStateJoin(t *testing.T) {
 	// "join", and can be confused with join events.
 	t.Run("Can change display name during partial state join", func(t *testing.T) {
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t45alice",
+			LocalpartSuffix: "t45alice",
 		})
 
 		server := createTestServer(t, deployment)
@@ -3595,7 +3595,7 @@ func TestPartialStateJoin(t *testing.T) {
 			// Before testing that leaves during resyncs are seen during resyncs, sanity
 			// check that leaves during resyncs appear after the resync.
 			alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-				Localpart: "t42alice",
+				LocalpartSuffix: "t42alice",
 			})
 			server := createTestServer(t, deployment)
 			cancel := server.Listen()
@@ -3638,7 +3638,7 @@ func TestPartialStateJoin(t *testing.T) {
 
 		t.Run("does not wait for resync", func(t *testing.T) {
 			alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-				Localpart: "t43alice",
+				LocalpartSuffix: "t43alice",
 			})
 			server := createTestServer(t, deployment)
 			cancel := server.Listen()
@@ -3698,10 +3698,10 @@ func TestPartialStateJoin(t *testing.T) {
 		// Test that the original joiner can leave during the resync, even after someone else has joined
 		t.Run("works after a second partial join", func(t *testing.T) {
 			alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-				Localpart: "t47alice",
+				LocalpartSuffix: "t47alice",
 			})
 			bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-				Localpart: "t47bob",
+				LocalpartSuffix: "t47bob",
 			})
 			server := createTestServer(t, deployment)
 			cancel := server.Listen()
@@ -3753,7 +3753,7 @@ func TestPartialStateJoin(t *testing.T) {
 
 		t.Run("succeeds, then rejoin succeeds without resync completing", func(t *testing.T) {
 			alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-				Localpart: "t48alice",
+				LocalpartSuffix: "t48alice",
 			})
 			server := createTestServer(t, deployment)
 			cancel := server.Listen()
@@ -3795,10 +3795,10 @@ func TestPartialStateJoin(t *testing.T) {
 
 		t.Run("succeeds, then another user can join without resync completing", func(t *testing.T) {
 			alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-				Localpart: "t49alice",
+				LocalpartSuffix: "t49alice",
 			})
 			bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-				Localpart: "t49bob",
+				LocalpartSuffix: "t49bob",
 			})
 			server := createTestServer(t, deployment)
 			cancel := server.Listen()
@@ -3843,7 +3843,7 @@ func TestPartialStateJoin(t *testing.T) {
 
 		t.Run("can be triggered by remote kick", func(t *testing.T) {
 			alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-				Localpart: "t50alice",
+				LocalpartSuffix: "t50alice",
 			})
 			server := createTestServer(t, deployment)
 			cancel := server.Listen()
@@ -3897,7 +3897,7 @@ func TestPartialStateJoin(t *testing.T) {
 
 		t.Run("can be triggered by remote ban", func(t *testing.T) {
 			alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-				Localpart: "t51alice",
+				LocalpartSuffix: "t51alice",
 			})
 			server := createTestServer(t, deployment)
 			cancel := server.Listen()
@@ -3962,8 +3962,8 @@ func TestPartialStateJoin(t *testing.T) {
 		// create a user with admin powers as we will need this power to make the remote room visible in the
 		// local room list
 		terry := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "terry",
-			IsAdmin:   true,
+			LocalpartSuffix: "terry",
+			IsAdmin:         true,
 		})
 
 		server := createTestServer(t, deployment)
@@ -4012,7 +4012,7 @@ func TestPartialStateJoin(t *testing.T) {
 
 	t.Run("User directory is correctly updated once state re-sync completes", func(t *testing.T) {
 		rocky := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "rocky",
+			LocalpartSuffix: "rocky",
 		})
 
 		server := createTestServer(t, deployment)
@@ -4080,8 +4080,8 @@ func TestPartialStateJoin(t *testing.T) {
 		}
 		t.Log("Alice begins a partial join to a room")
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t46alice",
-			IsAdmin:   true,
+			LocalpartSuffix: "t46alice",
+			IsAdmin:         true,
 		})
 		server := createTestServer(t, deployment)
 		cancel := server.Listen()


### PR DESCRIPTION
Based on https://github.com/matrix-org/complement/pull/673


This means clients can't register specific localparts, which is good for dirty runs.

TODO: Delete `Deployment.Client` and swap to `Deployment.Register` for standard alice/bob runs.