### PR TITLE
Remove Deployment.Client and change Deploy

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -38,12 +38,14 @@ const ansiResetForeground = "\x1b[39m"
 
 // errorf is a wrapper around t.Errorf which prints the failing error message in red.
 func errorf(t TestLike, format string, args ...any) {
+	t.Helper()
 	format = ansiRedForeground + format + ansiResetForeground
 	t.Errorf(format, args...)
 }
 
 // fatalf is a wrapper around t.Fatalf which prints the failing error message in red.
 func fatalf(t TestLike, format string, args ...any) {
+	t.Helper()
 	format = ansiRedForeground + format + ansiResetForeground
 	t.Fatalf(format, args...)
 }

--- a/helpers/clientopts.go
+++ b/helpers/clientopts.go
@@ -1,10 +1,10 @@
 package helpers
 
 type RegistrationOpts struct {
-	Localpart string // default '' (don't care)
-	DeviceID  string // default '' (generate new)
-	Password  string // default 'complement_meets_min_password_requirement'
-	IsAdmin   bool   // default false
+	LocalpartSuffix string // default '' (don't care)
+	DeviceID        string // default '' (generate new)
+	Password        string // default 'complement_meets_min_password_requirement'
+	IsAdmin         bool   // default false
 }
 
 type LoginOpts struct {

--- a/helpers/clientopts.go
+++ b/helpers/clientopts.go
@@ -1,0 +1,12 @@
+package helpers
+
+type RegistrationOpts struct {
+	Localpart string // default '' (don't care)
+	DeviceID  string // default '' (generate new)
+	Password  string // default 'complement_meets_min_password_requirement'
+	IsAdmin   bool   // default false
+}
+
+type LoginOpts struct {
+	Password string // default 'complement_meets_min_password_requirement'
+}

--- a/internal/docker/deployment.go
+++ b/internal/docker/deployment.go
@@ -85,7 +85,10 @@ func (d *Deployment) Register(t *testing.T, hsName string, opts helpers.Registra
 	if password == "" {
 		password = "complement_meets_min_password_req"
 	}
-	localpart := fmt.Sprintf("user-%v-%v", d.localpartCounter.Add(1), opts.Localpart)
+	localpart := opts.Localpart
+	if localpart == "" {
+		localpart = fmt.Sprintf("user-%v", d.localpartCounter.Add(1))
+	}
 	var userID, accessToken, deviceID string
 	if opts.IsAdmin {
 		userID, accessToken, deviceID = client.RegisterSharedSecret(t, localpart, password, opts.IsAdmin)

--- a/internal/docker/deployment.go
+++ b/internal/docker/deployment.go
@@ -1,6 +1,7 @@
 package docker
 
 import (
+	"net/http"
 	"sync"
 	"testing"
 	"time"
@@ -51,6 +52,14 @@ func (d *Deployment) Destroy(t *testing.T) {
 	d.Deployer.Destroy(d, d.Deployer.config.AlwaysPrintServerLogs || t.Failed(), t.Name(), t.Failed())
 }
 
+func (d *Deployment) GetConfig() *config.Complement {
+	return d.Config
+}
+
+func (d *Deployment) RoundTripper() http.RoundTripper {
+	return &RoundTripper{Deployment: d}
+}
+
 // Client returns a CSAPI client targeting the given hsName, using the access token for the given userID.
 // Fails the test if the hsName is not found. Returns an unauthenticated client if userID is "", fails the test
 // if the userID is otherwise not found.
@@ -91,7 +100,7 @@ func (d *Deployment) Client(t *testing.T, hsName, userID string) *client.CSAPI {
 
 // NewUser creates a new user as a convenience method to RegisterUser.
 //
-//It registers the user with a deterministic password, and without admin privileges.
+// It registers the user with a deterministic password, and without admin privileges.
 func (d *Deployment) NewUser(t *testing.T, localpart, hs string) *client.CSAPI {
 	return d.RegisterUser(t, hs, localpart, "complement_meets_min_pasword_req_"+localpart, false)
 }

--- a/internal/docker/deployment.go
+++ b/internal/docker/deployment.go
@@ -85,10 +85,7 @@ func (d *Deployment) Register(t *testing.T, hsName string, opts helpers.Registra
 	if password == "" {
 		password = "complement_meets_min_password_req"
 	}
-	localpart := opts.Localpart
-	if localpart == "" {
-		localpart = fmt.Sprintf("user-%v", d.localpartCounter.Add(1))
-	}
+	localpart := fmt.Sprintf("user-%v-%v", d.localpartCounter.Add(1), opts.LocalpartSuffix)
 	var userID, accessToken, deviceID string
 	if opts.IsAdmin {
 		userID, accessToken, deviceID = client.RegisterSharedSecret(t, localpart, password, opts.IsAdmin)

--- a/internal/docker/deployment.go
+++ b/internal/docker/deployment.go
@@ -155,10 +155,9 @@ func (d *Deployment) UnauthenticatedClient(t *testing.T, hsName string) *client.
 	return client
 }
 
-// Client returns a CSAPI client targeting the given hsName, using the access token for the given userID.
-// Fails the test if the hsName is not found. Returns an unauthenticated client if userID is "", fails the test
-// if the userID is otherwise not found.
-func (d *Deployment) Client(t *testing.T, hsName, userID string) *client.CSAPI {
+// AppServiceUser returns a client for the given app service user ID. The HS in question must have an appservice
+// hooked up to it already. TODO: REMOVE
+func (d *Deployment) AppServiceUser(t *testing.T, hsName, appServiceUserID string) *client.CSAPI {
 	t.Helper()
 	dep, ok := d.HS[hsName]
 	if !ok {
@@ -166,18 +165,18 @@ func (d *Deployment) Client(t *testing.T, hsName, userID string) *client.CSAPI {
 		return nil
 	}
 	dep.accessTokensMutex.RLock()
-	token := dep.AccessTokens[userID]
+	token := dep.AccessTokens[appServiceUserID]
 	dep.accessTokensMutex.RUnlock()
-	if token == "" && userID != "" {
-		t.Fatalf("Deployment.Client - HS name '%s' - user ID '%s' not found", hsName, userID)
+	if token == "" && appServiceUserID != "" {
+		t.Fatalf("Deployment.Client - HS name '%s' - user ID '%s' not found", hsName, appServiceUserID)
 		return nil
 	}
-	deviceID := dep.DeviceIDs[userID]
-	if deviceID == "" && userID != "" {
-		t.Logf("WARNING: Deployment.Client - HS name '%s' - user ID '%s' - deviceID not found", hsName, userID)
+	deviceID := dep.DeviceIDs[appServiceUserID]
+	if deviceID == "" && appServiceUserID != "" {
+		t.Logf("WARNING: Deployment.Client - HS name '%s' - user ID '%s' - deviceID not found", hsName, appServiceUserID)
 	}
 	client := &client.CSAPI{
-		UserID:           userID,
+		UserID:           appServiceUserID,
 		AccessToken:      token,
 		DeviceID:         deviceID,
 		BaseURL:          dep.BaseURL,

--- a/internal/federation/server_test.go
+++ b/internal/federation/server_test.go
@@ -7,14 +7,26 @@ import (
 	"testing"
 
 	"github.com/matrix-org/complement/internal/config"
-	"github.com/matrix-org/complement/internal/docker"
 )
+
+type fedDeploy struct {
+	cfg     *config.Complement
+	tripper http.RoundTripper
+}
+
+func (d *fedDeploy) GetConfig() *config.Complement {
+	return d.cfg
+}
+func (d *fedDeploy) RoundTripper() http.RoundTripper {
+	return d.tripper
+}
 
 func TestComplementServerIsSigned(t *testing.T) {
 	cfg := config.NewConfigFromEnvVars("test", "unimportant")
 	cfg.HostnameRunningComplement = "localhost"
-	srv := NewServer(t, &docker.Deployment{
-		Config: cfg,
+	srv := NewServer(t, &fedDeploy{
+		cfg:     cfg,
+		tripper: http.DefaultClient.Transport,
 	})
 	srv.UnexpectedRequestsAreErrors = false
 	cancel := srv.Listen()

--- a/test_main.go
+++ b/test_main.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/matrix-org/complement/b"
-	"github.com/matrix-org/complement/internal/docker"
 )
 
 var testPackage *TestPackage
@@ -35,7 +34,7 @@ func TestMain(m *testing.M, namespace string) {
 // It will construct the blueprint if it doesn't already exist in the docker image cache.
 // This function is the main setup function for all tests as it provides a deployment with
 // which tests can interact with.
-func Deploy(t *testing.T, blueprint b.Blueprint) *docker.Deployment {
+func Deploy(t *testing.T, blueprint b.Blueprint) Deployment {
 	t.Helper()
 	if testPackage == nil {
 		t.Fatalf("Deploy: testPackage not set, did you forget to call complement.TestMain?")

--- a/test_main.go
+++ b/test_main.go
@@ -34,10 +34,21 @@ func TestMain(m *testing.M, namespace string) {
 // It will construct the blueprint if it doesn't already exist in the docker image cache.
 // This function is the main setup function for all tests as it provides a deployment with
 // which tests can interact with.
-func Deploy(t *testing.T, blueprint b.Blueprint) Deployment {
+func OldDeploy(t *testing.T, blueprint b.Blueprint) Deployment {
 	t.Helper()
 	if testPackage == nil {
 		t.Fatalf("Deploy: testPackage not set, did you forget to call complement.TestMain?")
 	}
-	return testPackage.Deploy(t, blueprint)
+	return testPackage.OldDeploy(t, blueprint)
+}
+
+// Deploy will deploy the given number of servers or terminate the test.
+// This function is the main setup function for all tests as it provides a deployment with
+// which tests can interact with.
+func Deploy(t *testing.T, numServers int) Deployment {
+	t.Helper()
+	if testPackage == nil {
+		t.Fatalf("Deploy: testPackage not set, did you forget to call complement.TestMain?")
+	}
+	return testPackage.Deploy(t, numServers)
 }

--- a/test_package.go
+++ b/test_package.go
@@ -26,6 +26,9 @@ type Deployment interface {
 	// Login to an existing user account on the given server. In order to make tests not hardcode full user IDs,
 	// an existing logged in client must be supplied.
 	Login(t *testing.T, hsName string, existing *client.CSAPI, opts helpers.LoginOpts) *client.CSAPI
+	// AppServiceUser returns a client for the given app service user ID. The HS in question must have an appservice
+	// hooked up to it already. TODO: REMOVE
+	AppServiceUser(t *testing.T, hsName, appServiceUserID string) *client.CSAPI
 	// Restart a deployment.
 	Restart(t *testing.T) error
 	// Destroy the entire deployment. Destroys all running containers. If `printServerLogs` is true,

--- a/test_package.go
+++ b/test_package.go
@@ -19,10 +19,8 @@ import (
 
 // Deployment provides a way for tests to interact with a set of homeservers.
 type Deployment interface {
-	// Client returns a CSAPI client targeting the given hsName, using the access token for the given userID.
-	// Fails the test if the hsName is not found. Returns an unauthenticated client if userID is "", fails the test
-	// if the userID is otherwise not found.
-	Client(t *testing.T, serverName, userID string) *client.CSAPI
+	// UnauthenticatedClient returns a blank CSAPI client.
+	UnauthenticatedClient(t *testing.T, serverName string) *client.CSAPI
 	// Register a new user on the given server.
 	Register(t *testing.T, hsName string, opts helpers.RegistrationOpts) *client.CSAPI
 	// Login to an existing user account on the given server. In order to make tests not hardcode full user IDs,

--- a/test_package.go
+++ b/test_package.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/internal/config"
 	"github.com/matrix-org/complement/internal/docker"
 	"github.com/sirupsen/logrus"
@@ -22,16 +23,11 @@ type Deployment interface {
 	// Fails the test if the hsName is not found. Returns an unauthenticated client if userID is "", fails the test
 	// if the userID is otherwise not found.
 	Client(t *testing.T, serverName, userID string) *client.CSAPI
-	// RegisterUser within a homeserver and return an authenticatedClient, Fails the test if the hsName is not found.
-	RegisterUser(t *testing.T, hsName, localpart, password string, isAdmin bool) *client.CSAPI
-	// NewUser creates a new user as a convenience method to RegisterUser. TODO REMOVE
-	//
-	// It registers the user with a deterministic password, and without admin privileges.
-	NewUser(t *testing.T, localpart, hs string) *client.CSAPI
-	// TODO remove this, only used in 1 test in msc3890
-	// LoginUser within a homeserver and return an authenticatedClient. Fails the test if the hsName is not found.
-	// Note that this will not change the access token of the client that is returned by `deployment.Client`.
-	LoginUser(t *testing.T, hsName, localpart, password string) *client.CSAPI
+	// Register a new user on the given server.
+	Register(t *testing.T, hsName string, opts helpers.RegistrationOpts) *client.CSAPI
+	// Login to an existing user account on the given server. In order to make tests not hardcode full user IDs,
+	// an existing logged in client must be supplied.
+	Login(t *testing.T, hsName string, existing *client.CSAPI, opts helpers.LoginOpts) *client.CSAPI
 	// Restart a deployment.
 	Restart(t *testing.T) error
 	// Destroy the entire deployment. Destroys all running containers. If `printServerLogs` is true,

--- a/test_package.go
+++ b/test_package.go
@@ -4,15 +4,44 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/matrix-org/complement/b"
+	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/internal/config"
 	"github.com/matrix-org/complement/internal/docker"
 	"github.com/sirupsen/logrus"
 )
+
+// Deployment provides a way for tests to interact with a set of homeservers.
+type Deployment interface {
+	// Client returns a CSAPI client targeting the given hsName, using the access token for the given userID.
+	// Fails the test if the hsName is not found. Returns an unauthenticated client if userID is "", fails the test
+	// if the userID is otherwise not found.
+	Client(t *testing.T, serverName, userID string) *client.CSAPI
+	// RegisterUser within a homeserver and return an authenticatedClient, Fails the test if the hsName is not found.
+	RegisterUser(t *testing.T, hsName, localpart, password string, isAdmin bool) *client.CSAPI
+	// NewUser creates a new user as a convenience method to RegisterUser. TODO REMOVE
+	//
+	// It registers the user with a deterministic password, and without admin privileges.
+	NewUser(t *testing.T, localpart, hs string) *client.CSAPI
+	// TODO remove this, only used in 1 test in msc3890
+	// LoginUser within a homeserver and return an authenticatedClient. Fails the test if the hsName is not found.
+	// Note that this will not change the access token of the client that is returned by `deployment.Client`.
+	LoginUser(t *testing.T, hsName, localpart, password string) *client.CSAPI
+	// Restart a deployment.
+	Restart(t *testing.T) error
+	// Destroy the entire deployment. Destroys all running containers. If `printServerLogs` is true,
+	// will print container logs before killing the container.
+	Destroy(t *testing.T)
+	// Return the complement config current active for this deployment
+	GetConfig() *config.Complement
+	// Return an HTTP round tripper interface which can map HS names to the actual container:port
+	RoundTripper() http.RoundTripper
+}
 
 // TestPackage represents the configuration for a package of tests. A package of tests
 // are all tests in the same Go package (directory).
@@ -57,7 +86,7 @@ func (tp *TestPackage) Cleanup() {
 // It will construct the blueprint if it doesn't already exist in the docker image cache.
 // This function is the main setup function for all tests as it provides a deployment with
 // which tests can interact with.
-func (tp *TestPackage) Deploy(t *testing.T, blueprint b.Blueprint) *docker.Deployment {
+func (tp *TestPackage) Deploy(t *testing.T, blueprint b.Blueprint) Deployment {
 	t.Helper()
 	timeStartBlueprint := time.Now()
 	if err := tp.complementBuilder.ConstructBlueprintIfNotExist(blueprint); err != nil {
@@ -75,4 +104,8 @@ func (tp *TestPackage) Deploy(t *testing.T, blueprint b.Blueprint) *docker.Deplo
 	}
 	t.Logf("Deploy times: %v blueprints, %v containers", timeStartDeploy.Sub(timeStartBlueprint), time.Since(timeStartDeploy))
 	return dep
+}
+
+func (tp *TestPackage) DeployDirty(t *testing.T, numServers int) Deployment {
+	return nil
 }

--- a/tests/csapi/account_change_password_pushers_test.go
+++ b/tests/csapi/account_change_password_pushers_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 
@@ -20,7 +21,10 @@ func TestChangePasswordPushers(t *testing.T) {
 	defer deployment.Destroy(t)
 	password1 := "superuser"
 	password2 := "my_new_password"
-	passwordClient := deployment.RegisterUser(t, "hs1", "test_change_password_pusher_user", password1, false)
+	passwordClient := deployment.Register(t, "hs1", helpers.RegistrationOpts{
+		Localpart: "test_change_password_pusher_user",
+		Password:  password1,
+	})
 
 	// sytest: Pushers created with a different access token are deleted on password change
 	t.Run("Pushers created with a different access token are deleted on password change", func(t *testing.T) {

--- a/tests/csapi/account_change_password_pushers_test.go
+++ b/tests/csapi/account_change_password_pushers_test.go
@@ -22,8 +22,7 @@ func TestChangePasswordPushers(t *testing.T) {
 	password1 := "superuser"
 	password2 := "my_new_password"
 	passwordClient := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-		Localpart: "test_change_password_pusher_user",
-		Password:  password1,
+		Password: password1,
 	})
 
 	// sytest: Pushers created with a different access token are deleted on password change

--- a/tests/csapi/account_change_password_pushers_test.go
+++ b/tests/csapi/account_change_password_pushers_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
@@ -17,7 +16,7 @@ import (
 )
 
 func TestChangePasswordPushers(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 	password1 := "superuser"
 	password2 := "my_new_password"

--- a/tests/csapi/account_change_password_test.go
+++ b/tests/csapi/account_change_password_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
-	"github.com/matrix-org/complement/internal/docker"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 
@@ -121,7 +120,7 @@ func changePassword(t *testing.T, passwordClient *client.CSAPI, oldPassword stri
 	})
 }
 
-func createSession(t *testing.T, deployment *docker.Deployment, userID, password string) (deviceID string, authedClient *client.CSAPI) {
+func createSession(t *testing.T, deployment complement.Deployment, userID, password string) (deviceID string, authedClient *client.CSAPI) {
 	authedClient = deployment.Client(t, "hs1", "")
 	reqBody := client.WithJSONBody(t, map[string]interface{}{
 		"identifier": map[string]interface{}{

--- a/tests/csapi/account_change_password_test.go
+++ b/tests/csapi/account_change_password_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 
@@ -18,7 +19,10 @@ func TestChangePassword(t *testing.T) {
 	defer deployment.Destroy(t)
 	password1 := "superuser"
 	password2 := "my_new_password"
-	passwordClient := deployment.RegisterUser(t, "hs1", "test_change_password_user", password1, false)
+	passwordClient := deployment.Register(t, "hs1", helpers.RegistrationOpts{
+		Localpart: "test_change_password_user",
+		Password:  password1,
+	})
 	unauthedClient := deployment.Client(t, "hs1", "")
 	_, sessionTest := createSession(t, deployment, "test_change_password_user", "superuser")
 	// sytest: After changing password, can't log in with old password

--- a/tests/csapi/account_change_password_test.go
+++ b/tests/csapi/account_change_password_test.go
@@ -1,7 +1,7 @@
 package csapi_tests
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/matrix-org/complement"
@@ -20,11 +20,10 @@ func TestChangePassword(t *testing.T) {
 	password1 := "superuser"
 	password2 := "my_new_password"
 	passwordClient := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-		Localpart: "test_change_password_user",
-		Password:  password1,
+		Password: password1,
 	})
 	unauthedClient := deployment.Client(t, "hs1", "")
-	_, sessionTest := createSession(t, deployment, "test_change_password_user", "superuser")
+	_, sessionTest := createSession(t, deployment, passwordClient.UserID, "superuser")
 	// sytest: After changing password, can't log in with old password
 	t.Run("After changing password, can't log in with old password", func(t *testing.T) {
 
@@ -82,7 +81,7 @@ func TestChangePassword(t *testing.T) {
 
 	// sytest: After changing password, different sessions can optionally be kept
 	t.Run("After changing password, different sessions can optionally be kept", func(t *testing.T) {
-		_, sessionOptional := createSession(t, deployment, "test_change_password_user", password2)
+		_, sessionOptional := createSession(t, deployment, passwordClient.UserID, password2)
 		reqBody := client.WithJSONBody(t, map[string]interface{}{
 			"auth": map[string]interface{}{
 				"type":     "m.login.password",
@@ -135,7 +134,7 @@ func createSession(t *testing.T, deployment complement.Deployment, userID, passw
 		"password": password,
 	})
 	res := authedClient.Do(t, "POST", []string{"_matrix", "client", "v3", "login"}, reqBody)
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		t.Fatalf("unable to read response body: %v", err)
 	}

--- a/tests/csapi/account_change_password_test.go
+++ b/tests/csapi/account_change_password_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
@@ -15,7 +14,7 @@ import (
 )
 
 func TestChangePassword(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 	password1 := "superuser"
 	password2 := "my_new_password"

--- a/tests/csapi/account_change_password_test.go
+++ b/tests/csapi/account_change_password_test.go
@@ -22,7 +22,7 @@ func TestChangePassword(t *testing.T) {
 	passwordClient := deployment.Register(t, "hs1", helpers.RegistrationOpts{
 		Password: password1,
 	})
-	unauthedClient := deployment.Client(t, "hs1", "")
+	unauthedClient := deployment.UnauthenticatedClient(t, "hs1")
 	_, sessionTest := createSession(t, deployment, passwordClient.UserID, "superuser")
 	// sytest: After changing password, can't log in with old password
 	t.Run("After changing password, can't log in with old password", func(t *testing.T) {
@@ -124,7 +124,7 @@ func changePassword(t *testing.T, passwordClient *client.CSAPI, oldPassword stri
 }
 
 func createSession(t *testing.T, deployment complement.Deployment, userID, password string) (deviceID string, authedClient *client.CSAPI) {
-	authedClient = deployment.Client(t, "hs1", "")
+	authedClient = deployment.UnauthenticatedClient(t, "hs1")
 	reqBody := client.WithJSONBody(t, map[string]interface{}{
 		"identifier": map[string]interface{}{
 			"type": "m.id.user",

--- a/tests/csapi/account_data_test.go
+++ b/tests/csapi/account_data_test.go
@@ -4,14 +4,13 @@ import (
 	"testing"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
 
 func TestAddAccountData(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})

--- a/tests/csapi/account_data_test.go
+++ b/tests/csapi/account_data_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
@@ -13,7 +14,7 @@ func TestAddAccountData(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	// sytest: Can add account data
 	// sytest: Can get account data without syncing

--- a/tests/csapi/account_deactivate_test.go
+++ b/tests/csapi/account_deactivate_test.go
@@ -21,7 +21,7 @@ func TestDeactivateAccount(t *testing.T) {
 	authedClient := deployment.Register(t, "hs1", helpers.RegistrationOpts{
 		Password: password,
 	})
-	unauthedClient := deployment.Client(t, "hs1", "")
+	unauthedClient := deployment.UnauthenticatedClient(t, "hs1")
 
 	// Ensure that the first step, in which the client queries the server's user-interactive auth flows, returns
 	// at least one auth flow involving a password.

--- a/tests/csapi/account_deactivate_test.go
+++ b/tests/csapi/account_deactivate_test.go
@@ -19,8 +19,7 @@ func TestDeactivateAccount(t *testing.T) {
 	defer deployment.Destroy(t)
 	password := "superuser"
 	authedClient := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-		Localpart: "test_deactivate_user",
-		Password:  password,
+		Password: password,
 	})
 	unauthedClient := deployment.Client(t, "hs1", "")
 

--- a/tests/csapi/account_deactivate_test.go
+++ b/tests/csapi/account_deactivate_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/tidwall/gjson"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
@@ -15,7 +14,7 @@ import (
 )
 
 func TestDeactivateAccount(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 	password := "superuser"
 	authedClient := deployment.Register(t, "hs1", helpers.RegistrationOpts{

--- a/tests/csapi/account_deactivate_test.go
+++ b/tests/csapi/account_deactivate_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
@@ -17,7 +18,10 @@ func TestDeactivateAccount(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 	password := "superuser"
-	authedClient := deployment.RegisterUser(t, "hs1", "test_deactivate_user", password, false)
+	authedClient := deployment.Register(t, "hs1", helpers.RegistrationOpts{
+		Localpart: "test_deactivate_user",
+		Password:  password,
+	})
 	unauthedClient := deployment.Client(t, "hs1", "")
 
 	// Ensure that the first step, in which the client queries the server's user-interactive auth flows, returns

--- a/tests/csapi/admin_test.go
+++ b/tests/csapi/admin_test.go
@@ -21,9 +21,7 @@ func TestCanRegisterAdmin(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 	deployment.Register(t, "hs1", helpers.RegistrationOpts{
-		Localpart: "admin",
-		Password:  "adminpassword",
-		IsAdmin:   true,
+		IsAdmin: true,
 	})
 }
 
@@ -32,9 +30,7 @@ func TestServerNotices(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 	admin := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-		Localpart: "admin",
-		Password:  "adminpassword",
-		IsAdmin:   true,
+		IsAdmin: true,
 	})
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
 

--- a/tests/csapi/admin_test.go
+++ b/tests/csapi/admin_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/tidwall/gjson"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
@@ -18,7 +17,7 @@ import (
 // Check if this homeserver supports Synapse-style admin registration.
 // Not all images support this currently.
 func TestCanRegisterAdmin(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 	deployment.Register(t, "hs1", helpers.RegistrationOpts{
 		IsAdmin: true,
@@ -27,7 +26,7 @@ func TestCanRegisterAdmin(t *testing.T) {
 
 // Test if the implemented /_synapse/admin/v1/send_server_notice behaves as expected
 func TestServerNotices(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 	admin := deployment.Register(t, "hs1", helpers.RegistrationOpts{
 		IsAdmin: true,

--- a/tests/csapi/admin_test.go
+++ b/tests/csapi/admin_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
@@ -19,14 +20,22 @@ import (
 func TestCanRegisterAdmin(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
-	deployment.RegisterUser(t, "hs1", "admin", "adminpassword", true)
+	deployment.Register(t, "hs1", helpers.RegistrationOpts{
+		Localpart: "admin",
+		Password:  "adminpassword",
+		IsAdmin:   true,
+	})
 }
 
 // Test if the implemented /_synapse/admin/v1/send_server_notice behaves as expected
 func TestServerNotices(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
-	admin := deployment.RegisterUser(t, "hs1", "admin", "adminpassword", true)
+	admin := deployment.Register(t, "hs1", helpers.RegistrationOpts{
+		Localpart: "admin",
+		Password:  "adminpassword",
+		IsAdmin:   true,
+	})
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
 
 	reqBody := client.WithJSONBody(t, map[string]interface{}{

--- a/tests/csapi/admin_test.go
+++ b/tests/csapi/admin_test.go
@@ -32,10 +32,10 @@ func TestServerNotices(t *testing.T) {
 	admin := deployment.Register(t, "hs1", helpers.RegistrationOpts{
 		IsAdmin: true,
 	})
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	reqBody := client.WithJSONBody(t, map[string]interface{}{
-		"user_id": "@alice:hs1",
+		"user_id": alice.UserID,
 		"content": map[string]interface{}{
 			"msgtype": "m.text",
 			"body":    "hello from server notices!",

--- a/tests/csapi/apidoc_content_test.go
+++ b/tests/csapi/apidoc_content_test.go
@@ -5,13 +5,12 @@ import (
 	"testing"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/internal/data"
 )
 
 func TestContent(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})

--- a/tests/csapi/apidoc_content_test.go
+++ b/tests/csapi/apidoc_content_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/internal/data"
 )
 
@@ -13,7 +14,7 @@ func TestContent(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 	wantContentType := "image/png"
 	// sytest: POST /media/v3/upload can create an upload
 	mxcUri := alice.UploadContent(t, data.MatrixPng, "test.png", wantContentType)

--- a/tests/csapi/apidoc_device_management_test.go
+++ b/tests/csapi/apidoc_device_management_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/tidwall/gjson"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
@@ -14,7 +13,7 @@ import (
 )
 
 func TestDeviceManagement(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 	unauthedClient := deployment.UnauthenticatedClient(t, "hs1")
 	authedClient := deployment.Register(t, "hs1", helpers.RegistrationOpts{

--- a/tests/csapi/apidoc_device_management_test.go
+++ b/tests/csapi/apidoc_device_management_test.go
@@ -18,8 +18,7 @@ func TestDeviceManagement(t *testing.T) {
 	defer deployment.Destroy(t)
 	unauthedClient := deployment.Client(t, "hs1", "")
 	authedClient := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-		Localpart: "test_device_management_user",
-		Password:  "superuser",
+		Password: "superuser",
 	})
 
 	// sytest: GET /device/{deviceId}
@@ -199,8 +198,8 @@ func TestDeviceManagement(t *testing.T) {
 	// sytest: DELETE /device/{deviceId} requires UI auth user to match device owner
 	t.Run("DELETE /device/{deviceId} requires UI auth user to match device owner", func(t *testing.T) {
 		bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "bob",
-			Password:  "bobspassword",
+			LocalpartSuffix: "bob",
+			Password:        "bobspassword",
 		})
 
 		newDeviceID, session2 := createSession(t, deployment, authedClient.UserID, "superuser")

--- a/tests/csapi/apidoc_device_management_test.go
+++ b/tests/csapi/apidoc_device_management_test.go
@@ -16,7 +16,7 @@ import (
 func TestDeviceManagement(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
-	unauthedClient := deployment.Client(t, "hs1", "")
+	unauthedClient := deployment.UnauthenticatedClient(t, "hs1")
 	authedClient := deployment.Register(t, "hs1", helpers.RegistrationOpts{
 		Password: "superuser",
 	})

--- a/tests/csapi/apidoc_device_management_test.go
+++ b/tests/csapi/apidoc_device_management_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
@@ -16,7 +17,10 @@ func TestDeviceManagement(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 	unauthedClient := deployment.Client(t, "hs1", "")
-	authedClient := deployment.RegisterUser(t, "hs1", "test_device_management_user", "superuser", false)
+	authedClient := deployment.Register(t, "hs1", helpers.RegistrationOpts{
+		Localpart: "test_device_management_user",
+		Password:  "superuser",
+	})
 
 	// sytest: GET /device/{deviceId}
 	t.Run("GET /device/{deviceId}", func(t *testing.T) {
@@ -194,7 +198,10 @@ func TestDeviceManagement(t *testing.T) {
 	})
 	// sytest: DELETE /device/{deviceId} requires UI auth user to match device owner
 	t.Run("DELETE /device/{deviceId} requires UI auth user to match device owner", func(t *testing.T) {
-		bob := deployment.RegisterUser(t, "hs1", "bob", "bobspassword", false)
+		bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{
+			Localpart: "bob",
+			Password:  "bobspassword",
+		})
 
 		newDeviceID, session2 := createSession(t, deployment, authedClient.UserID, "superuser")
 		session2.MustSync(t, client.SyncReq{})

--- a/tests/csapi/apidoc_login_test.go
+++ b/tests/csapi/apidoc_login_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/tidwall/gjson"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
@@ -18,7 +17,7 @@ import (
 )
 
 func TestLogin(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 	unauthedClient := deployment.UnauthenticatedClient(t, "hs1")
 	testClient := deployment.Register(t, "hs1", helpers.RegistrationOpts{

--- a/tests/csapi/apidoc_login_test.go
+++ b/tests/csapi/apidoc_login_test.go
@@ -20,7 +20,7 @@ import (
 func TestLogin(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
-	unauthedClient := deployment.Client(t, "hs1", "")
+	unauthedClient := deployment.UnauthenticatedClient(t, "hs1")
 	testClient := deployment.Register(t, "hs1", helpers.RegistrationOpts{
 		Password: "superuser",
 	})

--- a/tests/csapi/apidoc_login_test.go
+++ b/tests/csapi/apidoc_login_test.go
@@ -3,6 +3,7 @@ package csapi_tests
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/tidwall/gjson"
@@ -13,15 +14,15 @@ import (
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
+	"github.com/matrix-org/gomatrixserverlib"
 )
 
 func TestLogin(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 	unauthedClient := deployment.Client(t, "hs1", "")
-	deployment.Register(t, "hs1", helpers.RegistrationOpts{
-		Localpart: "test_login_user",
-		Password:  "superuser",
+	testClient := deployment.Register(t, "hs1", helpers.RegistrationOpts{
+		Password: "superuser",
 	})
 	t.Run("parallel", func(t *testing.T) {
 		// sytest: GET /login yields a set of flows
@@ -48,14 +49,14 @@ func TestLogin(t *testing.T) {
 		// sytest: POST /login can log in as a user
 		t.Run("POST /login can login as user", func(t *testing.T) {
 			t.Parallel()
-			res := unauthedClient.MustDo(t, "POST", []string{"_matrix", "client", "v3", "login"}, client.WithRawBody(json.RawMessage(`{
+			res := unauthedClient.MustDo(t, "POST", []string{"_matrix", "client", "v3", "login"}, client.WithJSONBody(t, map[string]interface{}{
 				"type": "m.login.password",
-				"identifier": {
+				"identifier": map[string]interface{}{
 					"type": "m.id.user",
-					"user": "@test_login_user:hs1"
+					"user": testClient.UserID,
 				},
-				"password": "superuser"
-			}`)))
+				"password": "superuser",
+			}))
 
 			must.MatchResponse(t, res, match.HTTPResponse{
 				JSON: []match.JSON{
@@ -67,15 +68,15 @@ func TestLogin(t *testing.T) {
 		t.Run("POST /login returns the same device_id as that in the request", func(t *testing.T) {
 			t.Parallel()
 			deviceID := "test_device_id"
-			res := unauthedClient.MustDo(t, "POST", []string{"_matrix", "client", "v3", "login"}, client.WithRawBody(json.RawMessage(`{
+			res := unauthedClient.MustDo(t, "POST", []string{"_matrix", "client", "v3", "login"}, client.WithJSONBody(t, map[string]interface{}{
 				"type": "m.login.password",
-				"identifier": {
+				"identifier": map[string]interface{}{
 					"type": "m.id.user",
-					"user": "@test_login_user:hs1"
+					"user": testClient.UserID,
 				},
-				"password": "superuser",
-				"device_id": "`+deviceID+`"
-			}`)))
+				"password":  "superuser",
+				"device_id": deviceID,
+			}))
 
 			must.MatchResponse(t, res, match.HTTPResponse{
 				JSON: []match.JSON{
@@ -87,15 +88,16 @@ func TestLogin(t *testing.T) {
 		// sytest: POST /login can log in as a user with just the local part of the id
 		t.Run("POST /login can log in as a user with just the local part of the id", func(t *testing.T) {
 			t.Parallel()
-
-			res := unauthedClient.MustDo(t, "POST", []string{"_matrix", "client", "v3", "login"}, client.WithRawBody(json.RawMessage(`{
+			localpart, _, err := gomatrixserverlib.SplitID('@', testClient.UserID)
+			must.NotError(t, "failed to get localpart from user ID", err)
+			res := unauthedClient.MustDo(t, "POST", []string{"_matrix", "client", "v3", "login"}, client.WithJSONBody(t, map[string]interface{}{
 				"type": "m.login.password",
-				"identifier": {
+				"identifier": map[string]interface{}{
 					"type": "m.id.user",
-					"user": "test_login_user"
+					"user": localpart,
 				},
-				"password": "superuser"
-			}`)))
+				"password": "superuser",
+			}))
 
 			must.MatchResponse(t, res, match.HTTPResponse{
 				JSON: []match.JSON{
@@ -106,14 +108,14 @@ func TestLogin(t *testing.T) {
 		// sytest: POST /login as non-existing user is rejected
 		t.Run("POST /login as non-existing user is rejected", func(t *testing.T) {
 			t.Parallel()
-			res := unauthedClient.Do(t, "POST", []string{"_matrix", "client", "v3", "login"}, client.WithRawBody(json.RawMessage(`{
+			res := unauthedClient.MustDo(t, "POST", []string{"_matrix", "client", "v3", "login"}, client.WithJSONBody(t, map[string]interface{}{
 				"type": "m.login.password",
-				"identifier": {
+				"identifier": map[string]interface{}{
 					"type": "m.id.user",
-					"user": "i-dont-exist"
+					"user": "i-dont-exist",
 				},
-				"password": "superuser"
-			}`)))
+				"password": "superuser",
+			}))
 			must.MatchResponse(t, res, match.HTTPResponse{
 				StatusCode: 403,
 			})
@@ -121,14 +123,14 @@ func TestLogin(t *testing.T) {
 		// sytest: POST /login wrong password is rejected
 		t.Run("POST /login wrong password is rejected", func(t *testing.T) {
 			t.Parallel()
-			res := unauthedClient.Do(t, "POST", []string{"_matrix", "client", "v3", "login"}, client.WithRawBody(json.RawMessage(`{
+			res := unauthedClient.MustDo(t, "POST", []string{"_matrix", "client", "v3", "login"}, client.WithJSONBody(t, map[string]interface{}{
 				"type": "m.login.password",
-				"identifier": {
+				"identifier": map[string]interface{}{
 					"type": "m.id.user",
-					"user": "@test_login_user:hs1"
+					"user": testClient.UserID,
 				},
-				"password": "wrong_password"
-			}`)))
+				"password": "wrong_password",
+			}))
 			must.MatchResponse(t, res, match.HTTPResponse{
 				StatusCode: 403,
 				JSON: []match.JSON{
@@ -141,14 +143,17 @@ func TestLogin(t *testing.T) {
 		t.Run("Login with uppercase username works and GET /whoami afterwards also", func(t *testing.T) {
 			t.Parallel()
 			// login should be possible with uppercase username
-			res := unauthedClient.MustDo(t, "POST", []string{"_matrix", "client", "v3", "login"}, client.WithRawBody(json.RawMessage(`{
+			localpart, domain, err := gomatrixserverlib.SplitID('@', testClient.UserID)
+			must.NotError(t, "failed to get localpart from user ID", err)
+
+			res := unauthedClient.MustDo(t, "POST", []string{"_matrix", "client", "v3", "login"}, client.WithJSONBody(t, map[string]interface{}{
 				"type": "m.login.password",
-				"identifier": {
+				"identifier": map[string]interface{}{
 					"type": "m.id.user",
-					"user": "@Test_login_user:hs1"
+					"user": fmt.Sprintf("@%s:%s", strings.ToUpper(localpart), domain),
 				},
-				"password": "superuser"
-			}`)))
+				"password": "superuser",
+			}))
 			// extract access_token
 			js := must.ParseJSON(t, res.Body)
 			defer res.Body.Close()

--- a/tests/csapi/apidoc_login_test.go
+++ b/tests/csapi/apidoc_login_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
@@ -18,7 +19,10 @@ func TestLogin(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 	unauthedClient := deployment.Client(t, "hs1", "")
-	_ = deployment.RegisterUser(t, "hs1", "test_login_user", "superuser", false)
+	deployment.Register(t, "hs1", helpers.RegistrationOpts{
+		Localpart: "test_login_user",
+		Password:  "superuser",
+	})
 	t.Run("parallel", func(t *testing.T) {
 		// sytest: GET /login yields a set of flows
 		t.Run("GET /login yields a set of flows", func(t *testing.T) {

--- a/tests/csapi/apidoc_logout_test.go
+++ b/tests/csapi/apidoc_logout_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
@@ -18,7 +19,10 @@ func TestLogout(t *testing.T) {
 	defer deployment.Destroy(t)
 
 	password := "superuser"
-	verifyClientUser := deployment.RegisterUser(t, "hs1", "testuser", password, false)
+	verifyClientUser := deployment.Register(t, "hs1", helpers.RegistrationOpts{
+		Localpart: "testuser",
+		Password:  password,
+	})
 
 	// sytest: Can logout current device
 	t.Run("Can logout current device", func(t *testing.T) {

--- a/tests/csapi/apidoc_logout_test.go
+++ b/tests/csapi/apidoc_logout_test.go
@@ -8,14 +8,13 @@ import (
 	"github.com/tidwall/gjson"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
 
 func TestLogout(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	password := "superuser"

--- a/tests/csapi/apidoc_logout_test.go
+++ b/tests/csapi/apidoc_logout_test.go
@@ -20,8 +20,7 @@ func TestLogout(t *testing.T) {
 
 	password := "superuser"
 	verifyClientUser := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-		Localpart: "testuser",
-		Password:  password,
+		Password: password,
 	})
 
 	// sytest: Can logout current device

--- a/tests/csapi/apidoc_presence_test.go
+++ b/tests/csapi/apidoc_presence_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestPresence(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})

--- a/tests/csapi/apidoc_presence_test.go
+++ b/tests/csapi/apidoc_presence_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
@@ -21,8 +22,8 @@ func TestPresence(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	bob := deployment.Client(t, "hs1", "@bob:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	// sytest: GET /presence/:user_id/status fetches initial status
 	t.Run("GET /presence/:user_id/status fetches initial status", func(t *testing.T) {

--- a/tests/csapi/apidoc_profile_avatar_url_test.go
+++ b/tests/csapi/apidoc_profile_avatar_url_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
@@ -13,8 +14,8 @@ import (
 func TestProfileAvatarURL(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
-	unauthedClient := deployment.Client(t, "hs1", "")
-	authedClient := deployment.Client(t, "hs1", "@alice:hs1")
+	unauthedClient := deployment.UnauthenticatedClient(t, "hs1")
+	authedClient := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 	avatarURL := "mxc://example.com/SEsfnsuifSDFSSEF"
 	// sytest: PUT /profile/:user_id/avatar_url sets my avatar
 	t.Run("PUT /profile/:user_id/avatar_url sets my avatar", func(t *testing.T) {

--- a/tests/csapi/apidoc_profile_avatar_url_test.go
+++ b/tests/csapi/apidoc_profile_avatar_url_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
@@ -12,7 +11,7 @@ import (
 )
 
 func TestProfileAvatarURL(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 	unauthedClient := deployment.UnauthenticatedClient(t, "hs1")
 	authedClient := deployment.Register(t, "hs1", helpers.RegistrationOpts{})

--- a/tests/csapi/apidoc_profile_displayname_test.go
+++ b/tests/csapi/apidoc_profile_displayname_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
@@ -13,8 +14,8 @@ import (
 func TestProfileDisplayName(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
-	unauthedClient := deployment.Client(t, "hs1", "")
-	authedClient := deployment.Client(t, "hs1", "@alice:hs1")
+	unauthedClient := deployment.UnauthenticatedClient(t, "hs1")
+	authedClient := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 	displayName := "my_display_name"
 	// sytest: PUT /profile/:user_id/displayname sets my name
 	t.Run("PUT /profile/:user_id/displayname sets my name", func(t *testing.T) {

--- a/tests/csapi/apidoc_profile_displayname_test.go
+++ b/tests/csapi/apidoc_profile_displayname_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
@@ -12,7 +11,7 @@ import (
 )
 
 func TestProfileDisplayName(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 	unauthedClient := deployment.UnauthenticatedClient(t, "hs1")
 	authedClient := deployment.Register(t, "hs1", helpers.RegistrationOpts{})

--- a/tests/csapi/apidoc_register_test.go
+++ b/tests/csapi/apidoc_register_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/tidwall/gjson"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
@@ -37,7 +36,7 @@ import (
 // Can register using an email address
 
 func TestRegistration(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 	unauthedClient := deployment.UnauthenticatedClient(t, "hs1")
 	t.Run("parallel", func(t *testing.T) {

--- a/tests/csapi/apidoc_register_test.go
+++ b/tests/csapi/apidoc_register_test.go
@@ -39,7 +39,7 @@ import (
 func TestRegistration(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
-	unauthedClient := deployment.Client(t, "hs1", "")
+	unauthedClient := deployment.UnauthenticatedClient(t, "hs1")
 	t.Run("parallel", func(t *testing.T) {
 		// sytest: GET /register yields a set of flows
 		// The name in Sytest is different, the test is actually doing a POST request.

--- a/tests/csapi/apidoc_register_test.go
+++ b/tests/csapi/apidoc_register_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
@@ -181,7 +182,10 @@ func TestRegistration(t *testing.T) {
 			for x := range testChars {
 				localpart := fmt.Sprintf("chrtestuser%s", string(testChars[x]))
 				t.Run(string(testChars[x]), func(t *testing.T) {
-					deployment.RegisterUser(t, "hs1", localpart, "sUp3rs3kr1t", false)
+					deployment.Register(t, "hs1", helpers.RegistrationOpts{
+						Localpart: localpart,
+						Password:  "sUp3rs3kr1t",
+					})
 				})
 			}
 		})
@@ -275,7 +279,7 @@ func TestRegistration(t *testing.T) {
 			t.Parallel()
 			testUserName := "username_not_available"
 			// Don't need the return value here, just need a user to be registered to test against
-			_ = deployment.NewUser(t, testUserName, "hs1")
+			deployment.Register(t, "hs1", helpers.RegistrationOpts{Localpart: testUserName})
 			res := unauthedClient.Do(t, "GET", []string{"_matrix", "client", "v3", "register", "available"}, client.WithQueries(url.Values{
 				"username": []string{testUserName},
 			}))

--- a/tests/csapi/apidoc_request_encoding_test.go
+++ b/tests/csapi/apidoc_request_encoding_test.go
@@ -6,14 +6,13 @@ import (
 	"encoding/json"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
 
 func TestRequestEncodingFails(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 	unauthedClient := deployment.UnauthenticatedClient(t, "hs1")
 	testString := `{ "test":"a` + "\x81" + `" }`

--- a/tests/csapi/apidoc_request_encoding_test.go
+++ b/tests/csapi/apidoc_request_encoding_test.go
@@ -15,7 +15,7 @@ import (
 func TestRequestEncodingFails(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
-	unauthedClient := deployment.Client(t, "hs1", "")
+	unauthedClient := deployment.UnauthenticatedClient(t, "hs1")
 	testString := `{ "test":"a` + "\x81" + `" }`
 	// sytest: POST rejects invalid utf-8 in JSON
 	t.Run("POST rejects invalid utf-8 in JSON", func(t *testing.T) {

--- a/tests/csapi/apidoc_room_alias_test.go
+++ b/tests/csapi/apidoc_room_alias_test.go
@@ -61,7 +61,7 @@ func mustSetCanonicalAlias(t *testing.T, c *client.CSAPI, roomID string, roomAli
 }
 
 func TestRoomAlias(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
@@ -187,7 +187,7 @@ func TestRoomAlias(t *testing.T) {
 }
 
 func TestRoomDeleteAlias(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
@@ -458,7 +458,7 @@ func TestRoomDeleteAlias(t *testing.T) {
 }
 
 func TestRoomCanonicalAlias(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 

--- a/tests/csapi/apidoc_room_alias_test.go
+++ b/tests/csapi/apidoc_room_alias_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 	"github.com/matrix-org/complement/should"
@@ -62,8 +63,8 @@ func mustSetCanonicalAlias(t *testing.T, c *client.CSAPI, roomID string, roomAli
 func TestRoomAlias(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	bob := deployment.Client(t, "hs1", "@bob:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	t.Run("Parallel", func(t *testing.T) {
 		// sytest: PUT /directory/room/:room_alias creates alias
@@ -188,8 +189,8 @@ func TestRoomAlias(t *testing.T) {
 func TestRoomDeleteAlias(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	bob := deployment.Client(t, "hs1", "@bob:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	t.Run("Parallel", func(t *testing.T) {
 		// sytest: Alias creators can delete alias with no ops
@@ -459,7 +460,7 @@ func TestRoomDeleteAlias(t *testing.T) {
 func TestRoomCanonicalAlias(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	t.Run("Parallel", func(t *testing.T) {
 

--- a/tests/csapi/apidoc_room_create_test.go
+++ b/tests/csapi/apidoc_room_create_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestRoomCreate(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})

--- a/tests/csapi/apidoc_room_create_test.go
+++ b/tests/csapi/apidoc_room_create_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
@@ -16,8 +17,8 @@ func TestRoomCreate(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	bob := deployment.Client(t, "hs1", "@bob:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	t.Run("Parallel", func(t *testing.T) {
 		// sytest: POST /createRoom makes a public room

--- a/tests/csapi/apidoc_room_forget_test.go
+++ b/tests/csapi/apidoc_room_forget_test.go
@@ -18,7 +18,7 @@ import (
 
 // These tests ensure that forgetting about rooms works as intended
 func TestRoomForget(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})

--- a/tests/csapi/apidoc_room_forget_test.go
+++ b/tests/csapi/apidoc_room_forget_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
@@ -20,8 +21,8 @@ func TestRoomForget(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	bob := deployment.Client(t, "hs1", "@bob:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 	t.Run("Parallel", func(t *testing.T) {
 		// sytest: Can't forget room you're still in
 		t.Run("Can't forget room you're still in", func(t *testing.T) {

--- a/tests/csapi/apidoc_room_history_visibility_test.go
+++ b/tests/csapi/apidoc_room_history_visibility_test.go
@@ -38,7 +38,7 @@ func createRoomWithVisibility(t *testing.T, c *client.CSAPI, visibility string) 
 // Fetches an event after join, and succeeds.
 // sytest: /event/ on joined room works
 func TestFetchEvent(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
@@ -84,7 +84,7 @@ func TestFetchEvent(t *testing.T) {
 // history_visibility: joined
 // sytest: /event/ does not allow access to events before the user joined
 func TestFetchHistoricalJoinedEventDenied(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
@@ -113,7 +113,7 @@ func TestFetchHistoricalJoinedEventDenied(t *testing.T) {
 // Tries to fetch an event before join, and succeeds.
 // history_visibility: shared
 func TestFetchHistoricalSharedEvent(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
@@ -157,7 +157,7 @@ func TestFetchHistoricalSharedEvent(t *testing.T) {
 // Tries to fetch an event between being invited and joined, and succeeds.
 // history_visibility: invited
 func TestFetchHistoricalInvitedEventFromBetweenInvite(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
@@ -204,7 +204,7 @@ func TestFetchHistoricalInvitedEventFromBetweenInvite(t *testing.T) {
 // Tries to fetch an event before being invited, and fails.
 // history_visibility: invited
 func TestFetchHistoricalInvitedEventFromBeforeInvite(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
@@ -237,7 +237,7 @@ func TestFetchHistoricalInvitedEventFromBeforeInvite(t *testing.T) {
 // history_visibility: shared
 // sytest: /event/ on non world readable room does not work
 func TestFetchEventNonWorldReadable(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
@@ -263,7 +263,7 @@ func TestFetchEventNonWorldReadable(t *testing.T) {
 // Tries to fetch an event without having joined, and succeeds.
 // history_visibility: world_readable
 func TestFetchEventWorldReadable(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})

--- a/tests/csapi/apidoc_room_history_visibility_test.go
+++ b/tests/csapi/apidoc_room_history_visibility_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
@@ -40,8 +41,8 @@ func TestFetchEvent(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	bob := deployment.Client(t, "hs1", "@bob:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	roomID := createRoomWithVisibility(t, alice, "shared")
 
@@ -86,8 +87,8 @@ func TestFetchHistoricalJoinedEventDenied(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	bob := deployment.Client(t, "hs1", "@bob:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	roomID := createRoomWithVisibility(t, alice, "joined")
 
@@ -115,8 +116,8 @@ func TestFetchHistoricalSharedEvent(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	bob := deployment.Client(t, "hs1", "@bob:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	roomID := createRoomWithVisibility(t, alice, "shared")
 
@@ -159,8 +160,8 @@ func TestFetchHistoricalInvitedEventFromBetweenInvite(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	bob := deployment.Client(t, "hs1", "@bob:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	roomID := createRoomWithVisibility(t, alice, "invited")
 
@@ -206,8 +207,8 @@ func TestFetchHistoricalInvitedEventFromBeforeInvite(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	bob := deployment.Client(t, "hs1", "@bob:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	roomID := createRoomWithVisibility(t, alice, "invited")
 
@@ -239,8 +240,8 @@ func TestFetchEventNonWorldReadable(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	bob := deployment.Client(t, "hs1", "@bob:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	roomID := createRoomWithVisibility(t, alice, "shared")
 
@@ -265,8 +266,8 @@ func TestFetchEventWorldReadable(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	bob := deployment.Client(t, "hs1", "@bob:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	roomID := createRoomWithVisibility(t, alice, "world_readable")
 

--- a/tests/csapi/apidoc_room_members_test.go
+++ b/tests/csapi/apidoc_room_members_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
@@ -15,8 +16,8 @@ import (
 func TestRoomMembers(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	bob := deployment.Client(t, "hs1", "@bob:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 	t.Run("Parallel", func(t *testing.T) {
 		// sytest: POST /rooms/:room_id/join can join a room
 		t.Run("POST /rooms/:room_id/join can join a room", func(t *testing.T) {

--- a/tests/csapi/apidoc_room_members_test.go
+++ b/tests/csapi/apidoc_room_members_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestRoomMembers(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{})

--- a/tests/csapi/apidoc_room_receipts_test.go
+++ b/tests/csapi/apidoc_room_receipts_test.go
@@ -6,13 +6,12 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
-	"github.com/matrix-org/complement/internal/docker"
 	"github.com/tidwall/gjson"
 )
 
 // tests/10apidoc/37room-receipts.pl
 
-func createRoomForReadReceipts(t *testing.T, c *client.CSAPI, deployment *docker.Deployment) (string, string) {
+func createRoomForReadReceipts(t *testing.T, c *client.CSAPI, deployment complement.Deployment) (string, string) {
 	roomID := c.MustCreateRoom(t, map[string]interface{}{"preset": "public_chat"})
 
 	c.MustSyncUntil(t, client.SyncReq{}, client.SyncJoinedTo(c.UserID, roomID))

--- a/tests/csapi/apidoc_room_receipts_test.go
+++ b/tests/csapi/apidoc_room_receipts_test.go
@@ -37,7 +37,7 @@ func syncHasReadReceipt(roomID, userID, eventID string) client.SyncCheckOpt {
 
 // sytest: POST /rooms/:room_id/receipt can create receipts
 func TestRoomReceipts(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 	roomID, eventID := createRoomForReadReceipts(t, alice, deployment)
@@ -50,7 +50,7 @@ func TestRoomReceipts(t *testing.T) {
 
 // sytest: POST /rooms/:room_id/read_markers can create read marker
 func TestRoomReadMarkers(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 	roomID, eventID := createRoomForReadReceipts(t, alice, deployment)

--- a/tests/csapi/apidoc_room_receipts_test.go
+++ b/tests/csapi/apidoc_room_receipts_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/tidwall/gjson"
 )
 
@@ -38,7 +39,7 @@ func syncHasReadReceipt(roomID, userID, eventID string) client.SyncCheckOpt {
 func TestRoomReceipts(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 	roomID, eventID := createRoomForReadReceipts(t, alice, deployment)
 
 	alice.MustDo(t, "POST", []string{"_matrix", "client", "v3", "rooms", roomID, "receipt", "m.read", eventID}, client.WithJSONBody(t, struct{}{}))
@@ -51,7 +52,7 @@ func TestRoomReceipts(t *testing.T) {
 func TestRoomReadMarkers(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 	roomID, eventID := createRoomForReadReceipts(t, alice, deployment)
 
 	reqBody := client.WithJSONBody(t, map[string]interface{}{

--- a/tests/csapi/apidoc_room_state_test.go
+++ b/tests/csapi/apidoc_room_state_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/tidwall/gjson"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
@@ -17,7 +16,7 @@ import (
 )
 
 func TestRoomState(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 	authedClient := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 	t.Run("Parallel", func(t *testing.T) {

--- a/tests/csapi/apidoc_room_state_test.go
+++ b/tests/csapi/apidoc_room_state_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
@@ -18,7 +19,7 @@ import (
 func TestRoomState(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
-	authedClient := deployment.Client(t, "hs1", "@alice:hs1")
+	authedClient := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 	t.Run("Parallel", func(t *testing.T) {
 		// sytest: GET /rooms/:room_id/state/m.room.member/:user_id fetches my membership
 		t.Run("GET /rooms/:room_id/state/m.room.member/:user_id fetches my membership", func(t *testing.T) {

--- a/tests/csapi/apidoc_search_test.go
+++ b/tests/csapi/apidoc_search_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
@@ -21,7 +22,7 @@ func TestSearch(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	t.Run("parallel", func(t *testing.T) {
 		// sytest: Can search for an event by body

--- a/tests/csapi/apidoc_search_test.go
+++ b/tests/csapi/apidoc_search_test.go
@@ -19,7 +19,7 @@ import (
 // Note: In contrast to Sytest, we define a filter.rooms on each search request, this is to mimic
 // creating a new user and new room per test. This also allows us to run in parallel.
 func TestSearch(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})

--- a/tests/csapi/apidoc_server_capabilities_test.go
+++ b/tests/csapi/apidoc_server_capabilities_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
@@ -14,8 +15,8 @@ func TestServerCapabilities(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
-	unauthedClient := deployment.Client(t, "hs1", "")
-	authedClient := deployment.Client(t, "hs1", "@alice:hs1")
+	unauthedClient := deployment.UnauthenticatedClient(t, "hs1")
+	authedClient := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	// sytest: GET /capabilities is present and well formed for registered user
 	data := authedClient.GetCapabilities(t)

--- a/tests/csapi/apidoc_server_capabilities_test.go
+++ b/tests/csapi/apidoc_server_capabilities_test.go
@@ -5,14 +5,13 @@ import (
 	"testing"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
 
 func TestServerCapabilities(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	unauthedClient := deployment.UnauthenticatedClient(t, "hs1")

--- a/tests/csapi/apidoc_version_test.go
+++ b/tests/csapi/apidoc_version_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/tidwall/gjson"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
@@ -22,7 +21,7 @@ const GlobalVersionRegex = `v[1-9]\d*\.\d+(?:-\S+)?`
 const r0Regex = `r0\.\d+\.\d+`
 
 func TestVersionStructure(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	client := deployment.UnauthenticatedClient(t, "hs1")

--- a/tests/csapi/apidoc_version_test.go
+++ b/tests/csapi/apidoc_version_test.go
@@ -25,7 +25,7 @@ func TestVersionStructure(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
-	client := deployment.Client(t, "hs1", "")
+	client := deployment.UnauthenticatedClient(t, "hs1")
 
 	// sytest: Version responds 200 OK with valid structure
 	t.Run("Version responds 200 OK with valid structure", func(t *testing.T) {

--- a/tests/csapi/device_lists_test.go
+++ b/tests/csapi/device_lists_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 	"github.com/matrix-org/complement/runtime"
@@ -117,7 +118,10 @@ func TestDeviceListUpdates(t *testing.T) {
 	) func(t *testing.T, nextBatch string) string {
 		t.Helper()
 
-		barry := deployment.RegisterUser(t, otherHSName, generateLocalpart("barry"), "password", false)
+		barry := deployment.Register(t, otherHSName, helpers.RegistrationOpts{
+			Localpart: generateLocalpart("barry"),
+			Password:  "password",
+		})
 
 		// The observing user must share a room with the dummy barrier user.
 		roomID := barry.MustCreateRoom(t, map[string]interface{}{"preset": "public_chat"})
@@ -142,8 +146,14 @@ func TestDeviceListUpdates(t *testing.T) {
 
 	// testOtherUserJoin tests another user joining a room Alice is already in.
 	testOtherUserJoin := func(t *testing.T, deployment complement.Deployment, hsName string, otherHSName string) {
-		alice := deployment.RegisterUser(t, hsName, generateLocalpart("alice"), "password", false)
-		bob := deployment.RegisterUser(t, otherHSName, generateLocalpart("bob"), "password", false)
+		alice := deployment.Register(t, hsName, helpers.RegistrationOpts{
+			Localpart: generateLocalpart("alice"),
+			Password:  "password",
+		})
+		bob := deployment.Register(t, otherHSName, helpers.RegistrationOpts{
+			Localpart: generateLocalpart("bob"),
+			Password:  "password",
+		})
 		barrier := makeBarrier(t, deployment, alice, otherHSName)
 		checkBobKeys := uploadNewKeys(t, bob)
 
@@ -189,8 +199,14 @@ func TestDeviceListUpdates(t *testing.T) {
 	testJoin := func(
 		t *testing.T, deployment complement.Deployment, hsName string, otherHSName string,
 	) {
-		alice := deployment.RegisterUser(t, hsName, generateLocalpart("alice"), "password", false)
-		bob := deployment.RegisterUser(t, otherHSName, generateLocalpart("bob"), "password", false)
+		alice := deployment.Register(t, hsName, helpers.RegistrationOpts{
+			Localpart: generateLocalpart("alice"),
+			Password:  "password",
+		})
+		bob := deployment.Register(t, otherHSName, helpers.RegistrationOpts{
+			Localpart: generateLocalpart("bob"),
+			Password:  "password",
+		})
 		barrier := makeBarrier(t, deployment, alice, otherHSName)
 		checkBobKeys := uploadNewKeys(t, bob)
 
@@ -234,8 +250,14 @@ func TestDeviceListUpdates(t *testing.T) {
 
 	// testOtherUserLeave tests another user leaving a room Alice is in.
 	testOtherUserLeave := func(t *testing.T, deployment complement.Deployment, hsName string, otherHSName string) {
-		alice := deployment.RegisterUser(t, hsName, generateLocalpart("alice"), "password", false)
-		bob := deployment.RegisterUser(t, otherHSName, generateLocalpart("bob"), "password", false)
+		alice := deployment.Register(t, hsName, helpers.RegistrationOpts{
+			Localpart: generateLocalpart("alice"),
+			Password:  "password",
+		})
+		bob := deployment.Register(t, otherHSName, helpers.RegistrationOpts{
+			Localpart: generateLocalpart("bob"),
+			Password:  "password",
+		})
 		barrier := makeBarrier(t, deployment, alice, otherHSName)
 		checkBobKeys := uploadNewKeys(t, bob)
 
@@ -285,8 +307,14 @@ func TestDeviceListUpdates(t *testing.T) {
 
 	// testLeave tests Alice leaving a room another user is in.
 	testLeave := func(t *testing.T, deployment complement.Deployment, hsName string, otherHSName string) {
-		alice := deployment.RegisterUser(t, hsName, generateLocalpart("alice"), "password", false)
-		bob := deployment.RegisterUser(t, otherHSName, generateLocalpart("bob"), "password", false)
+		alice := deployment.Register(t, hsName, helpers.RegistrationOpts{
+			Localpart: generateLocalpart("alice"),
+			Password:  "password",
+		})
+		bob := deployment.Register(t, otherHSName, helpers.RegistrationOpts{
+			Localpart: generateLocalpart("bob"),
+			Password:  "password",
+		})
 		barrier := makeBarrier(t, deployment, alice, otherHSName)
 		checkBobKeys := uploadNewKeys(t, bob)
 
@@ -336,8 +364,14 @@ func TestDeviceListUpdates(t *testing.T) {
 
 	// testOtherUserRejoin tests another user leaving and rejoining a room Alice is in.
 	testOtherUserRejoin := func(t *testing.T, deployment complement.Deployment, hsName string, otherHSName string) {
-		alice := deployment.RegisterUser(t, hsName, generateLocalpart("alice"), "password", false)
-		bob := deployment.RegisterUser(t, otherHSName, generateLocalpart("bob"), "password", false)
+		alice := deployment.Register(t, hsName, helpers.RegistrationOpts{
+			Localpart: generateLocalpart("alice"),
+			Password:  "password",
+		})
+		bob := deployment.Register(t, otherHSName, helpers.RegistrationOpts{
+			Localpart: generateLocalpart("bob"),
+			Password:  "password",
+		})
 		barrier := makeBarrier(t, deployment, alice, otherHSName)
 		checkBobKeys := uploadNewKeys(t, bob)
 

--- a/tests/csapi/device_lists_test.go
+++ b/tests/csapi/device_lists_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
-	"github.com/matrix-org/complement/internal/docker"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 	"github.com/matrix-org/complement/runtime"
@@ -112,7 +111,7 @@ func TestDeviceListUpdates(t *testing.T) {
 	// updates and queries before the barrier do not appear in `/sync` responses after the barrier.
 	makeBarrier := func(
 		t *testing.T,
-		deployment *docker.Deployment,
+		deployment complement.Deployment,
 		observingUser *client.CSAPI,
 		otherHSName string,
 	) func(t *testing.T, nextBatch string) string {
@@ -142,7 +141,7 @@ func TestDeviceListUpdates(t *testing.T) {
 	// We only care about what Alice sees.
 
 	// testOtherUserJoin tests another user joining a room Alice is already in.
-	testOtherUserJoin := func(t *testing.T, deployment *docker.Deployment, hsName string, otherHSName string) {
+	testOtherUserJoin := func(t *testing.T, deployment complement.Deployment, hsName string, otherHSName string) {
 		alice := deployment.RegisterUser(t, hsName, generateLocalpart("alice"), "password", false)
 		bob := deployment.RegisterUser(t, otherHSName, generateLocalpart("bob"), "password", false)
 		barrier := makeBarrier(t, deployment, alice, otherHSName)
@@ -188,7 +187,7 @@ func TestDeviceListUpdates(t *testing.T) {
 
 	// testJoin tests Alice joining a room another user is already in.
 	testJoin := func(
-		t *testing.T, deployment *docker.Deployment, hsName string, otherHSName string,
+		t *testing.T, deployment complement.Deployment, hsName string, otherHSName string,
 	) {
 		alice := deployment.RegisterUser(t, hsName, generateLocalpart("alice"), "password", false)
 		bob := deployment.RegisterUser(t, otherHSName, generateLocalpart("bob"), "password", false)
@@ -234,7 +233,7 @@ func TestDeviceListUpdates(t *testing.T) {
 	}
 
 	// testOtherUserLeave tests another user leaving a room Alice is in.
-	testOtherUserLeave := func(t *testing.T, deployment *docker.Deployment, hsName string, otherHSName string) {
+	testOtherUserLeave := func(t *testing.T, deployment complement.Deployment, hsName string, otherHSName string) {
 		alice := deployment.RegisterUser(t, hsName, generateLocalpart("alice"), "password", false)
 		bob := deployment.RegisterUser(t, otherHSName, generateLocalpart("bob"), "password", false)
 		barrier := makeBarrier(t, deployment, alice, otherHSName)
@@ -285,7 +284,7 @@ func TestDeviceListUpdates(t *testing.T) {
 	}
 
 	// testLeave tests Alice leaving a room another user is in.
-	testLeave := func(t *testing.T, deployment *docker.Deployment, hsName string, otherHSName string) {
+	testLeave := func(t *testing.T, deployment complement.Deployment, hsName string, otherHSName string) {
 		alice := deployment.RegisterUser(t, hsName, generateLocalpart("alice"), "password", false)
 		bob := deployment.RegisterUser(t, otherHSName, generateLocalpart("bob"), "password", false)
 		barrier := makeBarrier(t, deployment, alice, otherHSName)
@@ -336,7 +335,7 @@ func TestDeviceListUpdates(t *testing.T) {
 	}
 
 	// testOtherUserRejoin tests another user leaving and rejoining a room Alice is in.
-	testOtherUserRejoin := func(t *testing.T, deployment *docker.Deployment, hsName string, otherHSName string) {
+	testOtherUserRejoin := func(t *testing.T, deployment complement.Deployment, hsName string, otherHSName string) {
 		alice := deployment.RegisterUser(t, hsName, generateLocalpart("alice"), "password", false)
 		bob := deployment.RegisterUser(t, otherHSName, generateLocalpart("bob"), "password", false)
 		barrier := makeBarrier(t, deployment, alice, otherHSName)

--- a/tests/csapi/device_lists_test.go
+++ b/tests/csapi/device_lists_test.go
@@ -2,7 +2,6 @@ package csapi_tests
 
 import (
 	"fmt"
-	"sync/atomic"
 	"testing"
 
 	"github.com/matrix-org/complement"
@@ -21,13 +20,6 @@ import (
 //  1. `/sync`'s `device_lists.changed/left` contain the correct user IDs.
 //  2. `/keys/query` returns the correct information after device list updates.
 func TestDeviceListUpdates(t *testing.T) {
-	var localpartIndex int64 = 0
-	// generateLocalpart generates a unique localpart based on the given name.
-	generateLocalpart := func(localpart string) string {
-		index := atomic.AddInt64(&localpartIndex, 1)
-		return fmt.Sprintf("%s%d", localpart, index)
-	}
-
 	// uploadNewKeys uploads a new set of keys for a given client.
 	// Returns a check function that can be passed to mustQueryKeys.
 	uploadNewKeys := func(t *testing.T, user *client.CSAPI) []match.JSON {
@@ -119,8 +111,8 @@ func TestDeviceListUpdates(t *testing.T) {
 		t.Helper()
 
 		barry := deployment.Register(t, otherHSName, helpers.RegistrationOpts{
-			Localpart: generateLocalpart("barry"),
-			Password:  "password",
+			LocalpartSuffix: "barry",
+			Password:        "password",
 		})
 
 		// The observing user must share a room with the dummy barrier user.
@@ -147,12 +139,12 @@ func TestDeviceListUpdates(t *testing.T) {
 	// testOtherUserJoin tests another user joining a room Alice is already in.
 	testOtherUserJoin := func(t *testing.T, deployment complement.Deployment, hsName string, otherHSName string) {
 		alice := deployment.Register(t, hsName, helpers.RegistrationOpts{
-			Localpart: generateLocalpart("alice"),
-			Password:  "password",
+			LocalpartSuffix: "alice",
+			Password:        "password",
 		})
 		bob := deployment.Register(t, otherHSName, helpers.RegistrationOpts{
-			Localpart: generateLocalpart("bob"),
-			Password:  "password",
+			LocalpartSuffix: "bob",
+			Password:        "password",
 		})
 		barrier := makeBarrier(t, deployment, alice, otherHSName)
 		checkBobKeys := uploadNewKeys(t, bob)
@@ -200,12 +192,12 @@ func TestDeviceListUpdates(t *testing.T) {
 		t *testing.T, deployment complement.Deployment, hsName string, otherHSName string,
 	) {
 		alice := deployment.Register(t, hsName, helpers.RegistrationOpts{
-			Localpart: generateLocalpart("alice"),
-			Password:  "password",
+			LocalpartSuffix: "alice",
+			Password:        "password",
 		})
 		bob := deployment.Register(t, otherHSName, helpers.RegistrationOpts{
-			Localpart: generateLocalpart("bob"),
-			Password:  "password",
+			LocalpartSuffix: "bob",
+			Password:        "password",
 		})
 		barrier := makeBarrier(t, deployment, alice, otherHSName)
 		checkBobKeys := uploadNewKeys(t, bob)
@@ -251,12 +243,12 @@ func TestDeviceListUpdates(t *testing.T) {
 	// testOtherUserLeave tests another user leaving a room Alice is in.
 	testOtherUserLeave := func(t *testing.T, deployment complement.Deployment, hsName string, otherHSName string) {
 		alice := deployment.Register(t, hsName, helpers.RegistrationOpts{
-			Localpart: generateLocalpart("alice"),
-			Password:  "password",
+			LocalpartSuffix: "alice",
+			Password:        "password",
 		})
 		bob := deployment.Register(t, otherHSName, helpers.RegistrationOpts{
-			Localpart: generateLocalpart("bob"),
-			Password:  "password",
+			LocalpartSuffix: "bob",
+			Password:        "password",
 		})
 		barrier := makeBarrier(t, deployment, alice, otherHSName)
 		checkBobKeys := uploadNewKeys(t, bob)
@@ -308,12 +300,12 @@ func TestDeviceListUpdates(t *testing.T) {
 	// testLeave tests Alice leaving a room another user is in.
 	testLeave := func(t *testing.T, deployment complement.Deployment, hsName string, otherHSName string) {
 		alice := deployment.Register(t, hsName, helpers.RegistrationOpts{
-			Localpart: generateLocalpart("alice"),
-			Password:  "password",
+			LocalpartSuffix: "alice",
+			Password:        "password",
 		})
 		bob := deployment.Register(t, otherHSName, helpers.RegistrationOpts{
-			Localpart: generateLocalpart("bob"),
-			Password:  "password",
+			LocalpartSuffix: "bob",
+			Password:        "password",
 		})
 		barrier := makeBarrier(t, deployment, alice, otherHSName)
 		checkBobKeys := uploadNewKeys(t, bob)
@@ -365,12 +357,12 @@ func TestDeviceListUpdates(t *testing.T) {
 	// testOtherUserRejoin tests another user leaving and rejoining a room Alice is in.
 	testOtherUserRejoin := func(t *testing.T, deployment complement.Deployment, hsName string, otherHSName string) {
 		alice := deployment.Register(t, hsName, helpers.RegistrationOpts{
-			Localpart: generateLocalpart("alice"),
-			Password:  "password",
+			LocalpartSuffix: "alice",
+			Password:        "password",
 		})
 		bob := deployment.Register(t, otherHSName, helpers.RegistrationOpts{
-			Localpart: generateLocalpart("bob"),
-			Password:  "password",
+			LocalpartSuffix: "bob",
+			Password:        "password",
 		})
 		barrier := makeBarrier(t, deployment, alice, otherHSName)
 		checkBobKeys := uploadNewKeys(t, bob)

--- a/tests/csapi/device_lists_test.go
+++ b/tests/csapi/device_lists_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
@@ -422,7 +421,7 @@ func TestDeviceListUpdates(t *testing.T) {
 	// Create two homeservers
 	// The users and rooms in the blueprint won't be used.
 	// Each test creates their own Alice and Bob users.
-	deployment := complement.Deploy(t, b.BlueprintFederationOneToOneRoom)
+	deployment := complement.Deploy(t, 2)
 	defer deployment.Destroy(t)
 
 	t.Run("when local user joins a room", func(t *testing.T) { testOtherUserJoin(t, deployment, "hs1", "hs1") })

--- a/tests/csapi/e2e_key_backup_test.go
+++ b/tests/csapi/e2e_key_backup_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
@@ -25,7 +24,7 @@ type backupKey struct {
 //	if they have the same values for is_verified, then it will keep the key with a lower first_message_index;
 //	and finally, is is_verified and first_message_index are equal, then it will keep the key with a lower forwarded_count.
 func TestE2EKeyBackupReplaceRoomKeyRules(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 	roomID := "!foo:hs1"
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})

--- a/tests/csapi/e2e_key_backup_test.go
+++ b/tests/csapi/e2e_key_backup_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
@@ -26,9 +27,8 @@ type backupKey struct {
 func TestE2EKeyBackupReplaceRoomKeyRules(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
-	userID := "@alice:hs1"
 	roomID := "!foo:hs1"
-	alice := deployment.Client(t, "hs1", userID)
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	// make a new key backup
 	res := alice.MustDo(t, "POST", []string{"_matrix", "client", "v3", "room_keys", "version"}, client.WithJSONBody(t, map[string]interface{}{

--- a/tests/csapi/ignored_users_test.go
+++ b/tests/csapi/ignored_users_test.go
@@ -31,9 +31,9 @@ import (
 func TestInviteFromIgnoredUsersDoesNotAppearInSync(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintCleanHS)
 	defer deployment.Destroy(t)
-	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{Localpart: "alice"})
-	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{Localpart: "bob"})
-	chris := deployment.Register(t, "hs1", helpers.RegistrationOpts{Localpart: "chris"})
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{LocalpartSuffix: "alice"})
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{LocalpartSuffix: "bob"})
+	chris := deployment.Register(t, "hs1", helpers.RegistrationOpts{LocalpartSuffix: "chris"})
 
 	// Alice creates a room for herself.
 	publicRoom := alice.MustCreateRoom(t, map[string]interface{}{

--- a/tests/csapi/ignored_users_test.go
+++ b/tests/csapi/ignored_users_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
@@ -30,9 +31,9 @@ import (
 func TestInviteFromIgnoredUsersDoesNotAppearInSync(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintCleanHS)
 	defer deployment.Destroy(t)
-	alice := deployment.RegisterUser(t, "hs1", "alice", "sufficiently_long_password_alice", false)
-	bob := deployment.RegisterUser(t, "hs1", "bob", "sufficiently_long_password_bob", false)
-	chris := deployment.RegisterUser(t, "hs1", "chris", "sufficiently_long_password_chris", false)
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{Localpart: "alice"})
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{Localpart: "bob"})
+	chris := deployment.Register(t, "hs1", helpers.RegistrationOpts{Localpart: "chris"})
 
 	// Alice creates a room for herself.
 	publicRoom := alice.MustCreateRoom(t, map[string]interface{}{

--- a/tests/csapi/ignored_users_test.go
+++ b/tests/csapi/ignored_users_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/tidwall/gjson"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
@@ -29,7 +28,7 @@ import (
 // https://github.com/matrix-org/synapse/issues/11506
 // to ensure that Synapse complies with this part of the spec.
 func TestInviteFromIgnoredUsersDoesNotAppearInSync(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintCleanHS)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{LocalpartSuffix: "alice"})
 	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{LocalpartSuffix: "bob"})

--- a/tests/csapi/invalid_test.go
+++ b/tests/csapi/invalid_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
@@ -14,7 +13,7 @@ import (
 )
 
 func TestJson(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 	roomID := alice.MustCreateRoom(t, map[string]interface{}{
@@ -172,7 +171,7 @@ func getFilters() []map[string]interface{} {
 func TestFilter(t *testing.T) {
 	runtime.SkipIf(t, runtime.Dendrite) // FIXME: https://github.com/matrix-org/dendrite/issues/2067
 
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
@@ -189,7 +188,7 @@ func TestFilter(t *testing.T) {
 
 // sytest: Event size limits
 func TestEvent(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 	roomID := alice.MustCreateRoom(t, map[string]interface{}{

--- a/tests/csapi/invalid_test.go
+++ b/tests/csapi/invalid_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 	"github.com/matrix-org/complement/runtime"
@@ -15,7 +16,7 @@ import (
 func TestJson(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 	roomID := alice.MustCreateRoom(t, map[string]interface{}{
 		"room_opts": map[string]interface{}{
 			"room_version": "6",
@@ -173,7 +174,7 @@ func TestFilter(t *testing.T) {
 
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	filters := getFilters()
 
@@ -190,7 +191,7 @@ func TestFilter(t *testing.T) {
 func TestEvent(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 	roomID := alice.MustCreateRoom(t, map[string]interface{}{
 		"room_opts": map[string]interface{}{
 			"room_version": "6",

--- a/tests/csapi/keychanges_test.go
+++ b/tests/csapi/keychanges_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
@@ -21,7 +22,10 @@ func TestKeyChangesLocal(t *testing.T) {
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
 	password := "$uperSecretPassword"
-	bob := deployment.RegisterUser(t, "hs1", "bob", password, false)
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{
+		Localpart: "bob",
+		Password:  password,
+	})
 	unauthedClient := deployment.Client(t, "hs1", "")
 
 	t.Run("New login should create a device_lists.changed entry", func(t *testing.T) {

--- a/tests/csapi/keychanges_test.go
+++ b/tests/csapi/keychanges_test.go
@@ -23,8 +23,8 @@ func TestKeyChangesLocal(t *testing.T) {
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
 	password := "$uperSecretPassword"
 	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-		Localpart: "bob",
-		Password:  password,
+		LocalpartSuffix: "bob",
+		Password:        password,
 	})
 	unauthedClient := deployment.Client(t, "hs1", "")
 

--- a/tests/csapi/keychanges_test.go
+++ b/tests/csapi/keychanges_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/tidwall/gjson"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
@@ -17,7 +16,7 @@ import (
 )
 
 func TestKeyChangesLocal(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})

--- a/tests/csapi/keychanges_test.go
+++ b/tests/csapi/keychanges_test.go
@@ -20,13 +20,13 @@ func TestKeyChangesLocal(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 	password := "$uperSecretPassword"
 	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{
 		LocalpartSuffix: "bob",
 		Password:        password,
 	})
-	unauthedClient := deployment.Client(t, "hs1", "")
+	unauthedClient := deployment.UnauthenticatedClient(t, "hs1")
 
 	t.Run("New login should create a device_lists.changed entry", func(t *testing.T) {
 		mustUploadKeys(t, bob)

--- a/tests/csapi/media_misc_test.go
+++ b/tests/csapi/media_misc_test.go
@@ -21,7 +21,7 @@ import (
 func TestRoomImageRoundtrip(t *testing.T) {
 	runtime.SkipIf(t, runtime.Dendrite) // FIXME: https://github.com/matrix-org/dendrite/issues/1303
 
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
@@ -63,7 +63,7 @@ func TestRoomImageRoundtrip(t *testing.T) {
 
 // sytest: Can read configuration endpoint
 func TestMediaConfig(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})

--- a/tests/csapi/media_misc_test.go
+++ b/tests/csapi/media_misc_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/internal/data"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
@@ -23,7 +24,7 @@ func TestRoomImageRoundtrip(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	mxcUri := alice.UploadContent(t, data.MatrixPng, "test.png", "image/png")
 
@@ -65,7 +66,7 @@ func TestMediaConfig(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	res := alice.MustDo(t, "GET", []string{"_matrix", "media", "v3", "config"})
 

--- a/tests/csapi/power_levels_test.go
+++ b/tests/csapi/power_levels_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
@@ -20,7 +21,7 @@ func TestDemotingUsersViaUsersDefault(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	roomID := alice.MustCreateRoom(t, map[string]interface{}{
 		"preset": "public_chat",
@@ -52,7 +53,7 @@ func TestPowerLevels(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	roomID := alice.MustCreateRoom(t, map[string]interface{}{})
 

--- a/tests/csapi/power_levels_test.go
+++ b/tests/csapi/power_levels_test.go
@@ -18,7 +18,7 @@ import (
 // when that value is equal to the value of authorised user.
 // Regression test for https://github.com/matrix-org/gomatrixserverlib/pull/306
 func TestDemotingUsersViaUsersDefault(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
@@ -50,7 +50,7 @@ func TestDemotingUsersViaUsersDefault(t *testing.T) {
 }
 
 func TestPowerLevels(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})

--- a/tests/csapi/push_test.go
+++ b/tests/csapi/push_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
@@ -19,7 +20,7 @@ func TestPushRuleCacheHealth(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	// Set a global push rule
 	alice.SetPushRule(t, "global", "sender", alice.UserID, map[string]interface{}{
@@ -37,7 +38,7 @@ func TestPushSync(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	var syncResp gjson.Result
 	var nextBatch string

--- a/tests/csapi/push_test.go
+++ b/tests/csapi/push_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/tidwall/gjson"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
@@ -17,7 +16,7 @@ import (
 
 // sytest: Getting push rules doesn't corrupt the cache SYN-390
 func TestPushRuleCacheHealth(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
@@ -35,7 +34,7 @@ func TestPushRuleCacheHealth(t *testing.T) {
 }
 
 func TestPushSync(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})

--- a/tests/csapi/room_ban_test.go
+++ b/tests/csapi/room_ban_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
@@ -38,9 +39,9 @@ func TestNotPresentUserCannotBanOthers(t *testing.T) {
 	}))
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	bob := deployment.Client(t, "hs1", "@bob:hs1")
-	charlie := deployment.Client(t, "hs1", "@charlie:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	charlie := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	roomID := alice.MustCreateRoom(t, map[string]interface{}{
 		"preset": "public_chat",

--- a/tests/csapi/room_ban_test.go
+++ b/tests/csapi/room_ban_test.go
@@ -15,28 +15,7 @@ import (
 // but this will actually validate against a present user in the room.
 // sytest: Non-present room members cannot ban others
 func TestNotPresentUserCannotBanOthers(t *testing.T) {
-	deployment := complement.Deploy(t, b.MustValidate(b.Blueprint{
-		Name: "abc",
-		Homeservers: []b.Homeserver{
-			{
-				Name: "hs1",
-				Users: []b.User{
-					{
-						Localpart:   "@alice",
-						DisplayName: "Alice",
-					},
-					{
-						Localpart:   "@bob",
-						DisplayName: "Bob",
-					},
-					{
-						Localpart:   "@charlie",
-						DisplayName: "Charlie",
-					},
-				},
-			},
-		},
-	}))
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})

--- a/tests/csapi/room_kick_test.go
+++ b/tests/csapi/room_kick_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
@@ -15,8 +16,8 @@ func TestCannotKickNonPresentUser(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	bob := deployment.Client(t, "hs1", "@bob:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	roomID := alice.MustCreateRoom(t, map[string]interface{}{
 		"preset": "public_chat",
@@ -39,8 +40,8 @@ func TestCannotKickLeftUser(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	bob := deployment.Client(t, "hs1", "@bob:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	roomID := alice.MustCreateRoom(t, map[string]interface{}{
 		"preset": "public_chat",

--- a/tests/csapi/room_kick_test.go
+++ b/tests/csapi/room_kick_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
@@ -13,7 +12,7 @@ import (
 
 // sytest: Users cannot kick users from a room they are not in
 func TestCannotKickNonPresentUser(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
@@ -37,7 +36,7 @@ func TestCannotKickNonPresentUser(t *testing.T) {
 
 // sytest: Users cannot kick users who have already left a room
 func TestCannotKickLeftUser(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})

--- a/tests/csapi/room_leave_test.go
+++ b/tests/csapi/room_leave_test.go
@@ -22,8 +22,8 @@ func TestLeftRoomFixture(t *testing.T) {
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
 	bob := deployment.Client(t, "hs1", "@bob:hs1")
 	charlie := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-		Localpart: "charlie",
-		Password:  "sufficiently_long_password_charlie",
+		LocalpartSuffix: "charlie",
+		Password:        "sufficiently_long_password_charlie",
 	})
 
 	roomID := alice.MustCreateRoom(t, map[string]interface{}{

--- a/tests/csapi/room_leave_test.go
+++ b/tests/csapi/room_leave_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
@@ -20,7 +21,10 @@ func TestLeftRoomFixture(t *testing.T) {
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
 	bob := deployment.Client(t, "hs1", "@bob:hs1")
-	charlie := deployment.RegisterUser(t, "hs1", "charlie", "sufficiently_long_password_charlie", false)
+	charlie := deployment.Register(t, "hs1", helpers.RegistrationOpts{
+		Localpart: "charlie",
+		Password:  "sufficiently_long_password_charlie",
+	})
 
 	roomID := alice.MustCreateRoom(t, map[string]interface{}{
 		"initial_state": []map[string]interface{}{

--- a/tests/csapi/room_leave_test.go
+++ b/tests/csapi/room_leave_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestLeftRoomFixture(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})

--- a/tests/csapi/room_leave_test.go
+++ b/tests/csapi/room_leave_test.go
@@ -19,8 +19,8 @@ func TestLeftRoomFixture(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	bob := deployment.Client(t, "hs1", "@bob:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 	charlie := deployment.Register(t, "hs1", helpers.RegistrationOpts{
 		LocalpartSuffix: "charlie",
 		Password:        "sufficiently_long_password_charlie",

--- a/tests/csapi/room_members_test.go
+++ b/tests/csapi/room_members_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
@@ -24,8 +25,8 @@ func TestGetRoomMembers(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	bob := deployment.Client(t, "hs1", "@bob:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	roomID := alice.MustCreateRoom(t, map[string]interface{}{
 		"preset": "public_chat",
@@ -63,8 +64,8 @@ func TestGetRoomMembersAtPoint(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	bob := deployment.Client(t, "hs1", "@bob:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	roomID := alice.MustCreateRoom(t, map[string]interface{}{
 		"preset": "public_chat",
@@ -123,8 +124,8 @@ func TestGetFilteredRoomMembers(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	bob := deployment.Client(t, "hs1", "@bob:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	roomID := alice.MustCreateRoom(t, map[string]interface{}{
 		"preset": "public_chat",

--- a/tests/csapi/room_members_test.go
+++ b/tests/csapi/room_members_test.go
@@ -22,7 +22,7 @@ func typeToStateKeyMapper(result gjson.Result) interface{} {
 
 // sytest: Can get rooms/{roomId}/members
 func TestGetRoomMembers(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
@@ -61,7 +61,7 @@ func TestGetRoomMembers(t *testing.T) {
 // Utilize ?at= to get room members at a point in sync.
 // sytest: Can get rooms/{roomId}/members at a given point
 func TestGetRoomMembersAtPoint(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
@@ -121,7 +121,7 @@ func TestGetRoomMembersAtPoint(t *testing.T) {
 // sytest: Can filter rooms/{roomId}/members
 func TestGetFilteredRoomMembers(t *testing.T) {
 
-	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})

--- a/tests/csapi/room_messages_test.go
+++ b/tests/csapi/room_messages_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 	"github.com/matrix-org/complement/runtime"
@@ -23,7 +24,7 @@ func TestSendAndFetchMessage(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	roomID := alice.MustCreateRoom(t, map[string]interface{}{"preset": "public_chat"})
 
@@ -66,7 +67,7 @@ func TestFetchMessagesFromNonExistentRoom(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 	roomID := "!does-not-exist:hs1"
 
 	// then request messages from the room
@@ -84,7 +85,7 @@ func TestSendMessageWithTxn(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	roomID := alice.MustCreateRoom(t, map[string]interface{}{})
 
@@ -132,9 +133,9 @@ func TestRoomMessagesLazyLoading(t *testing.T) {
 	}))
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	bob := deployment.Client(t, "hs1", "@bob:hs1")
-	charlie := deployment.Client(t, "hs1", "@charlie:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	charlie := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	roomID := alice.MustCreateRoom(t, map[string]interface{}{"preset": "public_chat"})
 	bob.MustJoinRoom(t, roomID, nil)
@@ -202,7 +203,7 @@ func TestRoomMessagesLazyLoadingLocalUser(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	roomID := alice.MustCreateRoom(t, map[string]interface{}{})
 

--- a/tests/csapi/room_messages_test.go
+++ b/tests/csapi/room_messages_test.go
@@ -21,7 +21,7 @@ import (
 // sytest: GET /rooms/:room_id/messages returns a message
 func TestSendAndFetchMessage(t *testing.T) {
 	runtime.SkipIf(t, runtime.Dendrite) // flakey
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
@@ -64,7 +64,7 @@ func TestSendAndFetchMessage(t *testing.T) {
 // With a non-existent room_id, GET /rooms/:room_id/messages returns 403
 // forbidden ("You aren't a member of the room").
 func TestFetchMessagesFromNonExistentRoom(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
@@ -82,7 +82,7 @@ func TestFetchMessagesFromNonExistentRoom(t *testing.T) {
 // sytest: PUT /rooms/:room_id/send/:event_type/:txn_id sends a message
 // sytest: PUT /rooms/:room_id/send/:event_type/:txn_id deduplicates the same txn id
 func TestSendMessageWithTxn(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
@@ -109,28 +109,7 @@ func TestSendMessageWithTxn(t *testing.T) {
 }
 
 func TestRoomMessagesLazyLoading(t *testing.T) {
-	deployment := complement.Deploy(t, b.MustValidate(b.Blueprint{
-		Name: "alice_bob_and_charlie",
-		Homeservers: []b.Homeserver{
-			{
-				Name: "hs1",
-				Users: []b.User{
-					{
-						Localpart:   "@alice",
-						DisplayName: "Alice",
-					},
-					{
-						Localpart:   "@bob",
-						DisplayName: "Bob",
-					},
-					{
-						Localpart:   "@charlie",
-						DisplayName: "Charlie",
-					},
-				},
-			},
-		},
-	}))
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
@@ -200,7 +179,7 @@ func TestRoomMessagesLazyLoading(t *testing.T) {
 //
 // sytest: GET /rooms/:room_id/messages lazy loads members correctly
 func TestRoomMessagesLazyLoadingLocalUser(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})

--- a/tests/csapi/room_profile_test.go
+++ b/tests/csapi/room_profile_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 )
 
 func TestAvatarUrlUpdate(t *testing.T) {
@@ -25,7 +26,7 @@ func testProfileFieldUpdate(t *testing.T, field string) {
 
 	const bogusData = "LemurLover"
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	roomID := alice.MustCreateRoom(t, map[string]interface{}{
 		"preset": "public_chat",

--- a/tests/csapi/room_profile_test.go
+++ b/tests/csapi/room_profile_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/tidwall/gjson"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/helpers"
 )
@@ -21,7 +20,7 @@ func TestDisplayNameUpdate(t *testing.T) {
 
 // sytest: $datum updates affect room member events
 func testProfileFieldUpdate(t *testing.T, field string) {
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	const bogusData = "LemurLover"

--- a/tests/csapi/room_relations_test.go
+++ b/tests/csapi/room_relations_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 	"github.com/matrix-org/complement/runtime"
@@ -20,7 +21,7 @@ func TestRelations(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 	roomID := alice.MustCreateRoom(t, map[string]interface{}{"preset": "public_chat"})
 	_, token := alice.MustSync(t, client.SyncReq{})
 
@@ -115,7 +116,7 @@ func TestRelationsPagination(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 	roomID := alice.MustCreateRoom(t, map[string]interface{}{"preset": "public_chat"})
 	_, token := alice.MustSync(t, client.SyncReq{})
 
@@ -214,7 +215,7 @@ func TestRelationsPaginationSync(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 	roomID := alice.MustCreateRoom(t, map[string]interface{}{"preset": "public_chat"})
 	_, token := alice.MustSync(t, client.SyncReq{})
 

--- a/tests/csapi/room_relations_test.go
+++ b/tests/csapi/room_relations_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestRelations(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
@@ -113,7 +113,7 @@ func TestRelations(t *testing.T) {
 }
 
 func TestRelationsPagination(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
@@ -212,7 +212,7 @@ func TestRelationsPagination(t *testing.T) {
 func TestRelationsPaginationSync(t *testing.T) {
 	runtime.SkipIf(t, runtime.Dendrite) // FIXME: https://github.com/matrix-org/dendrite/issues/2944
 
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})

--- a/tests/csapi/room_threads_test.go
+++ b/tests/csapi/room_threads_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/tidwall/gjson"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
@@ -34,7 +33,7 @@ func checkResults(t *testing.T, body []byte, expected []string) {
 // Test the /threads endpoint.
 func TestThreadsEndpoint(t *testing.T) {
 	runtime.SkipIf(t, runtime.Dendrite) // not supported
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})

--- a/tests/csapi/room_threads_test.go
+++ b/tests/csapi/room_threads_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 	"github.com/matrix-org/complement/runtime"
@@ -36,7 +37,7 @@ func TestThreadsEndpoint(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 	roomID := alice.MustCreateRoom(t, map[string]interface{}{"preset": "public_chat"})
 	_, token := alice.MustSync(t, client.SyncReq{})
 

--- a/tests/csapi/room_typing_test.go
+++ b/tests/csapi/room_typing_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 )
 
 // sytest: PUT /rooms/:room_id/typing/:user_id sets typing notification
@@ -42,7 +43,10 @@ func TestLeakyTyping(t *testing.T) {
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
 	bob := deployment.Client(t, "hs1", "@bob:hs1")
-	charlie := deployment.RegisterUser(t, "hs1", "charlie", "charliepassword", false)
+	charlie := deployment.Register(t, "hs1", helpers.RegistrationOpts{
+		Localpart: "charlie",
+		Password:  "charliepassword",
+	})
 
 	// Alice creates a room. Bob joins it.
 	roomID := alice.MustCreateRoom(t, map[string]interface{}{"preset": "public_chat"})

--- a/tests/csapi/room_typing_test.go
+++ b/tests/csapi/room_typing_test.go
@@ -14,8 +14,8 @@ func TestTyping(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	bob := deployment.Client(t, "hs1", "@bob:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	roomID := alice.MustCreateRoom(t, map[string]interface{}{"preset": "public_chat"})
 
@@ -41,8 +41,8 @@ func TestLeakyTyping(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	bob := deployment.Client(t, "hs1", "@bob:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 	charlie := deployment.Register(t, "hs1", helpers.RegistrationOpts{
 		LocalpartSuffix: "charlie",
 		Password:        "charliepassword",

--- a/tests/csapi/room_typing_test.go
+++ b/tests/csapi/room_typing_test.go
@@ -44,8 +44,8 @@ func TestLeakyTyping(t *testing.T) {
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
 	bob := deployment.Client(t, "hs1", "@bob:hs1")
 	charlie := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-		Localpart: "charlie",
-		Password:  "charliepassword",
+		LocalpartSuffix: "charlie",
+		Password:        "charliepassword",
 	})
 
 	// Alice creates a room. Bob joins it.

--- a/tests/csapi/room_typing_test.go
+++ b/tests/csapi/room_typing_test.go
@@ -4,14 +4,13 @@ import (
 	"testing"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/helpers"
 )
 
 // sytest: PUT /rooms/:room_id/typing/:user_id sets typing notification
 func TestTyping(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
@@ -38,7 +37,7 @@ func TestTyping(t *testing.T) {
 
 // sytest: Typing notifications don't leak
 func TestLeakyTyping(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})

--- a/tests/csapi/rooms_invite_test.go
+++ b/tests/csapi/rooms_invite_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
@@ -14,7 +13,7 @@ import (
 )
 
 func TestRoomsInvite(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})

--- a/tests/csapi/rooms_invite_test.go
+++ b/tests/csapi/rooms_invite_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 	"github.com/tidwall/gjson"
@@ -16,8 +17,8 @@ func TestRoomsInvite(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	bob := deployment.Client(t, "hs1", "@bob:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	t.Run("Parallel", func(t *testing.T) {
 		// sytest: Can invite users to invite-only rooms

--- a/tests/csapi/rooms_members_local_test.go
+++ b/tests/csapi/rooms_members_local_test.go
@@ -14,7 +14,7 @@ func TestMembersLocal(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 	// Here we don't use the BlueprintOneToOneRoom because else Bob would be able to see Alice's presence changes through
 	// that pre-existing one-on-one DM room. So we exclude that here.
 	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{

--- a/tests/csapi/rooms_members_local_test.go
+++ b/tests/csapi/rooms_members_local_test.go
@@ -4,14 +4,13 @@ import (
 	"testing"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/runtime"
 )
 
 func TestMembersLocal(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})

--- a/tests/csapi/rooms_members_local_test.go
+++ b/tests/csapi/rooms_members_local_test.go
@@ -18,8 +18,8 @@ func TestMembersLocal(t *testing.T) {
 	// Here we don't use the BlueprintOneToOneRoom because else Bob would be able to see Alice's presence changes through
 	// that pre-existing one-on-one DM room. So we exclude that here.
 	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-		Localpart: "bob",
-		Password:  "bobspassword",
+		LocalpartSuffix: "bob",
+		Password:        "bobspassword",
 	})
 	roomID := alice.MustCreateRoom(t, map[string]interface{}{"preset": "public_chat"})
 

--- a/tests/csapi/rooms_members_local_test.go
+++ b/tests/csapi/rooms_members_local_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/runtime"
 )
 
@@ -16,7 +17,10 @@ func TestMembersLocal(t *testing.T) {
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
 	// Here we don't use the BlueprintOneToOneRoom because else Bob would be able to see Alice's presence changes through
 	// that pre-existing one-on-one DM room. So we exclude that here.
-	bob := deployment.RegisterUser(t, "hs1", "bob", "bobspassword", false)
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{
+		Localpart: "bob",
+		Password:  "bobspassword",
+	})
 	roomID := alice.MustCreateRoom(t, map[string]interface{}{"preset": "public_chat"})
 
 	bob.MustDo(

--- a/tests/csapi/rooms_state_test.go
+++ b/tests/csapi/rooms_state_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/must"
 )
 
@@ -21,7 +22,10 @@ func TestRoomCreationReportsEventsToMyself(t *testing.T) {
 
 	userID := "@alice:hs1"
 	alice := deployment.Client(t, "hs1", userID)
-	bob := deployment.RegisterUser(t, "hs1", "bob", "bobpassword", false)
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{
+		Localpart: "bob",
+		Password:  "bobpassword",
+	})
 	roomID := alice.MustCreateRoom(t, map[string]interface{}{})
 
 	t.Run("parallel", func(t *testing.T) {

--- a/tests/csapi/rooms_state_test.go
+++ b/tests/csapi/rooms_state_test.go
@@ -23,8 +23,8 @@ func TestRoomCreationReportsEventsToMyself(t *testing.T) {
 	userID := "@alice:hs1"
 	alice := deployment.Client(t, "hs1", userID)
 	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-		Localpart: "bob",
-		Password:  "bobpassword",
+		LocalpartSuffix: "bob",
+		Password:        "bobpassword",
 	})
 	roomID := alice.MustCreateRoom(t, map[string]interface{}{})
 

--- a/tests/csapi/rooms_state_test.go
+++ b/tests/csapi/rooms_state_test.go
@@ -20,8 +20,7 @@ func TestRoomCreationReportsEventsToMyself(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
-	userID := "@alice:hs1"
-	alice := deployment.Client(t, "hs1", userID)
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{
 		LocalpartSuffix: "bob",
 		Password:        "bobpassword",
@@ -37,8 +36,8 @@ func TestRoomCreationReportsEventsToMyself(t *testing.T) {
 				if ev.Get("type").Str != "m.room.create" {
 					return false
 				}
-				must.Equal(t, ev.Get("sender").Str, userID, "wrong sender")
-				must.Equal(t, ev.Get("content").Get("creator").Str, userID, "wrong content.creator")
+				must.Equal(t, ev.Get("sender").Str, alice.UserID, "wrong sender")
+				must.Equal(t, ev.Get("content").Get("creator").Str, alice.UserID, "wrong content.creator")
 				return true
 			}))
 		})
@@ -51,8 +50,8 @@ func TestRoomCreationReportsEventsToMyself(t *testing.T) {
 				if ev.Get("type").Str != "m.room.member" {
 					return false
 				}
-				must.Equal(t, ev.Get("sender").Str, userID, "wrong sender")
-				must.Equal(t, ev.Get("state_key").Str, userID, "wrong state_key")
+				must.Equal(t, ev.Get("sender").Str, alice.UserID, "wrong sender")
+				must.Equal(t, ev.Get("state_key").Str, alice.UserID, "wrong state_key")
 				must.Equal(t, ev.Get("content").Get("membership").Str, "join", "wrong content.membership")
 				return true
 			}))
@@ -79,7 +78,7 @@ func TestRoomCreationReportsEventsToMyself(t *testing.T) {
 				if !ev.Get("state_key").Exists() {
 					return false
 				}
-				must.Equal(t, ev.Get("sender").Str, userID, "wrong sender")
+				must.Equal(t, ev.Get("sender").Str, alice.UserID, "wrong sender")
 				must.Equal(t, ev.Get("content").Get("topic").Str, roomTopic, "wrong content.topic")
 				return true
 			}))

--- a/tests/csapi/rooms_state_test.go
+++ b/tests/csapi/rooms_state_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestRoomCreationReportsEventsToMyself(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})

--- a/tests/csapi/sync_archive_test.go
+++ b/tests/csapi/sync_archive_test.go
@@ -16,7 +16,7 @@ import (
 func TestSyncLeaveSection(t *testing.T) {
 	runtime.SkipIf(t, runtime.Dendrite) // FIXME: https://github.com/matrix-org/dendrite/issues/1323
 
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
@@ -77,7 +77,7 @@ func TestSyncLeaveSection(t *testing.T) {
 func TestGappedSyncLeaveSection(t *testing.T) {
 	runtime.SkipIf(t, runtime.Dendrite) // FIXME: https://github.com/matrix-org/dendrite/issues/1323
 
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
@@ -118,7 +118,7 @@ func TestGappedSyncLeaveSection(t *testing.T) {
 func TestArchivedRoomsHistory(t *testing.T) {
 	runtime.SkipIf(t, runtime.Dendrite) // FIXME: https://github.com/matrix-org/dendrite/issues/1323
 
-	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
@@ -235,7 +235,7 @@ func TestArchivedRoomsHistory(t *testing.T) {
 func TestOlderLeftRoomsNotInLeaveSection(t *testing.T) {
 	runtime.SkipIf(t, runtime.Dendrite) // FIXME: https://github.com/matrix-org/dendrite/issues/1323
 
-	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
@@ -317,7 +317,7 @@ func TestLeaveEventVisibility(t *testing.T) {
 	//  this user is only meant to keep the room alive,
 	//  as a room with no users may be purged by the server,
 	//  creating side effects that this test is not looking for.
-	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
@@ -400,7 +400,7 @@ func TestLeaveEventVisibility(t *testing.T) {
 func TestLeaveEventInviteRejection(t *testing.T) {
 	runtime.SkipIf(t, runtime.Dendrite) // FIXME: https://github.com/matrix-org/dendrite/issues/1323
 
-	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})

--- a/tests/csapi/sync_archive_test.go
+++ b/tests/csapi/sync_archive_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/runtime"
 )
 
@@ -18,7 +19,7 @@ func TestSyncLeaveSection(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	includeLeaveFilter := createFilter(t, alice, map[string]interface{}{
 		"room": map[string]interface{}{
@@ -79,7 +80,7 @@ func TestGappedSyncLeaveSection(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	gappyFilter := createFilter(t, alice, map[string]interface{}{
 		"room": map[string]interface{}{
@@ -120,8 +121,8 @@ func TestArchivedRoomsHistory(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	bob := deployment.Client(t, "hs1", "@bob:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	const madeUpTestStateType = "a.madeup.test.state"
 
@@ -237,8 +238,8 @@ func TestOlderLeftRoomsNotInLeaveSection(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	bob := deployment.Client(t, "hs1", "@bob:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	aliceFilter := createFilter(t, alice, map[string]interface{}{
 		"room": map[string]interface{}{
@@ -319,8 +320,8 @@ func TestLeaveEventVisibility(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	bob := deployment.Client(t, "hs1", "@bob:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	aliceFilter := createFilter(t, alice, map[string]interface{}{
 		"room": map[string]interface{}{
@@ -402,8 +403,8 @@ func TestLeaveEventInviteRejection(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	bob := deployment.Client(t, "hs1", "@bob:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	aliceFilter := createFilter(t, alice, map[string]interface{}{
 		"room": map[string]interface{}{

--- a/tests/csapi/sync_filter_test.go
+++ b/tests/csapi/sync_filter_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
@@ -16,7 +17,7 @@ import (
 func TestSyncFilter(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
-	authedClient := deployment.Client(t, "hs1", "@alice:hs1")
+	authedClient := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 	// sytest: Can create filter
 	t.Run("Can create filter", func(t *testing.T) {
 		createFilter(t, authedClient, map[string]interface{}{

--- a/tests/csapi/sync_filter_test.go
+++ b/tests/csapi/sync_filter_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/tidwall/gjson"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
@@ -15,7 +14,7 @@ import (
 )
 
 func TestSyncFilter(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 	authedClient := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 	// sytest: Can create filter
@@ -37,7 +36,7 @@ func TestSyncFilter(t *testing.T) {
 				},
 			},
 		})
-		res := authedClient.MustDo(t, "GET", []string{"_matrix", "client", "v3", "user", "@alice:hs1", "filter", filterID})
+		res := authedClient.MustDo(t, "GET", []string{"_matrix", "client", "v3", "user", authedClient.UserID, "filter", filterID})
 		must.MatchResponse(t, res, match.HTTPResponse{
 			JSON: []match.JSON{
 				match.JSONKeyPresent("room"),

--- a/tests/csapi/sync_test.go
+++ b/tests/csapi/sync_test.go
@@ -383,7 +383,7 @@ func TestPresenceSyncDifferentRooms(t *testing.T) {
 	bob := deployment.Client(t, "hs1", "@bob:hs1")
 
 	charlie := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-		Localpart: "charlie",
+		LocalpartSuffix: "charlie",
 	})
 
 	// Alice creates two rooms: one with her and Bob, and a second with her and Charlie.
@@ -407,7 +407,7 @@ func TestPresenceSyncDifferentRooms(t *testing.T) {
 		"presence": "online",
 	})
 	bob.Do(t, "PUT", []string{"_matrix", "client", "v3", "presence", "@bob:hs1", "status"}, reqBody)
-	charlie.Do(t, "PUT", []string{"_matrix", "client", "v3", "presence", "@charlie:hs1", "status"}, reqBody)
+	charlie.Do(t, "PUT", []string{"_matrix", "client", "v3", "presence", charlie.UserID, "status"}, reqBody)
 
 	// Alice should see that Bob and Charlie are online. She may see this happen
 	// simultaneously in one /sync response, or separately in two /sync

--- a/tests/csapi/sync_test.go
+++ b/tests/csapi/sync_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/internal/federation"
 	"github.com/matrix-org/complement/runtime"
 )
@@ -381,7 +382,9 @@ func TestPresenceSyncDifferentRooms(t *testing.T) {
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
 	bob := deployment.Client(t, "hs1", "@bob:hs1")
 
-	charlie := deployment.NewUser(t, "charlie", "hs1")
+	charlie := deployment.Register(t, "hs1", helpers.RegistrationOpts{
+		Localpart: "charlie",
+	})
 
 	// Alice creates two rooms: one with her and Bob, and a second with her and Charlie.
 	bobRoomID := alice.MustCreateRoom(t, map[string]interface{}{})

--- a/tests/csapi/sync_test.go
+++ b/tests/csapi/sync_test.go
@@ -18,7 +18,7 @@ import (
 
 // Observes "first bug" from https://github.com/matrix-org/dendrite/pull/1394#issuecomment-687056673
 func TestCumulativeJoinLeaveJoinSync(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
@@ -56,7 +56,7 @@ func TestCumulativeJoinLeaveJoinSync(t *testing.T) {
 
 // Observes "second bug" from https://github.com/matrix-org/dendrite/pull/1394#issuecomment-687056673
 func TestTentativeEventualJoiningAfterRejecting(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
@@ -106,7 +106,7 @@ func TestTentativeEventualJoiningAfterRejecting(t *testing.T) {
 func TestSync(t *testing.T) {
 	runtime.SkipIf(t, runtime.Dendrite) // FIXME: https://github.com/matrix-org/dendrite/issues/1324
 	// sytest: Can sync
-	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
@@ -376,7 +376,7 @@ func TestSync(t *testing.T) {
 
 // Test presence from people in 2 different rooms in incremental sync
 func TestPresenceSyncDifferentRooms(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
@@ -406,7 +406,7 @@ func TestPresenceSyncDifferentRooms(t *testing.T) {
 	reqBody := client.WithJSONBody(t, map[string]interface{}{
 		"presence": "online",
 	})
-	bob.Do(t, "PUT", []string{"_matrix", "client", "v3", "presence", "@bob:hs1", "status"}, reqBody)
+	bob.Do(t, "PUT", []string{"_matrix", "client", "v3", "presence", bob.UserID, "status"}, reqBody)
 	charlie.Do(t, "PUT", []string{"_matrix", "client", "v3", "presence", charlie.UserID, "status"}, reqBody)
 
 	// Alice should see that Bob and Charlie are online. She may see this happen
@@ -439,7 +439,7 @@ func TestPresenceSyncDifferentRooms(t *testing.T) {
 
 func TestRoomSummary(t *testing.T) {
 	runtime.SkipIf(t, runtime.Synapse) // Currently more of a Dendrite test, so skip on Synapse
-	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{})

--- a/tests/csapi/sync_test.go
+++ b/tests/csapi/sync_test.go
@@ -21,8 +21,8 @@ func TestCumulativeJoinLeaveJoinSync(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	bob := deployment.Client(t, "hs1", "@bob:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	roomID := bob.MustCreateRoom(t, map[string]interface{}{
 		"preset": "public_chat",
@@ -59,8 +59,8 @@ func TestTentativeEventualJoiningAfterRejecting(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	bob := deployment.Client(t, "hs1", "@bob:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	roomID := alice.MustCreateRoom(t, map[string]interface{}{
 		"preset": "public_chat",
@@ -108,8 +108,8 @@ func TestSync(t *testing.T) {
 	// sytest: Can sync
 	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	bob := deployment.Client(t, "hs1", "@bob:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	filterID := createFilter(t, alice, map[string]interface{}{
 		"room": map[string]interface{}{
@@ -379,8 +379,8 @@ func TestPresenceSyncDifferentRooms(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	bob := deployment.Client(t, "hs1", "@bob:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	charlie := deployment.Register(t, "hs1", helpers.RegistrationOpts{
 		LocalpartSuffix: "charlie",
@@ -441,8 +441,8 @@ func TestRoomSummary(t *testing.T) {
 	runtime.SkipIf(t, runtime.Synapse) // Currently more of a Dendrite test, so skip on Synapse
 	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	bob := deployment.Client(t, "hs1", "@bob:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	_, aliceSince := alice.MustSync(t, client.SyncReq{TimeoutMillis: "0"})
 	roomID := alice.MustCreateRoom(t, map[string]interface{}{

--- a/tests/csapi/thread_notifications_test.go
+++ b/tests/csapi/thread_notifications_test.go
@@ -73,7 +73,7 @@ func syncHasThreadedReadReceipt(roomID, userID, eventID, threadID string) client
 // Notification counts and receipts are handled by bob.
 func TestThreadedReceipts(t *testing.T) {
 	runtime.SkipIf(t, runtime.Dendrite) // not supported
-	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	// Create a room with alice and bob.

--- a/tests/csapi/thread_notifications_test.go
+++ b/tests/csapi/thread_notifications_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/runtime"
 )
 
@@ -76,8 +77,8 @@ func TestThreadedReceipts(t *testing.T) {
 	defer deployment.Destroy(t)
 
 	// Create a room with alice and bob.
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	bob := deployment.Client(t, "hs1", "@bob:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	roomID := alice.MustCreateRoom(t, map[string]interface{}{"preset": "public_chat"})
 	bob.MustJoinRoom(t, roomID, nil)

--- a/tests/csapi/to_device_test.go
+++ b/tests/csapi/to_device_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/tidwall/gjson"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/helpers"
 )
@@ -16,7 +15,7 @@ import (
 // sytest: Can recv a device message using /sync
 // sytest: Can send a to-device message to two users which both receive it using /sync
 func TestToDeviceMessages(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})

--- a/tests/csapi/to_device_test.go
+++ b/tests/csapi/to_device_test.go
@@ -22,8 +22,8 @@ func TestToDeviceMessages(t *testing.T) {
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
 	bob := deployment.Client(t, "hs1", "@bob:hs1")
 	charlie := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-		Localpart: "charlie",
-		Password:  "charliepassword",
+		LocalpartSuffix: "charlie",
+		Password:        "charliepassword",
 	})
 
 	_, bobSince := bob.MustSync(t, client.SyncReq{TimeoutMillis: "0"})

--- a/tests/csapi/to_device_test.go
+++ b/tests/csapi/to_device_test.go
@@ -19,8 +19,8 @@ func TestToDeviceMessages(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	bob := deployment.Client(t, "hs1", "@bob:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 	charlie := deployment.Register(t, "hs1", helpers.RegistrationOpts{
 		LocalpartSuffix: "charlie",
 		Password:        "charliepassword",

--- a/tests/csapi/to_device_test.go
+++ b/tests/csapi/to_device_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 )
 
 // sytest: Can send a message directly to a device using PUT /sendToDevice
@@ -20,7 +21,10 @@ func TestToDeviceMessages(t *testing.T) {
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
 	bob := deployment.Client(t, "hs1", "@bob:hs1")
-	charlie := deployment.RegisterUser(t, "hs1", "charlie", "charliepassword", false)
+	charlie := deployment.Register(t, "hs1", helpers.RegistrationOpts{
+		Localpart: "charlie",
+		Password:  "charliepassword",
+	})
 
 	_, bobSince := bob.MustSync(t, client.SyncReq{TimeoutMillis: "0"})
 	_, charlieSince := charlie.MustSync(t, client.SyncReq{TimeoutMillis: "0"})

--- a/tests/csapi/txnid_test.go
+++ b/tests/csapi/txnid_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/must"
 	"github.com/matrix-org/complement/runtime"
 	"github.com/tidwall/gjson"
@@ -21,7 +22,10 @@ func TestTxnInEvent(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintCleanHS)
 	defer deployment.Destroy(t)
 
-	c := deployment.RegisterUser(t, "hs1", "alice", "password", false)
+	c := deployment.Register(t, "hs1", helpers.RegistrationOpts{
+		Localpart: "alice",
+		Password:  "password",
+	})
 
 	// Create a room where we can send events.
 	roomID := c.MustCreateRoom(t, map[string]interface{}{})
@@ -72,7 +76,10 @@ func TestTxnScopeOnLocalEcho(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintCleanHS)
 	defer deployment.Destroy(t)
 
-	deployment.RegisterUser(t, "hs1", "alice", "password", false)
+	deployment.Register(t, "hs1", helpers.RegistrationOpts{
+		Localpart: "alice",
+		Password:  "password",
+	})
 
 	// Create a first client, which allocates a device ID.
 	c1 := deployment.Client(t, "hs1", "")
@@ -111,7 +118,10 @@ func TestTxnIdempotencyScopedToDevice(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintCleanHS)
 	defer deployment.Destroy(t)
 
-	deployment.RegisterUser(t, "hs1", "alice", "password", false)
+	deployment.Register(t, "hs1", helpers.RegistrationOpts{
+		Localpart: "alice",
+		Password:  "password",
+	})
 
 	// Create a first client, which allocates a device ID.
 	c1 := deployment.Client(t, "hs1", "")
@@ -151,7 +161,10 @@ func TestTxnIdempotency(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintCleanHS)
 	defer deployment.Destroy(t)
 
-	deployment.RegisterUser(t, "hs1", "alice", "password", false)
+	deployment.Register(t, "hs1", helpers.RegistrationOpts{
+		Localpart: "alice",
+		Password:  "password",
+	})
 
 	// Create a first client, which allocates a device ID.
 	c1 := deployment.Client(t, "hs1", "")
@@ -206,7 +219,10 @@ func TestTxnIdWithRefreshToken(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintCleanHS)
 	defer deployment.Destroy(t)
 
-	deployment.RegisterUser(t, "hs1", "alice", "password", false)
+	deployment.Register(t, "hs1", helpers.RegistrationOpts{
+		Localpart: "alice",
+		Password:  "password",
+	})
 
 	c := deployment.Client(t, "hs1", "")
 

--- a/tests/csapi/txnid_test.go
+++ b/tests/csapi/txnid_test.go
@@ -83,7 +83,7 @@ func TestTxnScopeOnLocalEcho(t *testing.T) {
 	})
 
 	// Create a first client, which allocates a device ID.
-	c1 := deployment.Client(t, "hs1", "")
+	c1 := deployment.UnauthenticatedClient(t, "hs1")
 	c1.UserID, c1.AccessToken, c1.DeviceID = c1.LoginUser(t, alice.UserID, "password")
 
 	// Create a room where we can send events.
@@ -103,7 +103,7 @@ func TestTxnScopeOnLocalEcho(t *testing.T) {
 	c1.MustSyncUntil(t, client.SyncReq{}, mustHaveTransactionIDForEvent(t, roomID, eventID, txnId))
 
 	// Create a second client, inheriting the first device ID.
-	c2 := deployment.Client(t, "hs1", "")
+	c2 := deployment.UnauthenticatedClient(t, "hs1")
 	c2.UserID, c2.AccessToken, c2.DeviceID = c2.LoginUser(t, "alice", "password", client.WithDeviceID(c1.DeviceID))
 	must.Equal(t, c1.DeviceID, c2.DeviceID, "Device ID should be the same")
 
@@ -125,7 +125,7 @@ func TestTxnIdempotencyScopedToDevice(t *testing.T) {
 	})
 
 	// Create a first client, which allocates a device ID.
-	c1 := deployment.Client(t, "hs1", "")
+	c1 := deployment.UnauthenticatedClient(t, "hs1")
 	c1.UserID, c1.AccessToken, c1.DeviceID = c1.LoginUser(t, alice.UserID, "password")
 
 	// Create a room where we can send events.
@@ -143,7 +143,7 @@ func TestTxnIdempotencyScopedToDevice(t *testing.T) {
 	eventID1 := c1.Unsafe_SendEventUnsyncedWithTxnID(t, roomID, event, txnId)
 
 	// Create a second client, inheriting the first device ID.
-	c2 := deployment.Client(t, "hs1", "")
+	c2 := deployment.UnauthenticatedClient(t, "hs1")
 	c2.UserID, c2.AccessToken, c2.DeviceID = c2.LoginUser(t, "alice", "password", client.WithDeviceID(c1.DeviceID))
 	must.Equal(t, c1.DeviceID, c2.DeviceID, "Device ID should be the same")
 
@@ -168,7 +168,7 @@ func TestTxnIdempotency(t *testing.T) {
 	})
 
 	// Create a first client, which allocates a device ID.
-	c1 := deployment.Client(t, "hs1", "")
+	c1 := deployment.UnauthenticatedClient(t, "hs1")
 	c1.UserID, c1.AccessToken, c1.DeviceID = c1.LoginUser(t, alice.UserID, "password")
 
 	// Create a room where we can send events.
@@ -227,7 +227,7 @@ func TestTxnIdWithRefreshToken(t *testing.T) {
 	localpart, _, err := gomatrixserverlib.SplitID('@', alice.UserID)
 	must.NotError(t, "failed to get localpart from user ID", err)
 
-	c := deployment.Client(t, "hs1", "")
+	c := deployment.UnauthenticatedClient(t, "hs1")
 
 	var refreshToken string
 	c.UserID, c.AccessToken, refreshToken, c.DeviceID, _ = c.LoginUserWithRefreshToken(t, localpart, "password")

--- a/tests/csapi/txnid_test.go
+++ b/tests/csapi/txnid_test.go
@@ -20,7 +20,7 @@ func TestTxnInEvent(t *testing.T) {
 	// See https://github.com/matrix-org/dendrite/issues/3000
 	runtime.SkipIf(t, runtime.Dendrite)
 
-	deployment := complement.Deploy(t, b.BlueprintCleanHS)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	c := deployment.Register(t, "hs1", helpers.RegistrationOpts{
@@ -74,7 +74,7 @@ func mustHaveTransactionIDForEvent(t *testing.T, roomID, eventID, expectedTxnId 
 func TestTxnScopeOnLocalEcho(t *testing.T) {
 	runtime.SkipIf(t, runtime.Dendrite)
 
-	deployment := complement.Deploy(t, b.BlueprintCleanHS)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
@@ -116,7 +116,7 @@ func TestTxnScopeOnLocalEcho(t *testing.T) {
 func TestTxnIdempotencyScopedToDevice(t *testing.T) {
 	runtime.SkipIf(t, runtime.Dendrite)
 
-	deployment := complement.Deploy(t, b.BlueprintCleanHS)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
@@ -159,7 +159,7 @@ func TestTxnIdempotency(t *testing.T) {
 	// Conduit appears to be tracking transaction IDs individually rather than combined with the request URI/room ID
 	runtime.SkipIf(t, runtime.Conduit)
 
-	deployment := complement.Deploy(t, b.BlueprintCleanHS)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
@@ -217,7 +217,7 @@ func TestTxnIdWithRefreshToken(t *testing.T) {
 	// Dendrite and Conduit don't support refresh tokens yet.
 	runtime.SkipIf(t, runtime.Dendrite, runtime.Conduit)
 
-	deployment := complement.Deploy(t, b.BlueprintCleanHS)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{

--- a/tests/csapi/upload_keys_test.go
+++ b/tests/csapi/upload_keys_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 	"github.com/matrix-org/complement/runtime"
@@ -20,8 +21,8 @@ func TestUploadKey(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	bob := deployment.Client(t, "hs1", "@bob:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	deviceKeys, oneTimeKeys := alice.MustGenerateOneTimeKeys(t, 1)
 

--- a/tests/csapi/upload_keys_test.go
+++ b/tests/csapi/upload_keys_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/tidwall/gjson"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
@@ -18,7 +17,7 @@ import (
 )
 
 func TestUploadKey(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})

--- a/tests/csapi/url_preview_test.go
+++ b/tests/csapi/url_preview_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/internal/data"
 	"github.com/matrix-org/complement/internal/web"
 	"github.com/matrix-org/complement/match"
@@ -63,7 +64,7 @@ func TestUrlPreview(t *testing.T) {
 	})
 	defer webServer.Close()
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	res := alice.MustDo(t, "GET", []string{"_matrix", "media", "v3", "preview_url"},
 		client.WithQueries(url.Values{

--- a/tests/csapi/url_preview_test.go
+++ b/tests/csapi/url_preview_test.go
@@ -45,7 +45,7 @@ func TestUrlPreview(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
-	webServer := web.NewServer(t, deployment.Config, func(router *mux.Router) {
+	webServer := web.NewServer(t, deployment.GetConfig(), func(router *mux.Router) {
 		router.HandleFunc("/test.png", func(w http.ResponseWriter, req *http.Request) {
 			t.Log("/test.png fetched")
 

--- a/tests/csapi/url_preview_test.go
+++ b/tests/csapi/url_preview_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/tidwall/gjson"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/internal/data"
@@ -43,7 +42,7 @@ var oGraphHtml = fmt.Sprintf(`
 func TestUrlPreview(t *testing.T) {
 	runtime.SkipIf(t, runtime.Dendrite) // FIXME: https://github.com/matrix-org/dendrite/issues/621
 
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	webServer := web.NewServer(t, deployment.GetConfig(), func(router *mux.Router) {

--- a/tests/csapi/user_directory_display_names_test.go
+++ b/tests/csapi/user_directory_display_names_test.go
@@ -47,12 +47,10 @@ func setupUsers(t *testing.T) (*client.CSAPI, *client.CSAPI, *client.CSAPI, func
 
 	alice := deployment.Client(t, "hs1", aliceUserID)
 	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-		Localpart: "bob",
-		Password:  "bob-has-a-very-secret-pw",
+		LocalpartSuffix: "bob",
 	})
 	eve := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-		Localpart: "eve",
-		Password:  "eve-has-a-very-secret-pw",
+		LocalpartSuffix: "eve",
 	})
 
 	// Alice sets her profile displayname. This ensures that her

--- a/tests/csapi/user_directory_display_names_test.go
+++ b/tests/csapi/user_directory_display_names_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
@@ -45,8 +46,14 @@ func setupUsers(t *testing.T) (*client.CSAPI, *client.CSAPI, *client.CSAPI, func
 	}
 
 	alice := deployment.Client(t, "hs1", aliceUserID)
-	bob := deployment.RegisterUser(t, "hs1", "bob", "bob-has-a-very-secret-pw", false)
-	eve := deployment.RegisterUser(t, "hs1", "eve", "eve-has-a-very-secret-pw", false)
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{
+		Localpart: "bob",
+		Password:  "bob-has-a-very-secret-pw",
+	})
+	eve := deployment.Register(t, "hs1", helpers.RegistrationOpts{
+		Localpart: "eve",
+		Password:  "eve-has-a-very-secret-pw",
+	})
 
 	// Alice sets her profile displayname. This ensures that her
 	// public name, private name and userid localpart are all

--- a/tests/csapi/user_directory_display_names_test.go
+++ b/tests/csapi/user_directory_display_names_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
@@ -41,7 +40,7 @@ func setupUsers(t *testing.T) (*client.CSAPI, *client.CSAPI, *client.CSAPI, func
 	// - Eve knows about Alice,
 	// - Alice reveals a private name to another friend Bob
 	// - Eve shouldn't be able to see that private name via the directory.
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	cleanup := func(t *testing.T) {
 		deployment.Destroy(t)
 	}

--- a/tests/csapi/user_query_keys_test.go
+++ b/tests/csapi/user_query_keys_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
@@ -17,7 +16,7 @@ import (
 // like an array in Python and hence go un-noticed. In Go however it will result in a 400. The correct behaviour is
 // to return a 400. Element iOS uses this erroneous format.
 func TestKeysQueryWithDeviceIDAsObjectFails(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})

--- a/tests/csapi/user_query_keys_test.go
+++ b/tests/csapi/user_query_keys_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
@@ -19,8 +20,7 @@ func TestKeysQueryWithDeviceIDAsObjectFails(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
-	userID := "@alice:hs1"
-	alice := deployment.Client(t, "hs1", userID)
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 	res := alice.Do(t, "POST", []string{"_matrix", "client", "v3", "keys", "query"},
 		client.WithJSONBody(t, map[string]interface{}{
 			"device_keys": map[string]interface{}{

--- a/tests/direct_messaging_test.go
+++ b/tests/direct_messaging_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/internal/federation"
@@ -23,7 +22,7 @@ import (
 // Test that a client can write `m.direct` account data and get told about updates to that event.
 // Requires a functioning account data implementation.
 func TestWriteMDirectAccountData(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, 1)
 	defer func() {
 		// additional logging to debug https://github.com/matrix-org/synapse/issues/13334
 		t.Logf("%s: TestWriteMDirectAccountData complete: destroying HS deployment", time.Now())
@@ -71,7 +70,7 @@ func TestWriteMDirectAccountData(t *testing.T) {
 // Test that the `is_direct` flag on m.room.member invites propagate to the target user. Both users
 // are on the same homeserver.
 func TestIsDirectFlagLocal(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
@@ -104,7 +103,7 @@ func TestIsDirectFlagLocal(t *testing.T) {
 // Test that the `is_direct` flag on m.room.member invites propagate to the target user. Users
 // are on different homeservers.
 func TestIsDirectFlagFederation(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	srv := federation.NewServer(t, deployment,

--- a/tests/direct_messaging_test.go
+++ b/tests/direct_messaging_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/internal/federation"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
@@ -29,8 +30,8 @@ func TestWriteMDirectAccountData(t *testing.T) {
 		deployment.Destroy(t)
 	}()
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	bob := deployment.Client(t, "hs1", "@bob:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 	roomID := alice.MustCreateRoom(t, map[string]interface{}{
 		"invite":    []string{bob.UserID},
 		"is_direct": true,
@@ -73,8 +74,8 @@ func TestIsDirectFlagLocal(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	bob := deployment.Client(t, "hs1", "@bob:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 	roomID := alice.MustCreateRoom(t, map[string]interface{}{
 		"invite":    []string{bob.UserID},
 		"is_direct": true,
@@ -114,7 +115,7 @@ func TestIsDirectFlagFederation(t *testing.T) {
 	srv.UnexpectedRequestsAreErrors = false // we expect to be pushed events
 	cancel := srv.Listen()
 	defer cancel()
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 	roomVer := alice.GetDefaultRoomVersion(t)
 
 	bob := srv.UserID("bob")

--- a/tests/federation_acl_test.go
+++ b/tests/federation_acl_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 	"github.com/matrix-org/complement/runtime"
@@ -21,38 +22,20 @@ func TestACLs(t *testing.T) {
 		Homeservers: []b.Homeserver{
 			{
 				Name: "hs1",
-				Users: []b.User{
-					{
-						Localpart:   "alice",
-						DisplayName: "Alice",
-					},
-				},
 			},
 			{
 				Name: "hs2",
-				Users: []b.User{
-					{
-						Localpart:   "bob",
-						DisplayName: "Bob",
-					},
-				},
 			},
 			{
 				Name: "hs3",
-				Users: []b.User{
-					{
-						Localpart:   "charlie",
-						DisplayName: "Charlie",
-					},
-				},
 			},
 		},
 	})
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	bob := deployment.Client(t, "hs2", "@bob:hs2")
-	charlie := deployment.Client(t, "hs3", "@charlie:hs3")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	bob := deployment.Register(t, "hs2", helpers.RegistrationOpts{})
+	charlie := deployment.Register(t, "hs3", helpers.RegistrationOpts{})
 
 	// 2. Create room on 1st server
 	roomID := alice.MustCreateRoom(t, map[string]interface{}{"preset": "public_chat"})

--- a/tests/federation_acl_test.go
+++ b/tests/federation_acl_test.go
@@ -17,20 +17,7 @@ import (
 func TestACLs(t *testing.T) {
 	runtime.SkipIf(t, runtime.Dendrite) // needs https://github.com/matrix-org/dendrite/pull/3008
 	// 1. Prepare 3 or more servers. 1st will be room host, 2nd will be blocked with m.room.server_acl and 3rd server will be affected by this issue. 1st and 2nd servers don't have to be powered by dendrite.
-	deployment := complement.Deploy(t, b.Blueprint{
-		Name: "federation_three_homeservers",
-		Homeservers: []b.Homeserver{
-			{
-				Name: "hs1",
-			},
-			{
-				Name: "hs2",
-			},
-			{
-				Name: "hs3",
-			},
-		},
-	})
+	deployment := complement.Deploy(t, 3)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})

--- a/tests/federation_event_auth_test.go
+++ b/tests/federation_event_auth_test.go
@@ -29,7 +29,7 @@ import (
 //   - /event_auth for the latest join event returns the complete auth chain for Charlie (all the
 //     joins and leaves are included), without any extraneous events.
 func TestEventAuth(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})

--- a/tests/federation_event_auth_test.go
+++ b/tests/federation_event_auth_test.go
@@ -32,7 +32,7 @@ func TestEventAuth(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	// create a remote homeserver which will make the /event_auth request
 	var joinRuleEvent gomatrixserverlib.PDU

--- a/tests/federation_keys_test.go
+++ b/tests/federation_keys_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/tidwall/sjson"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
@@ -27,7 +26,7 @@ import (
 // https://matrix.org/docs/spec/server_server/latest#get-matrix-key-v2-server-keyid
 // sytest: Federation key API allows unsigned requests for keys
 func TestInboundFederationKeys(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	fedClient := &http.Client{

--- a/tests/federation_keys_test.go
+++ b/tests/federation_keys_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
-	"github.com/matrix-org/complement/internal/docker"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
@@ -33,7 +32,7 @@ func TestInboundFederationKeys(t *testing.T) {
 
 	fedClient := &http.Client{
 		Timeout:   10 * time.Second,
-		Transport: &docker.RoundTripper{Deployment: deployment},
+		Transport: deployment.RoundTripper(),
 	}
 
 	res, err := fedClient.Get("https://hs1/_matrix/key/v2/server")

--- a/tests/federation_presence_test.go
+++ b/tests/federation_presence_test.go
@@ -8,14 +8,15 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 )
 
 func TestRemotePresence(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintFederationOneToOneRoom)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	bob := deployment.Client(t, "hs2", "@bob:hs2")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	bob := deployment.Register(t, "hs2", helpers.RegistrationOpts{})
 
 	// sytest: Presence changes are also reported to remote room members
 	t.Run("Presence changes are also reported to remote room members", func(t *testing.T) {

--- a/tests/federation_presence_test.go
+++ b/tests/federation_presence_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestRemotePresence(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintFederationOneToOneRoom)
+	deployment := complement.Deploy(t, 2)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})

--- a/tests/federation_query_profile_test.go
+++ b/tests/federation_query_profile_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/matrix-org/gomatrixserverlib/spec"
 
-	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/internal/federation"
@@ -24,7 +23,7 @@ import (
 // Test that the server can make outbound federation profile requests
 // https://matrix.org/docs/spec/server_server/latest#get-matrix-federation-v1-query-profile
 func TestOutboundFederationProfile(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	srv := federation.NewServer(t, deployment,
@@ -72,7 +71,7 @@ func TestOutboundFederationProfile(t *testing.T) {
 }
 
 func TestInboundFederationProfile(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})

--- a/tests/federation_query_profile_test.go
+++ b/tests/federation_query_profile_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/internal/federation"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
@@ -60,7 +61,7 @@ func TestOutboundFederationProfile(t *testing.T) {
 		})).Methods("GET")
 
 		// query the display name which should do an outbound federation hit
-		unauthedClient := deployment.Client(t, "hs1", "")
+		unauthedClient := deployment.UnauthenticatedClient(t, "hs1")
 		res := unauthedClient.MustDo(t, "GET", []string{"_matrix", "client", "v3", "profile", remoteUserID, "displayname"})
 		must.MatchResponse(t, res, match.HTTPResponse{
 			JSON: []match.JSON{
@@ -74,7 +75,7 @@ func TestInboundFederationProfile(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	srv := federation.NewServer(t, deployment,
 		federation.HandleKeyRequests(),

--- a/tests/federation_redaction_test.go
+++ b/tests/federation_redaction_test.go
@@ -20,7 +20,7 @@ func TestFederationRedactSendsWithoutEvent(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	waiter := helpers.NewWaiter()
 	wantEventType := "m.room.redaction"

--- a/tests/federation_redaction_test.go
+++ b/tests/federation_redaction_test.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/internal/federation"
 	"github.com/matrix-org/complement/must"
@@ -17,7 +16,7 @@ import (
 func TestFederationRedactSendsWithoutEvent(t *testing.T) {
 	runtime.SkipIf(t, runtime.Dendrite)
 
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})

--- a/tests/federation_room_alias_test.go
+++ b/tests/federation_room_alias_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
@@ -15,8 +16,8 @@ func TestRemoteAliasRequestsUnderstandUnicode(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintFederationOneToOneRoom)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	bob := deployment.Client(t, "hs2", "@bob:hs2")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	bob := deployment.Register(t, "hs2", helpers.RegistrationOpts{})
 
 	const unicodeAlias = "#老虎Â£я🤨👉ඞ:hs1"
 

--- a/tests/federation_room_alias_test.go
+++ b/tests/federation_room_alias_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
@@ -13,7 +12,7 @@ import (
 
 // sytest: Remote room alias queries can handle Unicode
 func TestRemoteAliasRequestsUnderstandUnicode(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintFederationOneToOneRoom)
+	deployment := complement.Deploy(t, 2)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})

--- a/tests/federation_room_ban_test.go
+++ b/tests/federation_room_ban_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/helpers"
 )
@@ -13,7 +12,7 @@ import (
 // Create a federation room. Bob bans Alice. Bob unbans Alice. Bob invites Alice (unbanning her). Ensure the invite is
 // received and can be accepted.
 func TestUnbanViaInvite(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintFederationOneToOneRoom)
+	deployment := complement.Deploy(t, 2)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})

--- a/tests/federation_room_ban_test.go
+++ b/tests/federation_room_ban_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 )
 
 // Regression test for https://github.com/matrix-org/synapse/issues/1563
@@ -15,8 +16,8 @@ func TestUnbanViaInvite(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintFederationOneToOneRoom)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	bob := deployment.Client(t, "hs2", "@bob:hs2")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	bob := deployment.Register(t, "hs2", helpers.RegistrationOpts{})
 
 	roomID := bob.MustCreateRoom(t, map[string]interface{}{
 		"preset": "public_chat",

--- a/tests/federation_room_event_auth_test.go
+++ b/tests/federation_room_event_auth_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/internal/federation"
 	"github.com/matrix-org/complement/must"
 )
@@ -108,7 +109,7 @@ func TestInboundFederationRejectsEventsWithRejectedAuthEvents(t *testing.T) {
 	}).Methods("GET")
 
 	// have Alice create a room, and then join it
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 	testRoomID := alice.MustCreateRoom(t, map[string]interface{}{
 		"preset": "public_chat",
 	})

--- a/tests/federation_room_event_auth_test.go
+++ b/tests/federation_room_event_auth_test.go
@@ -74,7 +74,7 @@ func TestInboundFederationRejectsEventsWithRejectedAuthEvents(t *testing.T) {
 	 * /rooms/{roomID}/event. If it is rejected, we should get a 404.
 	 */
 
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 	srv := federation.NewServer(t, deployment,
 		federation.HandleKeyRequests(),

--- a/tests/federation_room_get_missing_events_test.go
+++ b/tests/federation_room_get_missing_events_test.go
@@ -42,7 +42,7 @@ func TestGetMissingEventsGapFilling(t *testing.T) {
 	// 4) Respond to /get_missing_events with the missing events if the request is well-formed.
 	// 5) Ensure the HS doesn't do /state_ids or /state
 	// 6) Ensure Alice sees all injected events in the correct order.
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	srv := federation.NewServer(t, deployment,
@@ -166,7 +166,7 @@ func TestGetMissingEventsGapFilling(t *testing.T) {
 //
 // sytest: Outbound federation will ignore a missing event with bad JSON for room version 6
 func TestOutboundFederationIgnoresMissingEventWithBadJSONForRoomVersion6(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
@@ -329,7 +329,7 @@ func TestOutboundFederationIgnoresMissingEventWithBadJSONForRoomVersion6(t *test
 }
 
 func TestInboundCanReturnMissingEvents(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})

--- a/tests/federation_room_get_missing_events_test.go
+++ b/tests/federation_room_get_missing_events_test.go
@@ -60,7 +60,7 @@ func TestGetMissingEventsGapFilling(t *testing.T) {
 	cancel := srv.Listen()
 	defer cancel()
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 	bob := srv.UserID("bob")
 
 	// 1) Create a room between the HS and Complement.
@@ -169,7 +169,7 @@ func TestOutboundFederationIgnoresMissingEventWithBadJSONForRoomVersion6(t *test
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	srv := federation.NewServer(t, deployment,
 		federation.HandleKeyRequests(),
@@ -332,7 +332,7 @@ func TestInboundCanReturnMissingEvents(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	srv := federation.NewServer(t, deployment,
 		federation.HandleKeyRequests(),

--- a/tests/federation_room_invite_test.go
+++ b/tests/federation_room_invite_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/gomatrixserverlib"
 
-	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/internal/federation"
 )
@@ -18,7 +17,7 @@ import (
 // alice sends an invite to charlie@hs2, which he rejects.
 // We check that delia sees the rejection.
 func TestFederationRejectInvite(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintFederationTwoLocalOneRemote)
+	deployment := complement.Deploy(t, 2)
 	defer deployment.Destroy(t)
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 	charlie := deployment.Register(t, "hs2", helpers.RegistrationOpts{})

--- a/tests/federation_room_invite_test.go
+++ b/tests/federation_room_invite_test.go
@@ -20,8 +20,8 @@ import (
 func TestFederationRejectInvite(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintFederationTwoLocalOneRemote)
 	defer deployment.Destroy(t)
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	charlie := deployment.Client(t, "hs2", "@charlie:hs2")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	charlie := deployment.Register(t, "hs2", helpers.RegistrationOpts{})
 
 	// we'll awaken this Waiter when we receive a membership event for Charlie
 	var waiter *helpers.Waiter

--- a/tests/federation_room_join_test.go
+++ b/tests/federation_room_join_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/internal/federation"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
@@ -41,7 +42,7 @@ func TestJoinViaRoomIDAndServerName(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintFederationOneToOneRoom)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	acceptMakeSendJoinRequests := true
 
@@ -78,7 +79,7 @@ func TestJoinViaRoomIDAndServerName(t *testing.T) {
 	acceptMakeSendJoinRequests = false
 
 	// join the room using ?server_name on HS2
-	bob := deployment.Client(t, "hs2", "@bob:hs2")
+	bob := deployment.Register(t, "hs2", helpers.RegistrationOpts{})
 	roomID := bob.MustJoinRoom(t, serverRoom.RoomID, []string{"hs1"})
 	must.Equal(t, roomID, serverRoom.RoomID, "joined room mismatch")
 }
@@ -89,8 +90,8 @@ func TestJoinFederatedRoomFailOver(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintFederationOneToOneRoom)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	bob := deployment.Client(t, "hs2", "@bob:hs2")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	bob := deployment.Register(t, "hs2", helpers.RegistrationOpts{})
 
 	srv := federation.NewServer(t, deployment)
 	cancel := srv.Listen()
@@ -129,7 +130,7 @@ func TestJoinFederatedRoomWithUnverifiableEvents(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	srv := federation.NewServer(t, deployment,
 		federation.HandleKeyRequests(),
@@ -308,7 +309,7 @@ func TestBannedUserCannotSendJoin(t *testing.T) {
 	charlie := srv.UserID("charlie")
 
 	// alice creates a room, and bans charlie from it.
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 	roomID := alice.MustCreateRoom(t, map[string]interface{}{
 		"preset": "public_chat",
 	})
@@ -402,7 +403,7 @@ func testValidationForSendMembershipEndpoint(t *testing.T, baseApiPath, expected
 	defer cancel()
 
 	// alice creates a room, and charlie joins it
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 	roomId := alice.MustCreateRoom(t, createRoomOpts)
 	charlie := srv.UserID("charlie")
 	room := srv.MustJoinRoom(t, deployment, "hs1", roomId, charlie)
@@ -510,8 +511,8 @@ func TestSendJoinPartialStateResponse(t *testing.T) {
 	// annoyingly we can't get to the room that alice and bob already share (see https://github.com/matrix-org/complement/issues/254)
 	// so we have to create a new one.
 	// alice creates a room, which bob joins
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	bob := deployment.Client(t, "hs1", "@bob:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 	roomID := alice.MustCreateRoom(t, map[string]interface{}{"preset": "public_chat"})
 	bob.MustJoinRoom(t, roomID, nil)
 
@@ -587,11 +588,10 @@ func TestJoinFederatedRoomFromApplicationServiceBridgeUser(t *testing.T) {
 
 	// Create the application service bridge user to try to join the room from
 	asUserID := "@the-bridge-user:hs1"
-	as := deployment.Client(t, "hs1", asUserID)
+	as := deployment.AppServiceUser(t, "hs1", asUserID)
 
 	// Create the federated remote user which will create the room
-	remoteUserID := "@charlie:hs2"
-	remoteCharlie := deployment.Client(t, "hs2", remoteUserID)
+	remoteCharlie := deployment.Register(t, "hs2", helpers.RegistrationOpts{})
 
 	t.Run("join remote federated room as application service user", func(t *testing.T) {
 		//t.Parallel()

--- a/tests/federation_room_join_test.go
+++ b/tests/federation_room_join_test.go
@@ -39,7 +39,7 @@ import (
 // m.room.create event would pick that up. We also can't tear down the Complement
 // server because otherwise signing key lookups will fail.
 func TestJoinViaRoomIDAndServerName(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintFederationOneToOneRoom)
+	deployment := complement.Deploy(t, 2)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
@@ -87,7 +87,7 @@ func TestJoinViaRoomIDAndServerName(t *testing.T) {
 // This tests that joining a room with multiple ?server_name=s works correctly.
 // The join should succeed even if the first server is not in the room.
 func TestJoinFederatedRoomFailOver(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintFederationOneToOneRoom)
+	deployment := complement.Deploy(t, 2)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
@@ -127,7 +127,7 @@ func TestJoinFederatedRoomFailOver(t *testing.T) {
 // the properties listed above, then asking HS1 to join them and make sure that
 // they 200 OK.
 func TestJoinFederatedRoomWithUnverifiableEvents(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
@@ -293,7 +293,7 @@ func TestJoinFederatedRoomWithUnverifiableEvents(t *testing.T) {
 
 // This test checks that users cannot circumvent the auth checks via send_join.
 func TestBannedUserCannotSendJoin(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	srv := federation.NewServer(t, deployment,
@@ -392,7 +392,7 @@ func testValidationForSendMembershipEndpoint(t *testing.T, baseApiPath, expected
 		}
 	}
 
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	srv := federation.NewServer(t, deployment,
@@ -495,7 +495,7 @@ func testValidationForSendMembershipEndpoint(t *testing.T, baseApiPath, expected
 // Will be skipped if the server returns a full-state response.
 func TestSendJoinPartialStateResponse(t *testing.T) {
 	// start with a homeserver with two users
-	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	srv := federation.NewServer(t, deployment,
@@ -583,7 +583,7 @@ func TestJoinFederatedRoomFromApplicationServiceBridgeUser(t *testing.T) {
 	// Dendrite doesn't read AS registration files from Complement yet
 	runtime.SkipIf(t, runtime.Dendrite) // FIXME: https://github.com/matrix-org/complement/issues/514
 
-	deployment := complement.Deploy(t, b.BlueprintHSWithApplicationService)
+	deployment := complement.OldDeploy(t, b.BlueprintHSWithApplicationService)
 	defer deployment.Destroy(t)
 
 	// Create the application service bridge user to try to join the room from

--- a/tests/federation_room_join_test.go
+++ b/tests/federation_room_join_test.go
@@ -183,7 +183,7 @@ func TestJoinFederatedRoomWithUnverifiableEvents(t *testing.T) {
 			},
 		})
 		newSignaturesBlock := map[string]interface{}{
-			deployment.Config.HostnameRunningComplement: map[string]string{
+			deployment.GetConfig().HostnameRunningComplement: map[string]string{
 				string(srv.KeyID): "/3z+pJjiJXWhwfqIEzmNksvBHCoXTktK/y0rRuWJXw6i1+ygRG/suDCKhFuuz6gPapRmEMPVILi2mJqHHXPKAg",
 			},
 		}
@@ -214,7 +214,7 @@ func TestJoinFederatedRoomWithUnverifiableEvents(t *testing.T) {
 			},
 		})
 		newSignaturesBlock := map[string]interface{}{
-			deployment.Config.HostnameRunningComplement: map[string]string{
+			deployment.GetConfig().HostnameRunningComplement: map[string]string{
 				string(srv.KeyID) + "bogus": "/3z+pJjiJXWhwfqIEzmNksvBHCoXTktK/y0rRuWJXw6i1+ygRG/suDCKhFuuz6gPapRmEMPVILi2mJqHHXPKAg",
 			},
 		}
@@ -249,7 +249,7 @@ func TestJoinFederatedRoomWithUnverifiableEvents(t *testing.T) {
 			},
 		}).JSON()
 		rawSig, err := json.Marshal(map[string]interface{}{
-			deployment.Config.HostnameRunningComplement: map[string]string{
+			deployment.GetConfig().HostnameRunningComplement: map[string]string{
 				string(srv.KeyID): "/3z+pJjiJXWhwfqIEzmNksvBHCoXTktK/y0rRuWJXw6i1+ygRG/suDCKhFuuz6gPapRmEMPVILi2mJqHHXPKAg",
 			},
 		})

--- a/tests/federation_room_send_test.go
+++ b/tests/federation_room_send_test.go
@@ -54,7 +54,7 @@ func TestOutboundFederationSend(t *testing.T) {
 	roomAlias := srv.MakeAliasMapping("flibble", serverRoom.RoomID)
 
 	// the local homeserver joins the room
-	alice.MustJoinRoom(t, roomAlias, []string{deployment.Config.HostnameRunningComplement})
+	alice.MustJoinRoom(t, roomAlias, []string{deployment.GetConfig().HostnameRunningComplement})
 
 	// the local homeserver sends an event into the room
 	alice.SendEventSynced(t, serverRoom.RoomID, b.Event{

--- a/tests/federation_room_send_test.go
+++ b/tests/federation_room_send_test.go
@@ -20,7 +20,7 @@ import (
 
 // Tests that the server is capable of making outbound /send requests
 func TestOutboundFederationSend(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})

--- a/tests/federation_room_send_test.go
+++ b/tests/federation_room_send_test.go
@@ -23,7 +23,7 @@ func TestOutboundFederationSend(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	waiter := helpers.NewWaiter()
 	wantEventType := "m.room.message"

--- a/tests/federation_room_typing_test.go
+++ b/tests/federation_room_typing_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 )
 
 // sytest: Typing notifications also sent to remote room members
@@ -13,9 +14,9 @@ func TestRemoteTyping(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintFederationTwoLocalOneRemote)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	bob := deployment.Client(t, "hs1", "@bob:hs1")
-	charlie := deployment.Client(t, "hs2", "@charlie:hs2")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	charlie := deployment.Register(t, "hs2", helpers.RegistrationOpts{})
 
 	roomID := alice.MustCreateRoom(t, map[string]interface{}{"preset": "public_chat"})
 	bob.MustJoinRoom(t, roomID, nil)

--- a/tests/federation_room_typing_test.go
+++ b/tests/federation_room_typing_test.go
@@ -4,14 +4,13 @@ import (
 	"testing"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/helpers"
 )
 
 // sytest: Typing notifications also sent to remote room members
 func TestRemoteTyping(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintFederationTwoLocalOneRemote)
+	deployment := complement.Deploy(t, 2)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})

--- a/tests/federation_rooms_invite_test.go
+++ b/tests/federation_rooms_invite_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/matrix-org/gomatrixserverlib/spec"
 	"github.com/tidwall/gjson"
 
-	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
@@ -15,7 +14,7 @@ import (
 )
 
 func TestFederationRoomsInvite(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintFederationOneToOneRoom)
+	deployment := complement.Deploy(t, 2)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})

--- a/tests/federation_rooms_invite_test.go
+++ b/tests/federation_rooms_invite_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
@@ -17,8 +18,8 @@ func TestFederationRoomsInvite(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintFederationOneToOneRoom)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	bob := deployment.Client(t, "hs2", "@bob:hs2")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	bob := deployment.Register(t, "hs2", helpers.RegistrationOpts{})
 
 	t.Run("Parallel", func(t *testing.T) {
 		// sytest: Invited user can reject invite over federation

--- a/tests/federation_unreject_rejected_test.go
+++ b/tests/federation_unreject_rejected_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/internal/federation"
 )
 
@@ -20,7 +21,7 @@ import (
 func TestUnrejectRejectedEvents(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	srv := federation.NewServer(t, deployment,
 		federation.HandleKeyRequests(),

--- a/tests/federation_unreject_rejected_test.go
+++ b/tests/federation_unreject_rejected_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/internal/federation"
@@ -19,7 +18,7 @@ import (
 // event B is unrejected on the second pass and will appear in
 // the /sync response AFTER event A.
 func TestUnrejectRejectedEvents(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 

--- a/tests/federation_upload_keys_test.go
+++ b/tests/federation_upload_keys_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/tidwall/gjson"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
@@ -17,7 +16,7 @@ import (
 )
 
 func TestFederationKeyUploadQuery(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintFederationOneToOneRoom)
+	deployment := complement.Deploy(t, 2)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})

--- a/tests/federation_upload_keys_test.go
+++ b/tests/federation_upload_keys_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
@@ -19,8 +20,8 @@ func TestFederationKeyUploadQuery(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintFederationOneToOneRoom)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	bob := deployment.Client(t, "hs2", "@bob:hs2")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	bob := deployment.Register(t, "hs2", helpers.RegistrationOpts{})
 
 	// Do an initial sync so that we can see the changes come down sync.
 	_, nextBatchBeforeKeyUpload := bob.MustSync(t, client.SyncReq{})

--- a/tests/knock_restricted_test.go
+++ b/tests/knock_restricted_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
+	"github.com/matrix-org/complement/helpers"
 )
 
 var (
@@ -49,7 +50,7 @@ func TestRestrictedRoomsLocalJoinInMSC3787Room(t *testing.T) {
 	alice, allowed_room, room := setupRestrictedRoom(t, deployment, roomVersion, joinRule)
 
 	// Create a second user on the same homeserver.
-	bob := deployment.Client(t, "hs1", "@bob:hs1")
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	// Execute the checks.
 	checkRestrictedRoom(t, alice, bob, allowed_room, room, joinRule)
@@ -64,7 +65,7 @@ func TestRestrictedRoomsRemoteJoinInMSC3787Room(t *testing.T) {
 	alice, allowed_room, room := setupRestrictedRoom(t, deployment, roomVersion, joinRule)
 
 	// Create a second user on a different homeserver.
-	bob := deployment.Client(t, "hs2", "@bob:hs2")
+	bob := deployment.Register(t, "hs2", helpers.RegistrationOpts{})
 
 	// Execute the checks.
 	checkRestrictedRoom(t, alice, bob, allowed_room, room, joinRule)

--- a/tests/knock_restricted_test.go
+++ b/tests/knock_restricted_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/helpers"
 )
 
@@ -43,7 +42,7 @@ func TestCannotSendKnockViaSendKnockInMSC3787Room(t *testing.T) {
 
 // See TestRestrictedRoomsLocalJoin
 func TestRestrictedRoomsLocalJoinInMSC3787Room(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	// Setup the user, allowed room, and restricted room.
@@ -58,7 +57,7 @@ func TestRestrictedRoomsLocalJoinInMSC3787Room(t *testing.T) {
 
 // See TestRestrictedRoomsRemoteJoin
 func TestRestrictedRoomsRemoteJoinInMSC3787Room(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintFederationOneToOneRoom)
+	deployment := complement.Deploy(t, 2)
 	defer deployment.Destroy(t)
 
 	// Setup the user, allowed room, and restricted room.

--- a/tests/knocking_test.go
+++ b/tests/knocking_test.go
@@ -40,7 +40,7 @@ func TestKnocking(t *testing.T) {
 }
 
 func doTestKnocking(t *testing.T, roomVersion string, joinRule string) {
-	deployment := complement.Deploy(t, b.BlueprintFederationTwoLocalOneRemote)
+	deployment := complement.Deploy(t, 2)
 	defer deployment.Destroy(t)
 
 	// Create a client for one local user
@@ -339,7 +339,7 @@ func TestKnockRoomsInPublicRoomsDirectory(t *testing.T) {
 }
 
 func doTestKnockRoomsInPublicRoomsDirectory(t *testing.T, roomVersion string, joinRule string) {
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	// Create a client for a local user

--- a/tests/knocking_test.go
+++ b/tests/knocking_test.go
@@ -44,16 +44,13 @@ func doTestKnocking(t *testing.T, roomVersion string, joinRule string) {
 	defer deployment.Destroy(t)
 
 	// Create a client for one local user
-	aliceUserID := "@alice:hs1"
-	alice := deployment.Client(t, "hs1", aliceUserID)
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	// Create a client for another local user
-	bobUserID := "@bob:hs1"
-	bob := deployment.Client(t, "hs1", bobUserID)
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	// Create a client for a remote user
-	charlieUserID := "@charlie:hs2"
-	charlie := deployment.Client(t, "hs2", charlieUserID)
+	charlie := deployment.Register(t, "hs2", helpers.RegistrationOpts{})
 
 	// Create a server to observe
 	inviteWaiter := helpers.NewWaiter()
@@ -346,8 +343,7 @@ func doTestKnockRoomsInPublicRoomsDirectory(t *testing.T, roomVersion string, jo
 	defer deployment.Destroy(t)
 
 	// Create a client for a local user
-	aliceUserID := "@alice:hs1"
-	alice := deployment.Client(t, "hs1", aliceUserID)
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	// Create an invite-only room with the knock room version
 	roomID := alice.MustCreateRoom(t, map[string]interface{}{

--- a/tests/media_filename_test.go
+++ b/tests/media_filename_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/internal/data"
@@ -17,7 +16,7 @@ const asciiFileName = "ascii"
 const unicodeFileName = "\xf0\x9f\x90\x94"
 
 func TestMediaFilenames(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintFederationOneToOneRoom)
+	deployment := complement.Deploy(t, 2)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})

--- a/tests/media_filename_test.go
+++ b/tests/media_filename_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/internal/data"
 	"github.com/matrix-org/complement/runtime"
 )
@@ -19,8 +20,8 @@ func TestMediaFilenames(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintFederationOneToOneRoom)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	bob := deployment.Client(t, "hs2", "@bob:hs2")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	bob := deployment.Register(t, "hs2", helpers.RegistrationOpts{})
 
 	t.Run("Parallel", func(t *testing.T) {
 

--- a/tests/media_nofilename_test.go
+++ b/tests/media_nofilename_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/internal/federation"
 	"github.com/matrix-org/complement/must"
 )
@@ -17,7 +18,7 @@ func TestMediaWithoutFileName(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	remoteMediaId := "PlainTextFile"
 	remoteFile := []byte("Hello from the other side")

--- a/tests/media_nofilename_test.go
+++ b/tests/media_nofilename_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/internal/federation"
 	"github.com/matrix-org/complement/must"
@@ -15,7 +14,7 @@ import (
 
 // Can handle uploads and remote/local downloads without a file name
 func TestMediaWithoutFileName(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})

--- a/tests/media_thumbnail_test.go
+++ b/tests/media_thumbnail_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/internal/data"
@@ -20,7 +19,7 @@ import (
 
 // sytest: POSTed media can be thumbnailed
 func TestLocalPngThumbnail(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
@@ -35,7 +34,7 @@ func TestLocalPngThumbnail(t *testing.T) {
 
 // sytest: Remote media can be thumbnailed
 func TestRemotePngThumbnail(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintFederationOneToOneRoom)
+	deployment := complement.Deploy(t, 2)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})

--- a/tests/media_thumbnail_test.go
+++ b/tests/media_thumbnail_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/internal/data"
 )
 
@@ -22,7 +23,7 @@ func TestLocalPngThumbnail(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	fileName := "test.png"
 	contentType := "image/png"
@@ -37,8 +38,8 @@ func TestRemotePngThumbnail(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintFederationOneToOneRoom)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	bob := deployment.Client(t, "hs2", "@bob:hs2")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	bob := deployment.Register(t, "hs2", helpers.RegistrationOpts{})
 
 	fileName := "test.png"
 	contentType := "image/png"

--- a/tests/msc2836/msc2836_test.go
+++ b/tests/msc2836/msc2836_test.go
@@ -44,7 +44,7 @@ func TestEventRelationships(t *testing.T) {
 	defer deployment.Destroy(t)
 
 	// Create the room and send events A,B,C,D
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 	roomID := alice.MustCreateRoom(t, map[string]interface{}{
 		"preset": "public_chat",
 	})
@@ -91,7 +91,7 @@ func TestEventRelationships(t *testing.T) {
 	t.Logf("Event ID A:%s  B:%s  C:%s  D:%s", eventA, eventB, eventC, eventD)
 
 	// Join the room from another server
-	bob := deployment.Client(t, "hs2", "@bob:hs2")
+	bob := deployment.Register(t, "hs2", helpers.RegistrationOpts{})
 	_ = bob.MustJoinRoom(t, roomID, []string{"hs1"})
 	bob.MustSyncUntil(t, client.SyncReq{}, client.SyncJoinedTo(bob.UserID, roomID))
 
@@ -195,9 +195,9 @@ func TestFederatedEventRelationships(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
-	srv := federation.NewServer(t, deployment.GetConfig(), deployment.RoundTripper(),
+	srv := federation.NewServer(t, deployment,
 		federation.HandleKeyRequests(),
 		federation.HandleMakeSendJoinRequests(),
 		federation.HandleTransactionRequests(nil, nil),

--- a/tests/msc2836/msc2836_test.go
+++ b/tests/msc2836/msc2836_test.go
@@ -40,7 +40,7 @@ import (
 // an event which the server does have, event B, to ensure that this request also works and also does
 // federated hits to return missing events (A,C).
 func TestEventRelationships(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintFederationOneToOneRoom)
+	deployment := complement.Deploy(t, 2)
 	defer deployment.Destroy(t)
 
 	// Create the room and send events A,B,C,D
@@ -192,7 +192,7 @@ func TestEventRelationships(t *testing.T) {
 // We then check that B, which wasn't on the return path on the previous request, was persisted by calling
 // /event_relationships again with event ID 'A' and direction 'down'.
 func TestFederatedEventRelationships(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})

--- a/tests/msc2836/msc2836_test.go
+++ b/tests/msc2836/msc2836_test.go
@@ -197,7 +197,7 @@ func TestFederatedEventRelationships(t *testing.T) {
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")
 
-	srv := federation.NewServer(t, deployment,
+	srv := federation.NewServer(t, deployment.GetConfig(), deployment.RoundTripper(),
 		federation.HandleKeyRequests(),
 		federation.HandleMakeSendJoinRequests(),
 		federation.HandleTransactionRequests(nil, nil),

--- a/tests/msc3391/msc3391_test.go
+++ b/tests/msc3391/msc3391_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
@@ -23,7 +22,7 @@ const testAccountDataType = "org.example.test"
 var testAccountDataContent = map[string]interface{}{"test_data": 1}
 
 func TestRemovingAccountData(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	// Create a user to manipulate the account data of

--- a/tests/msc3391/msc3391_test.go
+++ b/tests/msc3391/msc3391_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 
@@ -26,8 +27,7 @@ func TestRemovingAccountData(t *testing.T) {
 	defer deployment.Destroy(t)
 
 	// Create a user to manipulate the account data of
-	aliceUserID := "@alice:hs1"
-	alice := deployment.Client(t, "hs1", aliceUserID)
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	// And create a room with that user where we can store some room account data
 	roomID := alice.MustCreateRoom(t, map[string]interface{}{})

--- a/tests/msc3874/room_messages_relation_filter_test.go
+++ b/tests/msc3874/room_messages_relation_filter_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/tidwall/gjson"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
@@ -18,7 +17,7 @@ import (
 
 func TestFilterMessagesByRelType(t *testing.T) {
 	runtime.SkipIf(t, runtime.Dendrite) // flakey
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})

--- a/tests/msc3874/room_messages_relation_filter_test.go
+++ b/tests/msc3874/room_messages_relation_filter_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 	"github.com/matrix-org/complement/runtime"
@@ -20,7 +21,7 @@ func TestFilterMessagesByRelType(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	roomID := alice.MustCreateRoom(t, map[string]interface{}{"preset": "public_chat"})
 

--- a/tests/msc3890/msc3890_test.go
+++ b/tests/msc3890/msc3890_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
@@ -18,7 +17,7 @@ import (
 
 func TestDeletingDeviceRemovesDeviceLocalNotificationSettings(t *testing.T) {
 	// Create a deployment with a single user
-	deployment := complement.Deploy(t, b.BlueprintCleanHS)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	t.Log("Alice registers on device 1 and logs in to device 2.")

--- a/tests/msc3890/msc3890_test.go
+++ b/tests/msc3890/msc3890_test.go
@@ -25,8 +25,8 @@ func TestDeletingDeviceRemovesDeviceLocalNotificationSettings(t *testing.T) {
 	aliceLocalpart := "alice"
 	alicePassword := "hunter2"
 	aliceDeviceOne := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-		Localpart: aliceLocalpart,
-		Password:  alicePassword,
+		LocalpartSuffix: aliceLocalpart,
+		Password:        alicePassword,
 	})
 	aliceDeviceTwo := deployment.Login(t, "hs1", aliceDeviceOne, helpers.LoginOpts{
 		Password: alicePassword,

--- a/tests/msc3890/msc3890_test.go
+++ b/tests/msc3890/msc3890_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 	"github.com/tidwall/gjson"
@@ -23,8 +24,13 @@ func TestDeletingDeviceRemovesDeviceLocalNotificationSettings(t *testing.T) {
 	t.Log("Alice registers on device 1 and logs in to device 2.")
 	aliceLocalpart := "alice"
 	alicePassword := "hunter2"
-	aliceDeviceOne := deployment.RegisterUser(t, "hs1", aliceLocalpart, alicePassword, false)
-	aliceDeviceTwo := deployment.LoginUser(t, "hs1", aliceLocalpart, alicePassword)
+	aliceDeviceOne := deployment.Register(t, "hs1", helpers.RegistrationOpts{
+		Localpart: aliceLocalpart,
+		Password:  alicePassword,
+	})
+	aliceDeviceTwo := deployment.Login(t, "hs1", aliceDeviceOne, helpers.LoginOpts{
+		Password: alicePassword,
+	})
 
 	accountDataType := "org.matrix.msc3890.local_notification_settings." + aliceDeviceTwo.DeviceID
 	accountDataContent := map[string]interface{}{"is_silenced": true}

--- a/tests/msc3902/federation_room_join_partial_state_test.go
+++ b/tests/msc3902/federation_room_join_partial_state_test.go
@@ -507,7 +507,7 @@ func TestPartialStateJoin(t *testing.T) {
 	t.Run("CanReceiveTypingDuringPartialStateJoin", func(t *testing.T) {
 		deployment := complement.Deploy(t, b.BlueprintAlice)
 		defer deployment.Destroy(t)
-		alice := deployment.Client(t, "hs1", "@alice:hs1")
+		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 		server := createTestServer(t, deployment)
 		cancel := server.Listen()
@@ -577,7 +577,7 @@ func TestPartialStateJoin(t *testing.T) {
 		t.Skip("Presence EDUs are currently dropped during a resync")
 		deployment := complement.Deploy(t, b.BlueprintAlice)
 		defer deployment.Destroy(t)
-		alice := deployment.Client(t, "hs1", "@alice:hs1")
+		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 		server := createTestServer(t, deployment)
 		cancel := server.Listen()
@@ -624,7 +624,7 @@ func TestPartialStateJoin(t *testing.T) {
 	t.Run("CanReceiveToDeviceDuringPartialStateJoin", func(t *testing.T) {
 		deployment := complement.Deploy(t, b.BlueprintAlice)
 		defer deployment.Destroy(t)
-		alice := deployment.Client(t, "hs1", "@alice:hs1")
+		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 		server := createTestServer(t, deployment)
 		cancel := server.Listen()
@@ -674,7 +674,7 @@ func TestPartialStateJoin(t *testing.T) {
 	t.Run("CanReceiveReceiptDuringPartialStateJoin", func(t *testing.T) {
 		deployment := complement.Deploy(t, b.BlueprintAlice)
 		defer deployment.Destroy(t)
-		alice := deployment.Client(t, "hs1", "@alice:hs1")
+		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 		server := createTestServer(t, deployment)
 		cancel := server.Listen()
@@ -727,7 +727,7 @@ func TestPartialStateJoin(t *testing.T) {
 	t.Run("CanReceiveDeviceListUpdateDuringPartialStateJoin", func(t *testing.T) {
 		deployment := complement.Deploy(t, b.BlueprintAlice)
 		defer deployment.Destroy(t)
-		alice := deployment.Client(t, "hs1", "@alice:hs1")
+		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 		server := createTestServer(t, deployment)
 		cancel := server.Listen()
@@ -778,7 +778,7 @@ func TestPartialStateJoin(t *testing.T) {
 	t.Run("CanReceiveSigningKeyUpdateDuringPartialStateJoin", func(t *testing.T) {
 		deployment := complement.Deploy(t, b.BlueprintAlice)
 		defer deployment.Destroy(t)
-		alice := deployment.Client(t, "hs1", "@alice:hs1")
+		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 		server := createTestServer(t, deployment)
 		cancel := server.Listen()
@@ -1237,8 +1237,8 @@ func TestPartialStateJoin(t *testing.T) {
 		// set up 3 homeservers: hs1, hs2 and complement
 		deployment := complement.Deploy(t, b.BlueprintFederationTwoLocalOneRemote)
 		defer deployment.Destroy(t)
-		alice := deployment.Client(t, "hs1", "@alice:hs1")
-		charlie := deployment.Client(t, "hs2", "@charlie:hs2")
+		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+		charlie := deployment.Register(t, "hs2", helpers.RegistrationOpts{})
 
 		// create a public room
 		roomID := alice.MustCreateRoom(t, map[string]interface{}{

--- a/tests/msc3902/federation_room_join_partial_state_test.go
+++ b/tests/msc3902/federation_room_join_partial_state_test.go
@@ -221,7 +221,7 @@ func TestPartialStateJoin(t *testing.T) {
 		return syncToken
 	}
 
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	// Test that an eager (i.e. NOT lazy-loading members) /sync request made during a
@@ -505,7 +505,7 @@ func TestPartialStateJoin(t *testing.T) {
 
 	// we should be able to receive typing EDU over federation during the resync
 	t.Run("CanReceiveTypingDuringPartialStateJoin", func(t *testing.T) {
-		deployment := complement.Deploy(t, b.BlueprintAlice)
+		deployment := complement.Deploy(t, 1)
 		defer deployment.Destroy(t)
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
@@ -575,7 +575,7 @@ func TestPartialStateJoin(t *testing.T) {
 	t.Run("CanReceivePresenceDuringPartialStateJoin", func(t *testing.T) {
 		// See https://github.com/matrix-org/synapse/issues/13008")
 		t.Skip("Presence EDUs are currently dropped during a resync")
-		deployment := complement.Deploy(t, b.BlueprintAlice)
+		deployment := complement.Deploy(t, 1)
 		defer deployment.Destroy(t)
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
@@ -622,7 +622,7 @@ func TestPartialStateJoin(t *testing.T) {
 
 	// we should be able to receive to_device EDU over federation during the resync
 	t.Run("CanReceiveToDeviceDuringPartialStateJoin", func(t *testing.T) {
-		deployment := complement.Deploy(t, b.BlueprintAlice)
+		deployment := complement.Deploy(t, 1)
 		defer deployment.Destroy(t)
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
@@ -672,7 +672,7 @@ func TestPartialStateJoin(t *testing.T) {
 
 	// we should be able to receive receipt EDU over federation during the resync
 	t.Run("CanReceiveReceiptDuringPartialStateJoin", func(t *testing.T) {
-		deployment := complement.Deploy(t, b.BlueprintAlice)
+		deployment := complement.Deploy(t, 1)
 		defer deployment.Destroy(t)
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
@@ -725,7 +725,7 @@ func TestPartialStateJoin(t *testing.T) {
 
 	// we should be able to receive device list update EDU over federation during the resync
 	t.Run("CanReceiveDeviceListUpdateDuringPartialStateJoin", func(t *testing.T) {
-		deployment := complement.Deploy(t, b.BlueprintAlice)
+		deployment := complement.Deploy(t, 1)
 		defer deployment.Destroy(t)
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
@@ -776,7 +776,7 @@ func TestPartialStateJoin(t *testing.T) {
 
 	// we should be able to receive signing key update EDU over federation during the resync
 	t.Run("CanReceiveSigningKeyUpdateDuringPartialStateJoin", func(t *testing.T) {
-		deployment := complement.Deploy(t, b.BlueprintAlice)
+		deployment := complement.Deploy(t, 1)
 		defer deployment.Destroy(t)
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
@@ -1235,7 +1235,7 @@ func TestPartialStateJoin(t *testing.T) {
 	// partial state.
 	t.Run("PartialStateJoinSyncsUsingOtherHomeservers", func(t *testing.T) {
 		// set up 3 homeservers: hs1, hs2 and complement
-		deployment := complement.Deploy(t, b.BlueprintFederationTwoLocalOneRemote)
+		deployment := complement.Deploy(t, 2)
 		defer deployment.Destroy(t)
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 		charlie := deployment.Register(t, "hs2", helpers.RegistrationOpts{})

--- a/tests/msc3902/federation_room_join_partial_state_test.go
+++ b/tests/msc3902/federation_room_join_partial_state_test.go
@@ -246,7 +246,7 @@ func TestPartialStateJoin(t *testing.T) {
 
 	eagerSyncDuringPartialStateJoinTest := func(t *testing.T, usernameSuffix string, incremental bool) {
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t1alice_" + usernameSuffix,
+			LocalpartSuffix: "t1alice_" + usernameSuffix,
 		})
 
 		// Maintain two sync tokens: once for the eager syncs under test, and another
@@ -376,7 +376,7 @@ func TestPartialStateJoin(t *testing.T) {
 	// resync completes. This test does exactly that.
 	t.Run("EagerLongPollingSyncWokenWhenResyncCompletes", func(t *testing.T) {
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t1alice_long_polling",
+			LocalpartSuffix: "t1alice_long_polling",
 		})
 
 		t.Log("Alice partial-joins a remote room.")
@@ -441,7 +441,7 @@ func TestPartialStateJoin(t *testing.T) {
 	// when Alice does a lazy-loading sync, she should see the room immediately
 	t.Run("CanLazyLoadingSyncDuringPartialStateJoin", func(t *testing.T) {
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t2alice",
+			LocalpartSuffix: "t2alice",
 		})
 
 		server := createTestServer(t, deployment)
@@ -463,7 +463,7 @@ func TestPartialStateJoin(t *testing.T) {
 	// we should be able to send events in the room, during the resync
 	t.Run("CanSendEventsDuringPartialStateJoin", func(t *testing.T) {
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t3alice",
+			LocalpartSuffix: "t3alice",
 		})
 
 		server := createTestServer(t, deployment)
@@ -805,7 +805,7 @@ func TestPartialStateJoin(t *testing.T) {
 	// we should be able to receive events over federation during the resync
 	t.Run("CanReceiveEventsDuringPartialStateJoin", func(t *testing.T) {
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t4alice",
+			LocalpartSuffix: "t4alice",
 		})
 		syncToken := getSyncToken(t, alice)
 
@@ -829,7 +829,7 @@ func TestPartialStateJoin(t *testing.T) {
 	// we should be able to receive events with a missing prev event over federation during the resync
 	t.Run("CanReceiveEventsWithMissingParentsDuringPartialStateJoin", func(t *testing.T) {
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t5alice",
+			LocalpartSuffix: "t5alice",
 		})
 		syncToken := getSyncToken(t, alice)
 
@@ -869,7 +869,7 @@ func TestPartialStateJoin(t *testing.T) {
 	// we should be able to receive events with partially missing prev events over federation during the resync
 	t.Run("CanReceiveEventsWithHalfMissingParentsDuringPartialStateJoin", func(t *testing.T) {
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t6alice",
+			LocalpartSuffix: "t6alice",
 		})
 		syncToken := getSyncToken(t, alice)
 
@@ -912,7 +912,7 @@ func TestPartialStateJoin(t *testing.T) {
 	// over federation during the resync
 	t.Run("CanReceiveEventsWithHalfMissingGrandparentsDuringPartialStateJoin", func(t *testing.T) {
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t7alice",
+			LocalpartSuffix: "t7alice",
 		})
 		syncToken := getSyncToken(t, alice)
 
@@ -959,7 +959,7 @@ func TestPartialStateJoin(t *testing.T) {
 	// partial room state.
 	t.Run("Lazy-loading initial sync includes remote memberships during partial state join", func(t *testing.T) {
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t8alice",
+			LocalpartSuffix: "t8alice",
 		})
 
 		server := createTestServer(t, deployment)
@@ -1000,7 +1000,7 @@ func TestPartialStateJoin(t *testing.T) {
 	// partial room state.
 	t.Run("Lazy-loading gappy sync includes remote memberships during partial state join", func(t *testing.T) {
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t9alice",
+			LocalpartSuffix: "t9alice",
 		})
 		syncToken := getSyncToken(t, alice)
 
@@ -1072,7 +1072,7 @@ func TestPartialStateJoin(t *testing.T) {
 	// the partial room state.
 	t.Run("Lazy-loading incremental sync includes remote memberships during partial state join", func(t *testing.T) {
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t10alice",
+			LocalpartSuffix: "t10alice",
 		})
 		syncToken := getSyncToken(t, alice)
 
@@ -1122,7 +1122,7 @@ func TestPartialStateJoin(t *testing.T) {
 	// TODO(faster_joins): also need to test /state, and /members without an `at`, which follow a different path
 	t.Run("MembersRequestBlocksDuringPartialStateJoin", func(t *testing.T) {
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t11alice",
+			LocalpartSuffix: "t11alice",
 		})
 
 		server := createTestServer(t, deployment)
@@ -1184,7 +1184,7 @@ func TestPartialStateJoin(t *testing.T) {
 	// eager-syncing, and doesn't send a message to the partial-state room.)
 	t.Run("PartialStateJoinContinuesAfterRestart", func(t *testing.T) {
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t12alice",
+			LocalpartSuffix: "t12alice",
 		})
 
 		server := createTestServer(t, deployment)
@@ -1311,7 +1311,7 @@ func TestPartialStateJoin(t *testing.T) {
 	// since it was not sent on the previous sync.
 	t.Run("GappySyncAfterPartialStateSynced", func(t *testing.T) {
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t13alice",
+			LocalpartSuffix: "t13alice",
 		})
 
 		server := createTestServer(t, deployment)
@@ -1407,7 +1407,7 @@ func TestPartialStateJoin(t *testing.T) {
 	// an infinite loop of de-partial-stating.
 	t.Run("Resync completes even when events arrive before their prev_events", func(t *testing.T) {
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t14alice",
+			LocalpartSuffix: "t14alice",
 		})
 		syncToken := getSyncToken(t, alice)
 
@@ -1521,7 +1521,7 @@ func TestPartialStateJoin(t *testing.T) {
 	// do not suddenly become un-rejected during the resync
 	t.Run("Rejected events remain rejected after resync", func(t *testing.T) {
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t15alice",
+			LocalpartSuffix: "t15alice",
 		})
 		syncToken := getSyncToken(t, alice)
 
@@ -1592,7 +1592,7 @@ func TestPartialStateJoin(t *testing.T) {
 
 	t.Run("State accepted incorrectly", func(t *testing.T) {
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t16alice",
+			LocalpartSuffix: "t16alice",
 		})
 		syncToken := getSyncToken(t, alice)
 		server := createTestServer(t, deployment)
@@ -1672,7 +1672,7 @@ func TestPartialStateJoin(t *testing.T) {
 
 	t.Run("State rejected incorrectly", func(t *testing.T) {
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t17alice",
+			LocalpartSuffix: "t17alice",
 		})
 		syncToken := getSyncToken(t, alice)
 		server := createTestServer(t, deployment)
@@ -1799,7 +1799,7 @@ func TestPartialStateJoin(t *testing.T) {
 		//   testServer2 (another Complement test server) with @charlie:<server name>
 		//     This is the server that will try to make a join via testServer1.
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t18alice",
+			LocalpartSuffix: "t18alice",
 		})
 
 		testServer1 := createTestServer(t, deployment)
@@ -1850,7 +1850,7 @@ func TestPartialStateJoin(t *testing.T) {
 		//     of being able to build a request to /send_join)
 		//
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t19alice",
+			LocalpartSuffix: "t19alice",
 		})
 
 		testServer1 := createTestServer(t, deployment)
@@ -1910,7 +1910,7 @@ func TestPartialStateJoin(t *testing.T) {
 	// request blocks until the state is correctly synced.
 	t.Run("joined_members blocks during partial state join", func(t *testing.T) {
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t20alice",
+			LocalpartSuffix: "t20alice",
 		})
 
 		server := createTestServer(t, deployment)
@@ -1977,7 +1977,7 @@ func TestPartialStateJoin(t *testing.T) {
 		//   testServer2 (another Complement test server) with @charlie:<server name>
 		//     This is the server that will try to make a knock via testServer1.
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t21alice",
+			LocalpartSuffix: "t21alice",
 		})
 
 		testServer1 := createTestServer(t, deployment)
@@ -2028,7 +2028,7 @@ func TestPartialStateJoin(t *testing.T) {
 		//     of being able to build a request to /send_knock)
 		//
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t22alice",
+			LocalpartSuffix: "t22alice",
 		})
 
 		testServer1 := createTestServer(t, deployment)
@@ -2098,7 +2098,7 @@ func TestPartialStateJoin(t *testing.T) {
 			room *federation.ServerRoom, cleanup func(),
 		) {
 			alice = deployment.Register(t, "hs1", helpers.RegistrationOpts{
-				Localpart: aliceLocalpart,
+				LocalpartSuffix: aliceLocalpart,
 			})
 
 			deviceListUpdateChannel1 = make(chan gomatrixserverlib.DeviceListUpdateEvent, 10)
@@ -2622,8 +2622,8 @@ func TestPartialStateJoin(t *testing.T) {
 			room *federation.ServerRoom, sendDeviceListUpdate func(string), cleanup func(),
 		) {
 			alice = deployment.Register(t, "hs1", helpers.RegistrationOpts{
-				Localpart: aliceLocalpart,
-				Password:  "secret",
+				LocalpartSuffix: aliceLocalpart,
+				Password:        "secret",
 			})
 
 			userDevicesQueryChannel = make(chan string, 1)
@@ -3414,8 +3414,8 @@ func TestPartialStateJoin(t *testing.T) {
 	t.Run("Room aliases can be added and queried during a resync", func(t *testing.T) {
 		// Alice begins a partial join to a room.
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t40alice",
-			Password:  "secret",
+			LocalpartSuffix: "t40alice",
+			Password:        "secret",
 		})
 		server := createTestServer(t, deployment)
 		cancel := server.Listen()
@@ -3468,8 +3468,8 @@ func TestPartialStateJoin(t *testing.T) {
 	t.Run("Room aliases can be added and deleted during a resync", func(t *testing.T) {
 		// Alice begins a partial join to a room.
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t41alice",
-			Password:  "secret",
+			LocalpartSuffix: "t41alice",
+			Password:        "secret",
 		})
 		server := createTestServer(t, deployment)
 		cancel := server.Listen()
@@ -3508,10 +3508,10 @@ func TestPartialStateJoin(t *testing.T) {
 	// we should be able to join a room that is already joined & resyncing
 	t.Run("CanFastJoinDuringPartialStateJoin", func(t *testing.T) {
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t44alice",
+			LocalpartSuffix: "t44alice",
 		})
 		bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t44bob",
+			LocalpartSuffix: "t44bob",
 		})
 
 		server := createTestServer(t, deployment)
@@ -3545,7 +3545,7 @@ func TestPartialStateJoin(t *testing.T) {
 	// "join", and can be confused with join events.
 	t.Run("Can change display name during partial state join", func(t *testing.T) {
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t45alice",
+			LocalpartSuffix: "t45alice",
 		})
 
 		server := createTestServer(t, deployment)
@@ -3595,7 +3595,7 @@ func TestPartialStateJoin(t *testing.T) {
 			// Before testing that leaves during resyncs are seen during resyncs, sanity
 			// check that leaves during resyncs appear after the resync.
 			alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-				Localpart: "t42alice",
+				LocalpartSuffix: "t42alice",
 			})
 			server := createTestServer(t, deployment)
 			cancel := server.Listen()
@@ -3638,7 +3638,7 @@ func TestPartialStateJoin(t *testing.T) {
 
 		t.Run("does not wait for resync", func(t *testing.T) {
 			alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-				Localpart: "t43alice",
+				LocalpartSuffix: "t43alice",
 			})
 			server := createTestServer(t, deployment)
 			cancel := server.Listen()
@@ -3698,10 +3698,10 @@ func TestPartialStateJoin(t *testing.T) {
 		// Test that the original joiner can leave during the resync, even after someone else has joined
 		t.Run("works after a second partial join", func(t *testing.T) {
 			alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-				Localpart: "t47alice",
+				LocalpartSuffix: "t47alice",
 			})
 			bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-				Localpart: "t47bob",
+				LocalpartSuffix: "t47bob",
 			})
 			server := createTestServer(t, deployment)
 			cancel := server.Listen()
@@ -3753,7 +3753,7 @@ func TestPartialStateJoin(t *testing.T) {
 
 		t.Run("succeeds, then rejoin succeeds without resync completing", func(t *testing.T) {
 			alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-				Localpart: "t48alice",
+				LocalpartSuffix: "t48alice",
 			})
 			server := createTestServer(t, deployment)
 			cancel := server.Listen()
@@ -3795,10 +3795,10 @@ func TestPartialStateJoin(t *testing.T) {
 
 		t.Run("succeeds, then another user can join without resync completing", func(t *testing.T) {
 			alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-				Localpart: "t49alice",
+				LocalpartSuffix: "t49alice",
 			})
 			bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-				Localpart: "t49bob",
+				LocalpartSuffix: "t49bob",
 			})
 			server := createTestServer(t, deployment)
 			cancel := server.Listen()
@@ -3843,7 +3843,7 @@ func TestPartialStateJoin(t *testing.T) {
 
 		t.Run("can be triggered by remote kick", func(t *testing.T) {
 			alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-				Localpart: "t50alice",
+				LocalpartSuffix: "t50alice",
 			})
 			server := createTestServer(t, deployment)
 			cancel := server.Listen()
@@ -3897,7 +3897,7 @@ func TestPartialStateJoin(t *testing.T) {
 
 		t.Run("can be triggered by remote ban", func(t *testing.T) {
 			alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-				Localpart: "t51alice",
+				LocalpartSuffix: "t51alice",
 			})
 			server := createTestServer(t, deployment)
 			cancel := server.Listen()
@@ -3962,8 +3962,8 @@ func TestPartialStateJoin(t *testing.T) {
 		// create a user with admin powers as we will need this power to make the remote room visible in the
 		// local room list
 		terry := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "terry",
-			IsAdmin:   true,
+			LocalpartSuffix: "terry",
+			IsAdmin:         true,
 		})
 
 		server := createTestServer(t, deployment)
@@ -4012,7 +4012,7 @@ func TestPartialStateJoin(t *testing.T) {
 
 	t.Run("User directory is correctly updated once state re-sync completes", func(t *testing.T) {
 		rocky := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "rocky",
+			LocalpartSuffix: "rocky",
 		})
 
 		server := createTestServer(t, deployment)
@@ -4080,8 +4080,8 @@ func TestPartialStateJoin(t *testing.T) {
 		}
 		t.Log("Alice begins a partial join to a room")
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
-			Localpart: "t46alice",
-			IsAdmin:   true,
+			LocalpartSuffix: "t46alice",
+			IsAdmin:         true,
 		})
 		server := createTestServer(t, deployment)
 		cancel := server.Listen()

--- a/tests/msc3902/federation_room_join_partial_state_test.go
+++ b/tests/msc3902/federation_room_join_partial_state_test.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
-	"github.com/matrix-org/complement/internal/docker"
 	"github.com/matrix-org/complement/internal/federation"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
@@ -51,7 +50,7 @@ type server struct {
 //
 // The `federation.HandleTransactionRequests` handler must not be used.
 // Instead, `AddPDUHandler` and `AddEDUHandler` should be used.
-func createTestServer(t *testing.T, deployment *docker.Deployment, opts ...func(*federation.Server)) *server {
+func createTestServer(t *testing.T, deployment complement.Deployment, opts ...func(*federation.Server)) *server {
 	t.Helper()
 
 	server := &server{
@@ -2043,7 +2042,7 @@ func TestPartialStateJoin(t *testing.T) {
 		// Returns channels for device list updates arriving at the complement homeservers, which
 		// can be used with `mustReceiveDeviceListUpdate` and `mustNotReceiveDeviceListUpdate`.
 		setupOutgoingDeviceListUpdateTest := func(
-			t *testing.T, deployment *docker.Deployment, aliceLocalpart string,
+			t *testing.T, deployment complement.Deployment, aliceLocalpart string,
 			opts ...func(*federation.Server),
 		) (
 			alice *client.CSAPI, server1 *server, server2 *server,
@@ -2057,7 +2056,7 @@ func TestPartialStateJoin(t *testing.T) {
 			deviceListUpdateChannel2 = make(chan gomatrixserverlib.DeviceListUpdateEvent, 10)
 
 			createDeviceListUpdateTestServer := func(
-				t *testing.T, deployment *docker.Deployment,
+				t *testing.T, deployment complement.Deployment,
 				deviceListUpdateChannel chan gomatrixserverlib.DeviceListUpdateEvent,
 				opts ...func(*federation.Server),
 			) *server {
@@ -2292,7 +2291,7 @@ func TestPartialStateJoin(t *testing.T) {
 		// As a side effect, @derek is promoted to admin and leaves the room before the homeserver
 		// under test joins.
 		setupIncorrectlyAcceptedKick := func(
-			t *testing.T, deployment *docker.Deployment, alice *client.CSAPI,
+			t *testing.T, deployment complement.Deployment, alice *client.CSAPI,
 			server1 *server, server2 *server,
 			deviceListUpdateChannel1 chan gomatrixserverlib.DeviceListUpdateEvent,
 			deviceListUpdateChannel2 chan gomatrixserverlib.DeviceListUpdateEvent,
@@ -2365,7 +2364,7 @@ func TestPartialStateJoin(t *testing.T) {
 		// the public room, then leave the partial state room.
 		// Returns @alice:hs1's sync token after @elsie:server2 has left the partial state room.
 		setupAnotherSharedRoomThenLeave := func(
-			t *testing.T, deployment *docker.Deployment, alice *client.CSAPI,
+			t *testing.T, deployment complement.Deployment, alice *client.CSAPI,
 			server1 *server, server2 *server,
 			partialStateRoom *federation.ServerRoom, syncToken string,
 		) (nextSyncToken string, leaveSharedRoom func()) {
@@ -2405,7 +2404,7 @@ func TestPartialStateJoin(t *testing.T) {
 		// believes @elsie:server2 not to be present and tests that server2 receives missed device
 		// list updates once hs1's partial state join has completed.
 		testMissedDeviceListUpdateSentOncePartialJoinCompletes := func(
-			t *testing.T, deployment *docker.Deployment, alice *client.CSAPI,
+			t *testing.T, deployment complement.Deployment, alice *client.CSAPI,
 			server1 *server, server2 *server,
 			deviceListUpdateChannel1 chan gomatrixserverlib.DeviceListUpdateEvent,
 			deviceListUpdateChannel2 chan gomatrixserverlib.DeviceListUpdateEvent,
@@ -2568,7 +2567,7 @@ func TestPartialStateJoin(t *testing.T) {
 		// can be used with `mustQueryKeysWithFederationRequest` and
 		// `mustQueryKeysWithoutFederationRequest`.
 		setupDeviceListCachingTest := func(
-			t *testing.T, deployment *docker.Deployment, aliceLocalpart string,
+			t *testing.T, deployment complement.Deployment, aliceLocalpart string,
 		) (
 			alice *client.CSAPI, server *server, userDevicesQueryChannel chan string,
 			room *federation.ServerRoom, sendDeviceListUpdate func(string), cleanup func(),
@@ -3101,7 +3100,7 @@ func TestPartialStateJoin(t *testing.T) {
 		// in the room when they have really been kicked. Once the partial state join completes,
 		// @elsie will be discovered to be no longer in the room.
 		setupUserIncorrectlyInRoom := func(
-			t *testing.T, deployment *docker.Deployment, alice *client.CSAPI,
+			t *testing.T, deployment complement.Deployment, alice *client.CSAPI,
 			server *server, room *federation.ServerRoom,
 		) (syncToken string, psjResult partialStateJoinResult) {
 			charlie := server.UserID("charlie")
@@ -4064,7 +4063,7 @@ func TestPartialStateJoin(t *testing.T) {
 // sends the given event to the homeserver under test, checks that a client can see it and checks
 // the state at the event. returns the new sync token after the event.
 func testReceiveEventDuringPartialStateJoin(
-	t *testing.T, deployment *docker.Deployment, alice *client.CSAPI, psjResult partialStateJoinResult, event gomatrixserverlib.PDU, syncToken string,
+	t *testing.T, deployment complement.Deployment, alice *client.CSAPI, psjResult partialStateJoinResult, event gomatrixserverlib.PDU, syncToken string,
 ) string {
 	// send the event to the homeserver
 	psjResult.Server.MustSendTransaction(t, deployment, "hs1", []json.RawMessage{event.JSON()}, nil)

--- a/tests/msc3930/msc3930_test.go
+++ b/tests/msc3930/msc3930_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
@@ -31,8 +32,7 @@ func TestPollsLocalPushRules(t *testing.T) {
 	defer deployment.Destroy(t)
 
 	// Create a user to poll the push rules of.
-	aliceUserID := "@alice:hs1"
-	alice := deployment.Client(t, "hs1", aliceUserID)
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	// Test for the presence of the expected push rules. Clients are expected
 	// to implement local matching of events based on the presented rules.

--- a/tests/msc3930/msc3930_test.go
+++ b/tests/msc3930/msc3930_test.go
@@ -15,7 +15,6 @@ import (
 	"testing"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
@@ -28,7 +27,7 @@ const pollStartRuleID = ".org.matrix.msc3930.rule.poll_start"
 const pollEndRuleID = ".org.matrix.msc3930.rule.poll_end"
 
 func TestPollsLocalPushRules(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	// Create a user to poll the push rules of.

--- a/tests/restricted_room_hierarchy_test.go
+++ b/tests/restricted_room_hierarchy_test.go
@@ -37,7 +37,7 @@ func requestAndAssertSummary(t *testing.T, user *client.CSAPI, space string, exp
 // The user should be unable to see the room in the spaces summary unless they
 // are a member of the space.
 func TestRestrictedRoomsSpacesSummaryLocal(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	// Create the rooms
@@ -118,7 +118,7 @@ func TestRestrictedRoomsSpacesSummaryLocal(t *testing.T) {
 // different homeservers, and one might not have the proper information needed to
 // decide if a user is in a room.
 func TestRestrictedRoomsSpacesSummaryFederation(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintFederationTwoLocalOneRemote)
+	deployment := complement.Deploy(t, 2)
 	defer deployment.Destroy(t)
 
 	// Create the rooms

--- a/tests/restricted_room_hierarchy_test.go
+++ b/tests/restricted_room_hierarchy_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
@@ -40,7 +41,7 @@ func TestRestrictedRoomsSpacesSummaryLocal(t *testing.T) {
 	defer deployment.Destroy(t)
 
 	// Create the rooms
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 	space := alice.MustCreateRoom(t, map[string]interface{}{
 		"preset": "public_chat",
 		"name":   "Space",
@@ -92,7 +93,7 @@ func TestRestrictedRoomsSpacesSummaryLocal(t *testing.T) {
 	t.Logf("Room: %s", room)
 
 	// Create a second user on the same homeserver.
-	bob := deployment.Client(t, "hs1", "@bob:hs1")
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	// Querying the space returns only the space, as the room is restricted.
 	requestAndAssertSummary(t, bob, space, []interface{}{space})
@@ -121,8 +122,8 @@ func TestRestrictedRoomsSpacesSummaryFederation(t *testing.T) {
 	defer deployment.Destroy(t)
 
 	// Create the rooms
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
-	bob := deployment.Client(t, "hs1", "@bob:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 	space := alice.MustCreateRoom(t, map[string]interface{}{
 		"preset": "public_chat",
 		"name":   "Space",
@@ -142,7 +143,7 @@ func TestRestrictedRoomsSpacesSummaryFederation(t *testing.T) {
 
 	// The room is room version 8 which supports the restricted join_rule and is
 	// created on hs2.
-	charlie := deployment.Client(t, "hs2", "@charlie:hs2")
+	charlie := deployment.Register(t, "hs2", helpers.RegistrationOpts{})
 	room := charlie.MustCreateRoom(t, map[string]interface{}{
 		"preset":       "public_chat",
 		"name":         "Room",

--- a/tests/restricted_rooms_test.go
+++ b/tests/restricted_rooms_test.go
@@ -177,7 +177,7 @@ func checkRestrictedRoom(t *testing.T, alice *client.CSAPI, bob *client.CSAPI, a
 
 // Test joining a room with join rules restricted to membership in another room.
 func TestRestrictedRoomsLocalJoin(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	// Setup the user, allowed room, and restricted room.
@@ -192,7 +192,7 @@ func TestRestrictedRoomsLocalJoin(t *testing.T) {
 
 // Test joining a room with join rules restricted to membership in another room.
 func TestRestrictedRoomsRemoteJoin(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintFederationOneToOneRoom)
+	deployment := complement.Deploy(t, 2)
 	defer deployment.Destroy(t)
 
 	// Setup the user, allowed room, and restricted room.
@@ -214,7 +214,7 @@ func TestRestrictedRoomsRemoteJoinLocalUser(t *testing.T) {
 func doTestRestrictedRoomsRemoteJoinLocalUser(t *testing.T, roomVersion string, joinRule string) {
 	runtime.SkipIf(t, runtime.Dendrite) // FIXME: https://github.com/matrix-org/dendrite/issues/2801
 
-	deployment := complement.Deploy(t, b.BlueprintFederationTwoLocalOneRemote)
+	deployment := complement.Deploy(t, 2)
 	defer deployment.Destroy(t)
 
 	// Charlie sets up the allowed room so it is on the other server.
@@ -333,38 +333,7 @@ func TestRestrictedRoomsRemoteJoinFailOver(t *testing.T) {
 func doTestRestrictedRoomsRemoteJoinFailOver(t *testing.T, roomVersion string, joinRule string) {
 	runtime.SkipIf(t, runtime.Dendrite) // FIXME: https://github.com/matrix-org/dendrite/issues/2801
 
-	deployment := complement.Deploy(t, b.Blueprint{
-		Name: "federation_three_homeservers",
-		Homeservers: []b.Homeserver{
-			{
-				Name: "hs1",
-				Users: []b.User{
-					{
-						Localpart:   "alice",
-						DisplayName: "Alice",
-					},
-				},
-			},
-			{
-				Name: "hs2",
-				Users: []b.User{
-					{
-						Localpart:   "bob",
-						DisplayName: "Bob",
-					},
-				},
-			},
-			{
-				Name: "hs3",
-				Users: []b.User{
-					{
-						Localpart:   "charlie",
-						DisplayName: "Charlie",
-					},
-				},
-			},
-		},
-	})
+	deployment := complement.Deploy(t, 3)
 	defer deployment.Destroy(t)
 
 	// Setup the user, allowed room, and restricted room.

--- a/tests/restricted_rooms_test.go
+++ b/tests/restricted_rooms_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
-	"github.com/matrix-org/complement/internal/docker"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 	"github.com/matrix-org/complement/runtime"
@@ -18,7 +17,7 @@ import (
 
 // Creates two rooms on room version 8 and sets the second room to have
 // restricted join rules with allow set to the first room.
-func setupRestrictedRoom(t *testing.T, deployment *docker.Deployment, roomVersion string, joinRule string) (*client.CSAPI, string, string) {
+func setupRestrictedRoom(t *testing.T, deployment complement.Deployment, roomVersion string, joinRule string) (*client.CSAPI, string, string) {
 	t.Helper()
 
 	alice := deployment.Client(t, "hs1", "@alice:hs1")

--- a/tests/room_hierarchy_test.go
+++ b/tests/room_hierarchy_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
@@ -88,7 +89,7 @@ func TestClientSpacesSummary(t *testing.T) {
 	roomNames := make(map[string]string)
 
 	// create the rooms
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 	root := alice.MustCreateRoom(t, map[string]interface{}{
 		"preset": "public_chat",
 		"name":   "Root",
@@ -130,7 +131,7 @@ func TestClientSpacesSummary(t *testing.T) {
 	})
 	roomNames[r3] = "R3"
 	// alice is not joined to R4
-	bob := deployment.Client(t, "hs1", "@bob:hs1")
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 	r4 := bob.MustCreateRoom(t, map[string]interface{}{
 		"preset": "public_chat",
 		"name":   "R4",
@@ -396,7 +397,7 @@ func TestClientSpacesSummaryJoinRules(t *testing.T) {
 	defer deployment.Destroy(t)
 
 	// create the rooms
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 	root := alice.MustCreateRoom(t, map[string]interface{}{
 		"preset": "public_chat",
 		"name":   "Root",
@@ -468,7 +469,7 @@ func TestClientSpacesSummaryJoinRules(t *testing.T) {
 	})
 
 	// Querying is done by bob who is not yet in any of the rooms.
-	bob := deployment.Client(t, "hs1", "@bob:hs1")
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 	bob.MustJoinRoom(t, root, []string{"hs1"})
 
 	res := bob.MustDo(t, "GET", []string{"_matrix", "client", "v1", "rooms", root, "hierarchy"})
@@ -571,12 +572,12 @@ func TestFederatedClientSpaces(t *testing.T) {
 		},
 	}
 	// create the rooms
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 	root := alice.MustCreateRoom(t, worldReadableSpace)
 	r1 := alice.MustCreateRoom(t, worldReadable)
 	ss1 := alice.MustCreateRoom(t, worldReadableSpace)
 	r4 := alice.MustCreateRoom(t, worldReadable)
-	bob := deployment.Client(t, "hs2", "@bob:hs2")
+	bob := deployment.Register(t, "hs2", helpers.RegistrationOpts{})
 	r2 := bob.MustCreateRoom(t, worldReadable)
 	ss2 := bob.MustCreateRoom(t, worldReadableSpace)
 	r3 := bob.MustCreateRoom(t, worldReadable)

--- a/tests/room_hierarchy_test.go
+++ b/tests/room_hierarchy_test.go
@@ -83,7 +83,7 @@ func roomToChildrenMapper(r gjson.Result) interface{} {
 // - Events are returned correctly.
 // - Redacting links works correctly.
 func TestClientSpacesSummary(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	roomNames := make(map[string]string)
@@ -393,7 +393,7 @@ func TestClientSpacesSummary(t *testing.T) {
 // Tests that:
 // - Rooms/spaces the user is not invited to should not appear.
 func TestClientSpacesSummaryJoinRules(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintOneToOneRoom)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	// create the rooms
@@ -541,7 +541,7 @@ func TestClientSpacesSummaryJoinRules(t *testing.T) {
 // Tests that:
 // - Querying from root returns the entire graph
 func TestFederatedClientSpaces(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintFederationOneToOneRoom)
+	deployment := complement.Deploy(t, 2)
 	defer deployment.Destroy(t)
 
 	worldReadable := map[string]interface{}{

--- a/tests/room_timestamp_to_event_test.go
+++ b/tests/room_timestamp_to_event_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestJumpToDateEndpoint(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintHSWithApplicationService)
+	deployment := complement.OldDeploy(t, b.BlueprintHSWithApplicationService)
 	defer deployment.Destroy(t)
 
 	// Create the normal user which will send messages in the room

--- a/tests/room_timestamp_to_event_test.go
+++ b/tests/room_timestamp_to_event_test.go
@@ -37,7 +37,7 @@ func TestJumpToDateEndpoint(t *testing.T) {
 
 	// Create the application service bridge user that can use the ?ts query parameter
 	asUserID := "@the-bridge-user:hs1"
-	as := deployment.Client(t, "hs1", asUserID)
+	as := deployment.AppServiceUser(t, "hs1", asUserID)
 
 	t.Run("parallel", func(t *testing.T) {
 		t.Run("should find event after given timestmap", func(t *testing.T) {

--- a/tests/room_timestamp_to_event_test.go
+++ b/tests/room_timestamp_to_event_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 	"github.com/tidwall/gjson"
@@ -29,12 +30,10 @@ func TestJumpToDateEndpoint(t *testing.T) {
 	defer deployment.Destroy(t)
 
 	// Create the normal user which will send messages in the room
-	userID := "@alice:hs1"
-	alice := deployment.Client(t, "hs1", userID)
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	// Create the federated user which will fetch the messages from a remote homeserver
-	remoteUserID := "@charlie:hs2"
-	remoteCharlie := deployment.Client(t, "hs2", remoteUserID)
+	remoteCharlie := deployment.Register(t, "hs2", helpers.RegistrationOpts{})
 
 	// Create the application service bridge user that can use the ?ts query parameter
 	asUserID := "@the-bridge-user:hs1"
@@ -116,7 +115,7 @@ func TestJumpToDateEndpoint(t *testing.T) {
 			})
 
 			// We will use Bob to query the room they're not a member of
-			nonMemberUser := deployment.Client(t, "hs1", "@bob:hs1")
+			nonMemberUser := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 			// Make the `/timestamp_to_event` request from Bob's perspective (non room member)
 			timestamp := makeTimestampFromTime(timeBeforeRoomCreation)
@@ -144,7 +143,7 @@ func TestJumpToDateEndpoint(t *testing.T) {
 			})
 
 			// We will use Bob to query the room they're not a member of
-			nonMemberUser := deployment.Client(t, "hs1", "@bob:hs1")
+			nonMemberUser := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 			// Make the `/timestamp_to_event` request from Bob's perspective (non room member)
 			timestamp := makeTimestampFromTime(timeBeforeRoomCreation)

--- a/tests/unknown_endpoints_test.go
+++ b/tests/unknown_endpoints_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/matrix-org/complement"
-	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
@@ -39,7 +38,7 @@ func queryUnknownMethod(t *testing.T, user *client.CSAPI, method string, paths [
 // Homeservers should return a 404 for unknown endpoints and 405 for incorrect
 // methods to known endpoints.
 func TestUnknownEndpoints(t *testing.T) {
-	deployment := complement.Deploy(t, b.BlueprintAlice)
+	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})

--- a/tests/unknown_endpoints_test.go
+++ b/tests/unknown_endpoints_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 )
@@ -41,7 +42,7 @@ func TestUnknownEndpoints(t *testing.T) {
 	deployment := complement.Deploy(t, b.BlueprintAlice)
 	defer deployment.Destroy(t)
 
-	alice := deployment.Client(t, "hs1", "@alice:hs1")
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
 	// A completely unknown prefix to the matrix project.
 	t.Run("Unknown prefix", func(t *testing.T) {


### PR DESCRIPTION
- `Deployment.Client` was used to get pre-registered clients. Now we want tests to register new users for each test, for dirty runs. So swap for `Deployment.Register` everywhere.
- `Deploy` was used to deploy a blueprint. We don't want this to enable dirty runs. So replace it with the number of servers you need e.g `Deploy(t, 2)`.