### PR TITLE
Make dirty runs dirtier

### DIFF
--- a/internal/docker/deployer.go
+++ b/internal/docker/deployer.go
@@ -76,6 +76,54 @@ func (d *Deployer) log(str string, args ...interface{}) {
 	log.Printf(str, args...)
 }
 
+// CreateDirtyServer creates a new dirty server on the dirty network, creating one if needed.
+// This homeserver should be added to the dirty deployment. The hsName should start as 'hs1', then
+// 'hs2' ... 'hsN'.
+func (d *Deployer) CreateDirtyServer(hsName string) (*HomeserverDeployment, error) {
+	networkName, err := createNetworkIfNotExists(d.Docker, d.config.PackageNamespace, "dirty")
+	if err != nil {
+		return nil, fmt.Errorf("CreateDirtyDeployment: %w", err)
+	}
+	baseImageURI := d.config.BaseImageURI
+	// Use HS specific base image if defined
+	if uri, ok := d.config.BaseImageURIs[hsName]; ok {
+		baseImageURI = uri
+	}
+
+	hsDeployment, err := deployImage(
+		d.Docker, baseImageURI, fmt.Sprintf("complement_%s_dirty_%s", d.config.PackageNamespace, hsName),
+		d.config.PackageNamespace, "", hsName, nil, "dirty",
+		networkName, d.config,
+	)
+	if err != nil {
+		if hsDeployment != nil && hsDeployment.ContainerID != "" {
+			// print logs to help debug
+			printLogs(d.Docker, hsDeployment.ContainerID, "dirty")
+		}
+		return nil, fmt.Errorf("CreateDirtyServer: Failed to deploy image %v : %w", baseImageURI, err)
+	}
+	return hsDeployment, nil
+}
+
+// CreateDirtyDeployment creates a clean HS without any blueprints. More HSes can be added later via
+// CreateDirtyServer()
+func (d *Deployer) CreateDirtyDeployment() (*Deployment, error) {
+	hsName := "hs1"
+	hsDeployment, err := d.CreateDirtyServer(hsName)
+	if err != nil {
+		return nil, err
+	}
+	// assign the HS to the deployment
+	return &Deployment{
+		Deployer: d,
+		Dirty:    true,
+		HS: map[string]*HomeserverDeployment{
+			hsName: hsDeployment,
+		},
+		Config: d.config,
+	}, nil
+}
+
 func (d *Deployer) Deploy(ctx context.Context, blueprintName string) (*Deployment, error) {
 	dep := &Deployment{
 		Deployer:      d,

--- a/tests/csapi/apidoc_room_state_test.go
+++ b/tests/csapi/apidoc_room_state_test.go
@@ -108,7 +108,7 @@ func TestRoomState(t *testing.T) {
 			})
 
 			authedClient.MustDo(t, "GET", []string{"_matrix", "client", "v3", "publicRooms"},
-				client.WithRetryUntil(time.Second, func(res *http.Response) bool {
+				client.WithRetryUntil(3*time.Second, func(res *http.Response) bool {
 					foundRoom := false
 
 					must.MatchResponse(t, res, match.HTTPResponse{

--- a/tests/msc3902/federation_room_join_partial_state_test.go
+++ b/tests/msc3902/federation_room_join_partial_state_test.go
@@ -1030,7 +1030,7 @@ func TestPartialStateJoin(t *testing.T) {
 		psjResult.Server.MustSendTransaction(t, deployment, "hs1", []json.RawMessage{event1.JSON(), event2.JSON()}, nil)
 
 		// wait for the homeserver to persist the event.
-		awaitEventArrival(t, time.Second, alice, serverRoom.RoomID, event2.EventID())
+		awaitEventArrival(t, 2*time.Second, alice, serverRoom.RoomID, event2.EventID())
 
 		// do a gappy sync which only picks up the second message.
 		syncRes, _ := alice.MustSync(t,
@@ -1100,7 +1100,7 @@ func TestPartialStateJoin(t *testing.T) {
 		t.Logf("Derek created event with ID %s", event.EventID())
 
 		// wait for the homeserver to persist the event.
-		awaitEventArrival(t, time.Second, alice, serverRoom.RoomID, event.EventID())
+		awaitEventArrival(t, 2*time.Second, alice, serverRoom.RoomID, event.EventID())
 
 		// do an incremental sync.
 		syncRes, _ := alice.MustSync(t,

--- a/tests/msc3902/federation_room_join_partial_state_test.go
+++ b/tests/msc3902/federation_room_join_partial_state_test.go
@@ -1499,7 +1499,7 @@ func TestPartialStateJoin(t *testing.T) {
 		// instead let's just check for the presence of the room in the timeline.
 		// it can take a while for the homeserver to update its state for 100+ events, so raise
 		// the default timeout.
-		alice.SyncUntilTimeout = 20 * time.Second
+		alice.SyncUntilTimeout = 30 * time.Second
 		alice.MustSyncUntil(t,
 			client.SyncReq{},
 			func(clientUserID string, topLevelSyncJSON gjson.Result) error {

--- a/tests/msc3902/federation_room_join_partial_state_test.go
+++ b/tests/msc3902/federation_room_join_partial_state_test.go
@@ -1030,7 +1030,7 @@ func TestPartialStateJoin(t *testing.T) {
 		psjResult.Server.MustSendTransaction(t, deployment, "hs1", []json.RawMessage{event1.JSON(), event2.JSON()}, nil)
 
 		// wait for the homeserver to persist the event.
-		awaitEventArrival(t, 2*time.Second, alice, serverRoom.RoomID, event2.EventID())
+		awaitEventArrival(t, 5*time.Second, alice, serverRoom.RoomID, event2.EventID())
 
 		// do a gappy sync which only picks up the second message.
 		syncRes, _ := alice.MustSync(t,


### PR DESCRIPTION
Previously, `Deploy(t, 1)` would deploy 1 HS in 1 isolated blueprint which could be reused by other tests who also call `Deploy(t, 1)`. This pattern extended to `Deploy(t, 2)`, which would deploy 2x HSes in 1 isolated blueprint. This however means we'd run more containers in parallel. What's worse: these containers would only be cleaned up at the end of the entire test package run: `defer deployment.Destroy(t)` would do nothing.

This was Very Bad on GHA boxes as they have limited resources, causing synapse/workers to fail to complete.


The cost of this aggressive reuse of dirty containers is slightly more ugliness internally in Complement, as we now entirely have separate code paths for handling dirty stuff. This can be refactored later down the line to demarcate the difference between this and blueprints.
