### PR TITLE
Require go 1.19 for atomic.Int64

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3 # Checkout complement
       - uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
       - name: "Install Complement Dependencies"
         run: |
           sudo apt-get update && sudo apt-get install -y libolm3 libolm-dev
@@ -56,6 +58,9 @@ jobs:
       - uses: actions/checkout@v3 # Checkout complement
 
       - uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
+
       # Similar steps as dockerfiles/ComplementCIBuildkite.Dockerfile but on the host. We need
       # to do this so we can _be_ the host when running Complement so we can snaffle all the ports. If
       # we run Complement _in_ Docker then we can't -p all high numbered ports which then breaks federation

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/matrix-org/complement
 
-go 1.18
+go 1.19
 
 require (
 	github.com/docker/docker v24.0.6+incompatible


### PR DESCRIPTION
Synapse tried to build complement using the go version specificed in go.mod, and [failed](https://github.com/matrix-org/synapse/actions/runs/6685687057/job/18164290687?pr=16567#step:7:2616):

```
 📦 github.com/matrix-org/complement/internal/docker
Error: internal/docker/deployment.go:29:26: undefined: atomic.Int64
```

See https://github.com/matrix-org/synapse/pull/16567#issuecomment-1784220124 onwards.