### PR TITLE
Update references to matrix-org/synapse

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,12 +43,14 @@ jobs:
       matrix:
         include:
           - homeserver: Synapse
+            repo: element-hq/synapse
             tags: synapse_blacklist
             packages: ./tests/msc3874 ./tests/msc3902
             env: "COMPLEMENT_ENABLE_DIRTY_RUNS=1 COMPLEMENT_SHARE_ENV_PREFIX=PASS_ PASS_SYNAPSE_COMPLEMENT_DATABASE=sqlite"
             timeout: 20m
 
           - homeserver: Dendrite
+            repo: matrix-org/dendrite
             tags: dendrite_blacklist
             packages: ""
             env: "COMPLEMENT_ENABLE_DIRTY_RUNS=1"
@@ -95,7 +97,7 @@ jobs:
                 continue
                 ;;
             esac
-            (wget -O - "https://github.com/matrix-org/${{ matrix.homeserver }}/archive/$BRANCH_NAME.tar.gz" | tar -xz --strip-components=1 -C homeserver) && break
+            (wget -O - "https://github.com/${{ matrix.repo }}/archive/$BRANCH_NAME.tar.gz" | tar -xz --strip-components=1 -C homeserver) && break
           done
 
       # Build homeserver image

--- a/README.md
+++ b/README.md
@@ -78,11 +78,11 @@ $ COMPLEMENT_BASE_IMAGE=complement-dendrite:latest go test -v ./tests/...
 
 ### Running against Synapse
 
-If you're looking to run Complement against a local dev instance of Synapse, see [`matrix-org/synapse` -> `scripts-dev/complement.sh`](https://github.com/matrix-org/synapse/blob/develop/scripts-dev/complement.sh).
+If you're looking to run Complement against a local dev instance of Synapse, see [`element-hq/synapse` -> `scripts-dev/complement.sh`](https://github.com/element-hq/synapse/blob/develop/scripts-dev/complement.sh).
 
 If you want to develop Complement tests while working on a local dev instance
 of Synapse, use the
-[`scripts-dev/complement.sh`](https://github.com/matrix-org/synapse/blob/develop/scripts-dev/complement.sh)
+[`scripts-dev/complement.sh`](https://github.com/element-hq/synapse/blob/develop/scripts-dev/complement.sh)
 script and set the `COMPLEMENT_DIR` environment variable to the filepath of
 your local Complement checkout. Arguments to `go test` can be supplied as an argument to the script, e.g.:
 


### PR DESCRIPTION
Active development now happens in element-hq/synapse.