### PR TITLE
Fix flakey test `EagerInitialSyncDuringPartialStateJoin`

### DIFF
--- a/federation/server_room.go
+++ b/federation/server_room.go
@@ -216,6 +216,20 @@ func (r *ServerRoom) ServersInRoom() (servers []string) {
 	return
 }
 
+// Fetches the event with given event ID from the room timeline.
+func (r *ServerRoom) GetEventInTimeline(eventID string) (gomatrixserverlib.PDU, bool) {
+	r.TimelineMutex.Lock()
+	defer r.TimelineMutex.Unlock()
+
+	for _, ev := range r.Timeline {
+		if ev.EventID() == eventID {
+			return ev, true
+		}
+	}
+
+	return nil, false
+}
+
 func initialPowerLevelsContent(roomCreator string) (c gomatrixserverlib.PowerLevelContent) {
 	c.Defaults()
 	c.Events = map[string]int64{


### PR DESCRIPTION
e.g. https://github.com/element-hq/synapse/actions/runs/7423009864/job/20199559386?pr=16782

The flake happened because the test received a PDU during the test clean up, i.e. after we had removed the PDU handler but before the test had finished. During this time a PDU would be received and not handled, resulting in the test being marked as a failure.

The fix is to explicitly wait for the event to be received.

<details>
<summary>Test output</summary>

```
❌ TestPartialStateJoin/EagerInitialSyncDuringPartialStateJoin (1.54s)
      client.go:642: [CSAPI] POST hs1/_matrix/client/v3/register => 200 OK (18.557323ms)
      federation_room_join_partial_state_test.go:275: Do a one-off initial sync for Alice, so we have a next_batch token for future incremental syncs
      client.go:642: [CSAPI] GET hs1/_matrix/client/v3/sync => 200 OK (12.230031ms)
      federation_room_join_partial_state_test.go:278: 1. Partial join Alice to a remote room.
      client.go:642: [CSAPI] GET hs1/_matrix/client/v3/capabilities => 200 OK (2.201364ms)
      server.go:185: Creating room !0-ZUdMofhywQfiJEk4U5:host.docker.internal:42259 with version 10
      federation_room_join_partial_state_test.go:4476: Registered state_ids handler for event $-L4alMjQcNE0iGsx1eUk8qWeg6LQXoKrblj8kQ_vY78
      federation_room_join_partial_state_test.go:4517: Registered /state handler for event $-L4alMjQcNE0iGsx1eUk8qWeg6LQXoKrblj8kQ_vY78
  2024/01/05 14:38:55 Received send-join of event $-yoG5lj0PcPImrpxLewRi0rfvqp4GGQ8nj9WenUTEEk
      client.go:642: [CSAPI] POST hs1/_matrix/client/v3/join/!0-ZUdMofhywQfiJEk4U5:host.docker.internal:42259 => 200 OK (140.317646ms)
      federation_room_join_partial_state_test.go:4370: /join request completed
      federation_room_join_partial_state_test.go:286: 2. Have Alice lazy-sync until she sees (1).
      federation_room_join_partial_state_test.go:4455: Incoming state_ids request for event [$-L4alMjQcNE0iGsx1eUk8qWeg6LQXoKrblj8kQ_vY78] in room !0-ZUdMofhywQfiJEk4U5:host.docker.internal:42259
      client.go:642: [CSAPI] GET hs1/_matrix/client/v3/sync => 200 OK (17.482882ms)
      federation_room_join_partial_state_test.go:293: 3. Have Alice eager sync. The response should omit the remote room.
      client.go:642: [CSAPI] GET hs1/_matrix/client/v3/sync => 200 OK (3.405506ms)
      federation_room_join_partial_state_test.go:306: 4. Have Alice send a message to the remote room.
      client.go:642: [CSAPI] PUT hs1/_matrix/client/v3/rooms/!0-ZUdMofhywQfiJEk4U5:host.docker.internal:42259/send/m.room.message/1 => 200 OK (16.001118ms)
      federation_room_join_partial_state_test.go:318: 5. Have Alice lazy-sync until she sees (4).
      client.go:642: [CSAPI] GET hs1/_matrix/client/v3/sync => 200 OK (21.063637ms)
      federation_room_join_partial_state_test.go:325: 6. Have Alice eager-sync. The response should omit the remote room.
      client.go:642: [CSAPI] GET hs1/_matrix/client/v3/sync => 200 OK (4.393183ms)
      federation_room_join_partial_state_test.go:336: 7. Allow the resync to complete.
      federation_room_join_partial_state_test.go:4462: Replying to /state_ids request for event [$-L4alMjQcNE0iGsx1eUk8qWeg6LQXoKrblj8kQ_vY78]
      federation_room_join_partial_state_test.go:4495: Incoming state request for event [$-L4alMjQcNE0iGsx1eUk8qWeg6LQXoKrblj8kQ_vY78] in room !0-ZUdMofhywQfiJEk4U5:host.docker.internal:42259
      federation_room_join_partial_state_test.go:4503: Replying to /state request for event [$-L4alMjQcNE0iGsx1eUk8qWeg6LQXoKrblj8kQ_vY78]
      client.go:642: [CSAPI] GET hs1/_matrix/client/v3/rooms/!0-ZUdMofhywQfiJEk4U5:host.docker.internal:42259/members => 200 OK (37.461027ms)
      federation_room_join_partial_state_test.go:342: @user-1-t1alice_initial:hs1's partial state join to !0-ZUdMofhywQfiJEk4U5:host.docker.internal:42259 completed.
      federation_room_join_partial_state_test.go:344: 8. Have Alice eager-sync. She should see the remote room.
      client.go:642: [CSAPI] GET hs1/_matrix/client/v3/sync => 200 OK (9.642345ms)
      federation_room_join_partial_state_test.go:4393: Cleaning up after test...
      federation_room_join_partial_state_test.go:77: Received unexpected PDU: {"auth_events":["$V8jfcsoBi0bSUt3Sc3XhxAX0I_hKz8T7PENwu0rwgBg","$-yoG5lj0PcPImrpxLewRi0rfvqp4GGQ8nj9WenUTEEk","$t9m5nWfcgFXkIav4enFRuCWxAy6Ftyu2cet8jyIgAdU"],"content":{"body":"Hello world","msgtype":"m.text"},"depth":7,"hashes":{"sha256":"Np1H/lPP5HihL1USqYZIP0kIHFrzleWpba39w3dvixY"},"origin":"hs1","origin_server_ts":1704465535464,"prev_events":["$-yoG5lj0PcPImrpxLewRi0rfvqp4GGQ8nj9WenUTEEk"],"room_id":"!0-ZUdMofhywQfiJEk4U5:host.docker.internal:42259","sender":"@user-1-t1alice_initial:hs1","signatures":{"hs1":{"ed25519:a_rEwe":"wtWuIQSdCwNb2qrfj93pyeJ2KqoKwJ5KtO3Bp/kJYlyqsT2ShQnqRZL3nJyeniN6XtzIwfDPWOc4N+Rjr1lwBw"}},"type":"m.room.message"}
      client.go:642: [CSAPI] GET hs1/_matrix/client/v3/rooms/!0-ZUdMofhywQfiJEk4U5:host.docker.internal:42259/members => 200 OK (3.650587ms)
      federation_room_join_partial_state_test.go:4395: @user-1-t1alice_initial:hs1's partial state join to !0-ZUdMofhywQfiJEk4U5:host.docker.internal:42259 completed.
      client.go:642: [CSAPI] POST hs1/_matrix/client/v3/rooms/!0-ZUdMofhywQfiJEk4U5:host.docker.internal:42259/leave => 200 OK (18.205892ms)
      federation_room_join_partial_state_test.go:156: host.docker.internal:42259 saw @user-1-t1alice_initial:hs1 leave test room !0-ZUdMofhywQfiJEk4U5:host.docker.internal:42259.
```

</details>