### PR TITLE
refactor: make logging test agnostic and colourful

### DIFF
--- a/client/auth.go
+++ b/client/auth.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"io"
 
+	"github.com/matrix-org/complement/ct"
 	"github.com/tidwall/gjson"
 )
 
@@ -22,7 +23,7 @@ func WithDeviceID(deviceID string) LoginOpt {
 }
 
 // LoginUser will log in to a homeserver and create a new device on an existing user.
-func (c *CSAPI) LoginUser(t TestLike, localpart, password string, opts ...LoginOpt) (userID, accessToken, deviceID string) {
+func (c *CSAPI) LoginUser(t ct.TestLike, localpart, password string, opts ...LoginOpt) (userID, accessToken, deviceID string) {
 	t.Helper()
 	reqBody := map[string]interface{}{
 		"identifier": map[string]interface{}{
@@ -41,7 +42,7 @@ func (c *CSAPI) LoginUser(t TestLike, localpart, password string, opts ...LoginO
 
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
-		fatalf(t, "unable to read response body: %v", err)
+		ct.Fatalf(t, "unable to read response body: %v", err)
 	}
 
 	userID = GetJSONFieldStr(t, body, "user_id")
@@ -52,7 +53,7 @@ func (c *CSAPI) LoginUser(t TestLike, localpart, password string, opts ...LoginO
 
 // LoginUserWithRefreshToken will log in to a homeserver, with refresh token enabled,
 // and create a new device on an existing user.
-func (c *CSAPI) LoginUserWithRefreshToken(t TestLike, localpart, password string) (userID, accessToken, refreshToken, deviceID string, expiresInMs int64) {
+func (c *CSAPI) LoginUserWithRefreshToken(t ct.TestLike, localpart, password string) (userID, accessToken, refreshToken, deviceID string, expiresInMs int64) {
 	t.Helper()
 	reqBody := map[string]interface{}{
 		"identifier": map[string]interface{}{
@@ -67,7 +68,7 @@ func (c *CSAPI) LoginUserWithRefreshToken(t TestLike, localpart, password string
 
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
-		fatalf(t, "unable to read response body: %v", err)
+		ct.Fatalf(t, "unable to read response body: %v", err)
 	}
 
 	userID = GetJSONFieldStr(t, body, "user_id")
@@ -79,7 +80,7 @@ func (c *CSAPI) LoginUserWithRefreshToken(t TestLike, localpart, password string
 }
 
 // RefreshToken will consume a refresh token and return a new access token and refresh token.
-func (c *CSAPI) ConsumeRefreshToken(t TestLike, refreshToken string) (newAccessToken, newRefreshToken string, expiresInMs int64) {
+func (c *CSAPI) ConsumeRefreshToken(t ct.TestLike, refreshToken string) (newAccessToken, newRefreshToken string, expiresInMs int64) {
 	t.Helper()
 	reqBody := map[string]interface{}{
 		"refresh_token": refreshToken,
@@ -88,7 +89,7 @@ func (c *CSAPI) ConsumeRefreshToken(t TestLike, refreshToken string) (newAccessT
 
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
-		fatalf(t, "unable to read response body: %v", err)
+		ct.Fatalf(t, "unable to read response body: %v", err)
 	}
 
 	newAccessToken = GetJSONFieldStr(t, body, "access_token")
@@ -99,7 +100,7 @@ func (c *CSAPI) ConsumeRefreshToken(t TestLike, refreshToken string) (newAccessT
 
 // RegisterUser will register the user with given parameters and
 // return user ID, access token and device ID. It fails the test on network error.
-func (c *CSAPI) RegisterUser(t TestLike, localpart, password string) (userID, accessToken, deviceID string) {
+func (c *CSAPI) RegisterUser(t ct.TestLike, localpart, password string) (userID, accessToken, deviceID string) {
 	t.Helper()
 	reqBody := map[string]interface{}{
 		"auth": map[string]string{
@@ -112,7 +113,7 @@ func (c *CSAPI) RegisterUser(t TestLike, localpart, password string) (userID, ac
 
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
-		fatalf(t, "unable to read response body: %v", err)
+		ct.Fatalf(t, "unable to read response body: %v", err)
 	}
 
 	userID = GetJSONFieldStr(t, body, "user_id")
@@ -123,7 +124,7 @@ func (c *CSAPI) RegisterUser(t TestLike, localpart, password string) (userID, ac
 
 // RegisterSharedSecret registers a new account with a shared secret via HMAC
 // See https://github.com/matrix-org/synapse/blob/e550ab17adc8dd3c48daf7fedcd09418a73f524b/synapse/_scripts/register_new_matrix_user.py#L40
-func (c *CSAPI) RegisterSharedSecret(t TestLike, user, pass string, isAdmin bool) (userID, accessToken, deviceID string) {
+func (c *CSAPI) RegisterSharedSecret(t ct.TestLike, user, pass string, isAdmin bool) (userID, accessToken, deviceID string) {
 	resp := c.Do(t, "GET", []string{"_synapse", "admin", "v1", "register"})
 	if resp.StatusCode != 200 {
 		t.Skipf("Homeserver image does not support shared secret registration, /_synapse/admin/v1/register returned HTTP %d", resp.StatusCode)
@@ -132,7 +133,7 @@ func (c *CSAPI) RegisterSharedSecret(t TestLike, user, pass string, isAdmin bool
 	body := ParseJSON(t, resp)
 	nonce := gjson.GetBytes(body, "nonce")
 	if !nonce.Exists() {
-		fatalf(t, "Malformed shared secret GET response: %s", string(body))
+		ct.Fatalf(t, "Malformed shared secret GET response: %s", string(body))
 	}
 	mac := hmac.New(sha1.New, []byte(SharedSecret))
 	mac.Write([]byte(nonce.Str))

--- a/client/client.go
+++ b/client/client.go
@@ -19,36 +19,8 @@ import (
 	"maunium.net/go/mautrix/crypto/olm"
 
 	"github.com/matrix-org/complement/b"
+	"github.com/matrix-org/complement/ct"
 )
-
-// TestLike is an interface that testing.T satisfies. All client functions accept a TestLike interface,
-// with the intention of a `testing.T` being passed into them. However, the client may be used in non-test
-// scenarios e.g benchmarks, which can then use the same client by just implementing this interface.
-type TestLike interface {
-	Helper()
-	Logf(msg string, args ...interface{})
-	Skipf(msg string, args ...interface{})
-	Error(args ...interface{})
-	Errorf(msg string, args ...interface{})
-	Fatalf(msg string, args ...interface{})
-}
-
-const ansiRedForeground = "\x1b[31m"
-const ansiResetForeground = "\x1b[39m"
-
-// errorf is a wrapper around t.Errorf which prints the failing error message in red.
-func errorf(t TestLike, format string, args ...any) {
-	t.Helper()
-	format = ansiRedForeground + format + ansiResetForeground
-	t.Errorf(format, args...)
-}
-
-// fatalf is a wrapper around t.Fatalf which prints the failing error message in red.
-func fatalf(t TestLike, format string, args ...any) {
-	t.Helper()
-	format = ansiRedForeground + format + ansiResetForeground
-	t.Fatalf(format, args...)
-}
 
 type ctxKey string
 
@@ -80,7 +52,7 @@ type CSAPI struct {
 }
 
 // CreateMedia creates an MXC URI for asynchronous media uploads.
-func (c *CSAPI) CreateMedia(t TestLike) string {
+func (c *CSAPI) CreateMedia(t ct.TestLike) string {
 	t.Helper()
 	res := c.MustDo(t, "POST", []string{"_matrix", "media", "v1", "create"})
 	body := ParseJSON(t, res)
@@ -88,7 +60,7 @@ func (c *CSAPI) CreateMedia(t TestLike) string {
 }
 
 // UploadMediaAsync uploads the provided content to the given server and media ID. Fails the test on error.
-func (c *CSAPI) UploadMediaAsync(t TestLike, serverName, mediaID string, fileBody []byte, fileName string, contentType string) {
+func (c *CSAPI) UploadMediaAsync(t ct.TestLike, serverName, mediaID string, fileBody []byte, fileName string, contentType string) {
 	t.Helper()
 	query := url.Values{}
 	if fileName != "" {
@@ -101,7 +73,7 @@ func (c *CSAPI) UploadMediaAsync(t TestLike, serverName, mediaID string, fileBod
 }
 
 // UploadContent uploads the provided content with an optional file name. Fails the test on error. Returns the MXC URI.
-func (c *CSAPI) UploadContent(t TestLike, fileBody []byte, fileName string, contentType string) string {
+func (c *CSAPI) UploadContent(t ct.TestLike, fileBody []byte, fileName string, contentType string) string {
 	t.Helper()
 	query := url.Values{}
 	if fileName != "" {
@@ -116,20 +88,20 @@ func (c *CSAPI) UploadContent(t TestLike, fileBody []byte, fileName string, cont
 }
 
 // DownloadContent downloads media from the server, returning the raw bytes and the Content-Type. Fails the test on error.
-func (c *CSAPI) DownloadContent(t TestLike, mxcUri string) ([]byte, string) {
+func (c *CSAPI) DownloadContent(t ct.TestLike, mxcUri string) ([]byte, string) {
 	t.Helper()
 	origin, mediaId := SplitMxc(mxcUri)
 	res := c.MustDo(t, "GET", []string{"_matrix", "media", "v3", "download", origin, mediaId})
 	contentType := res.Header.Get("Content-Type")
 	b, err := io.ReadAll(res.Body)
 	if err != nil {
-		errorf(t, err.Error())
+		ct.Errorf(t, err.Error())
 	}
 	return b, contentType
 }
 
 // MustCreateRoom creates a room with an optional HTTP request body. Fails the test on error. Returns the room ID.
-func (c *CSAPI) MustCreateRoom(t TestLike, reqBody map[string]interface{}) string {
+func (c *CSAPI) MustCreateRoom(t ct.TestLike, reqBody map[string]interface{}) string {
 	t.Helper()
 	res := c.CreateRoom(t, reqBody)
 	mustRespond2xx(t, res)
@@ -138,13 +110,13 @@ func (c *CSAPI) MustCreateRoom(t TestLike, reqBody map[string]interface{}) strin
 }
 
 // CreateRoom creates a room with an optional HTTP request body.
-func (c *CSAPI) CreateRoom(t TestLike, body map[string]interface{}) *http.Response {
+func (c *CSAPI) CreateRoom(t ct.TestLike, body map[string]interface{}) *http.Response {
 	t.Helper()
 	return c.Do(t, "POST", []string{"_matrix", "client", "v3", "createRoom"}, WithJSONBody(t, body))
 }
 
 // MustJoinRoom joins the room ID or alias given, else fails the test. Returns the room ID.
-func (c *CSAPI) MustJoinRoom(t TestLike, roomIDOrAlias string, serverNames []string) string {
+func (c *CSAPI) MustJoinRoom(t ct.TestLike, roomIDOrAlias string, serverNames []string) string {
 	t.Helper()
 	res := c.JoinRoom(t, roomIDOrAlias, serverNames)
 	mustRespond2xx(t, res)
@@ -158,7 +130,7 @@ func (c *CSAPI) MustJoinRoom(t TestLike, roomIDOrAlias string, serverNames []str
 }
 
 // JoinRoom joins the room ID or alias given. Returns the raw http response
-func (c *CSAPI) JoinRoom(t TestLike, roomIDOrAlias string, serverNames []string) *http.Response {
+func (c *CSAPI) JoinRoom(t ct.TestLike, roomIDOrAlias string, serverNames []string) *http.Response {
 	t.Helper()
 	// construct URL query parameters
 	query := make(url.Values, len(serverNames))
@@ -173,13 +145,13 @@ func (c *CSAPI) JoinRoom(t TestLike, roomIDOrAlias string, serverNames []string)
 }
 
 // MustLeaveRoom leaves the room ID, else fails the test.
-func (c *CSAPI) MustLeaveRoom(t TestLike, roomID string) {
+func (c *CSAPI) MustLeaveRoom(t ct.TestLike, roomID string) {
 	res := c.LeaveRoom(t, roomID)
 	mustRespond2xx(t, res)
 }
 
 // LeaveRoom leaves the room ID.
-func (c *CSAPI) LeaveRoom(t TestLike, roomID string) *http.Response {
+func (c *CSAPI) LeaveRoom(t ct.TestLike, roomID string) *http.Response {
 	t.Helper()
 	// leave the room
 	body := map[string]interface{}{}
@@ -187,14 +159,14 @@ func (c *CSAPI) LeaveRoom(t TestLike, roomID string) *http.Response {
 }
 
 // InviteRoom invites userID to the room ID, else fails the test.
-func (c *CSAPI) MustInviteRoom(t TestLike, roomID string, userID string) {
+func (c *CSAPI) MustInviteRoom(t ct.TestLike, roomID string, userID string) {
 	t.Helper()
 	res := c.InviteRoom(t, roomID, userID)
 	mustRespond2xx(t, res)
 }
 
 // InviteRoom invites userID to the room ID, else fails the test.
-func (c *CSAPI) InviteRoom(t TestLike, roomID string, userID string) *http.Response {
+func (c *CSAPI) InviteRoom(t ct.TestLike, roomID string, userID string) *http.Response {
 	t.Helper()
 	// Invite the user to the room
 	body := map[string]interface{}{
@@ -203,31 +175,31 @@ func (c *CSAPI) InviteRoom(t TestLike, roomID string, userID string) *http.Respo
 	return c.Do(t, "POST", []string{"_matrix", "client", "v3", "rooms", roomID, "invite"}, WithJSONBody(t, body))
 }
 
-func (c *CSAPI) MustGetGlobalAccountData(t TestLike, eventType string) *http.Response {
+func (c *CSAPI) MustGetGlobalAccountData(t ct.TestLike, eventType string) *http.Response {
 	res := c.GetGlobalAccountData(t, eventType)
 	mustRespond2xx(t, res)
 	return res
 }
 
-func (c *CSAPI) GetGlobalAccountData(t TestLike, eventType string) *http.Response {
+func (c *CSAPI) GetGlobalAccountData(t ct.TestLike, eventType string) *http.Response {
 	return c.Do(t, "GET", []string{"_matrix", "client", "v3", "user", c.UserID, "account_data", eventType})
 }
 
-func (c *CSAPI) MustSetGlobalAccountData(t TestLike, eventType string, content map[string]interface{}) *http.Response {
+func (c *CSAPI) MustSetGlobalAccountData(t ct.TestLike, eventType string, content map[string]interface{}) *http.Response {
 	return c.MustDo(t, "PUT", []string{"_matrix", "client", "v3", "user", c.UserID, "account_data", eventType}, WithJSONBody(t, content))
 }
 
-func (c *CSAPI) MustGetRoomAccountData(t TestLike, roomID string, eventType string) *http.Response {
+func (c *CSAPI) MustGetRoomAccountData(t ct.TestLike, roomID string, eventType string) *http.Response {
 	res := c.GetRoomAccountData(t, roomID, eventType)
 	mustRespond2xx(t, res)
 	return res
 }
 
-func (c *CSAPI) GetRoomAccountData(t TestLike, roomID string, eventType string) *http.Response {
+func (c *CSAPI) GetRoomAccountData(t ct.TestLike, roomID string, eventType string) *http.Response {
 	return c.Do(t, "GET", []string{"_matrix", "client", "v3", "user", c.UserID, "rooms", roomID, "account_data", eventType})
 }
 
-func (c *CSAPI) MustSetRoomAccountData(t TestLike, roomID string, eventType string, content map[string]interface{}) *http.Response {
+func (c *CSAPI) MustSetRoomAccountData(t ct.TestLike, roomID string, eventType string, content map[string]interface{}) *http.Response {
 	return c.MustDo(t, "PUT", []string{"_matrix", "client", "v3", "user", c.UserID, "rooms", roomID, "account_data", eventType}, WithJSONBody(t, content))
 }
 
@@ -244,7 +216,7 @@ func (c *CSAPI) MustSetRoomAccountData(t TestLike, roomID string, eventType stri
 //	}
 //
 // Push rules are returned in the same order received from the homeserver.
-func (c *CSAPI) GetAllPushRules(t TestLike) gjson.Result {
+func (c *CSAPI) GetAllPushRules(t ct.TestLike) gjson.Result {
 	t.Helper()
 
 	// We have to supply an empty string to the end of this path in order to generate a trailing slash.
@@ -269,7 +241,7 @@ func (c *CSAPI) GetAllPushRules(t TestLike) gjson.Result {
 //	    map[string]interface{}{"set_tweak": "highlight"},
 //	  }),
 //	)
-func (c *CSAPI) GetPushRule(t TestLike, scope string, kind string, ruleID string) gjson.Result {
+func (c *CSAPI) GetPushRule(t ct.TestLike, scope string, kind string, ruleID string) gjson.Result {
 	t.Helper()
 
 	res := c.MustDo(t, "GET", []string{"_matrix", "client", "v3", "pushrules", scope, kind, ruleID})
@@ -288,7 +260,7 @@ func (c *CSAPI) GetPushRule(t TestLike, scope string, kind string, ruleID string
 //	c.SetPushRule(t, "global", "underride", "com.example.rule2", map[string]interface{}{
 //	  "actions": []string{"dont_notify"},
 //	}, nil, "com.example.rule1")
-func (c *CSAPI) SetPushRule(t TestLike, scope string, kind string, ruleID string, body map[string]interface{}, before string, after string) *http.Response {
+func (c *CSAPI) SetPushRule(t ct.TestLike, scope string, kind string, ruleID string, body map[string]interface{}, before string, after string) *http.Response {
 	t.Helper()
 
 	// If the `before` or `after` arguments have been provided, construct same-named query parameters
@@ -306,7 +278,7 @@ func (c *CSAPI) SetPushRule(t TestLike, scope string, kind string, ruleID string
 // Unsafe_SendEventUnsynced sends `e` into the room. This function is UNSAFE as it does not wait
 // for the event to be fully processed. This can cause flakey tests. Prefer `SendEventSynced`.
 // Returns the event ID of the sent event.
-func (c *CSAPI) Unsafe_SendEventUnsynced(t TestLike, roomID string, e b.Event) string {
+func (c *CSAPI) Unsafe_SendEventUnsynced(t ct.TestLike, roomID string, e b.Event) string {
 	t.Helper()
 	txnID := int(atomic.AddInt64(&c.txnID, 1))
 	return c.Unsafe_SendEventUnsyncedWithTxnID(t, roomID, e, strconv.Itoa(txnID))
@@ -316,14 +288,14 @@ func (c *CSAPI) Unsafe_SendEventUnsynced(t TestLike, roomID string, e b.Event) s
 // This is useful for writing tests that interrogate transaction semantics. This function is UNSAFE
 // as it does not wait for the event to be fully processed. This can cause flakey tests. Prefer `SendEventSynced`.
 // Returns the event ID of the sent event.
-func (c *CSAPI) Unsafe_SendEventUnsyncedWithTxnID(t TestLike, roomID string, e b.Event, txnID string) string {
+func (c *CSAPI) Unsafe_SendEventUnsyncedWithTxnID(t ct.TestLike, roomID string, e b.Event, txnID string) string {
 	t.Helper()
 	paths := []string{"_matrix", "client", "v3", "rooms", roomID, "send", e.Type, txnID}
 	if e.StateKey != nil {
 		paths = []string{"_matrix", "client", "v3", "rooms", roomID, "state", e.Type, *e.StateKey}
 	}
 	if e.Sender != "" && e.Sender != c.UserID {
-		fatalf(t, "Event.Sender must not be set, as this is set by the client in use (%s)", c.UserID)
+		ct.Fatalf(t, "Event.Sender must not be set, as this is set by the client in use (%s)", c.UserID)
 	}
 	res := c.MustDo(t, "PUT", paths, WithJSONBody(t, e.Content))
 	body := ParseJSON(t, res)
@@ -333,7 +305,7 @@ func (c *CSAPI) Unsafe_SendEventUnsyncedWithTxnID(t TestLike, roomID string, e b
 
 // SendEventSynced sends `e` into the room and waits for its event ID to come down /sync.
 // Returns the event ID of the sent event.
-func (c *CSAPI) SendEventSynced(t TestLike, roomID string, e b.Event) string {
+func (c *CSAPI) SendEventSynced(t ct.TestLike, roomID string, e b.Event) string {
 	t.Helper()
 	eventID := c.Unsafe_SendEventUnsynced(t, roomID, e)
 	t.Logf("SendEventSynced waiting for event ID %s", eventID)
@@ -345,7 +317,7 @@ func (c *CSAPI) SendEventSynced(t TestLike, roomID string, e b.Event) string {
 
 // SendRedaction sends a redaction request. Will fail if the returned HTTP request code is not 200. Returns the
 // event ID of the redaction event.
-func (c *CSAPI) MustSendRedaction(t TestLike, roomID string, content map[string]interface{}, eventID string) string {
+func (c *CSAPI) MustSendRedaction(t ct.TestLike, roomID string, content map[string]interface{}, eventID string) string {
 	res := c.SendRedaction(t, roomID, content, eventID)
 	mustRespond2xx(t, res)
 	body := ParseJSON(t, res)
@@ -353,7 +325,7 @@ func (c *CSAPI) MustSendRedaction(t TestLike, roomID string, content map[string]
 }
 
 // SendRedaction sends a redaction request.
-func (c *CSAPI) SendRedaction(t TestLike, roomID string, content map[string]interface{}, eventID string) *http.Response {
+func (c *CSAPI) SendRedaction(t ct.TestLike, roomID string, content map[string]interface{}, eventID string) *http.Response {
 	t.Helper()
 	txnID := int(atomic.AddInt64(&c.txnID, 1))
 	paths := []string{"_matrix", "client", "v3", "rooms", roomID, "redact", eventID, strconv.Itoa(txnID)}
@@ -361,13 +333,13 @@ func (c *CSAPI) SendRedaction(t TestLike, roomID string, content map[string]inte
 }
 
 // MustSendTyping marks this user as typing until the timeout is reached. If isTyping is false, timeout is ignored.
-func (c *CSAPI) MustSendTyping(t TestLike, roomID string, isTyping bool, timeoutMillis int) {
+func (c *CSAPI) MustSendTyping(t ct.TestLike, roomID string, isTyping bool, timeoutMillis int) {
 	res := c.SendTyping(t, roomID, isTyping, timeoutMillis)
 	mustRespond2xx(t, res)
 }
 
 // SendTyping marks this user as typing until the timeout is reached. If isTyping is false, timeout is ignored.
-func (c *CSAPI) SendTyping(t TestLike, roomID string, isTyping bool, timeoutMillis int) *http.Response {
+func (c *CSAPI) SendTyping(t ct.TestLike, roomID string, isTyping bool, timeoutMillis int) *http.Response {
 	content := map[string]interface{}{
 		"typing": isTyping,
 	}
@@ -378,18 +350,18 @@ func (c *CSAPI) SendTyping(t TestLike, roomID string, isTyping bool, timeoutMill
 }
 
 // GetCapbabilities queries the server's capabilities
-func (c *CSAPI) GetCapabilities(t TestLike) []byte {
+func (c *CSAPI) GetCapabilities(t ct.TestLike) []byte {
 	t.Helper()
 	res := c.MustDo(t, "GET", []string{"_matrix", "client", "v3", "capabilities"})
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
-		fatalf(t, "unable to read response body: %v", err)
+		ct.Fatalf(t, "unable to read response body: %v", err)
 	}
 	return body
 }
 
 // GetDefaultRoomVersion returns the server's default room version
-func (c *CSAPI) GetDefaultRoomVersion(t TestLike) gomatrixserverlib.RoomVersion {
+func (c *CSAPI) GetDefaultRoomVersion(t ct.TestLike) gomatrixserverlib.RoomVersion {
 	t.Helper()
 	capabilities := c.GetCapabilities(t)
 	defaultVersion := gjson.GetBytes(capabilities, `capabilities.m\.room_versions.default`)
@@ -401,7 +373,7 @@ func (c *CSAPI) GetDefaultRoomVersion(t TestLike) gomatrixserverlib.RoomVersion 
 	return gomatrixserverlib.RoomVersion(defaultVersion.Str)
 }
 
-func (c *CSAPI) MustGenerateOneTimeKeys(t TestLike, otkCount uint) (deviceKeys map[string]interface{}, oneTimeKeys map[string]interface{}) {
+func (c *CSAPI) MustGenerateOneTimeKeys(t ct.TestLike, otkCount uint) (deviceKeys map[string]interface{}, oneTimeKeys map[string]interface{}) {
 	t.Helper()
 	account := olm.NewAccount()
 	ed25519Key, curveKey := account.IdentityKeys()
@@ -472,12 +444,12 @@ func WithContentType(cType string) RequestOpt {
 }
 
 // WithJSONBody sets the HTTP request body to the JSON serialised form of `obj`
-func WithJSONBody(t TestLike, obj interface{}) RequestOpt {
+func WithJSONBody(t ct.TestLike, obj interface{}) RequestOpt {
 	return func(req *http.Request) {
 		t.Helper()
 		b, err := json.Marshal(obj)
 		if err != nil {
-			fatalf(t, "CSAPI.Do failed to marshal JSON body: %s", err)
+			ct.Fatalf(t, "CSAPI.Do failed to marshal JSON body: %s", err)
 		}
 		WithRawBody(b)(req)
 	}
@@ -503,13 +475,13 @@ func WithRetryUntil(timeout time.Duration, untilFn func(res *http.Response) bool
 }
 
 // MustDo is the same as Do but fails the test if the returned HTTP response code is not 2xx.
-func (c *CSAPI) MustDo(t TestLike, method string, paths []string, opts ...RequestOpt) *http.Response {
+func (c *CSAPI) MustDo(t ct.TestLike, method string, paths []string, opts ...RequestOpt) *http.Response {
 	t.Helper()
 	res := c.Do(t, method, paths, opts...)
 	if res.StatusCode < 200 || res.StatusCode >= 300 {
 		defer res.Body.Close()
 		body, _ := io.ReadAll(res.Body)
-		fatalf(t, "CSAPI.MustDo %s %s returned non-2xx code: %s - body: %s", method, res.Request.URL.String(), res.Status, string(body))
+		ct.Fatalf(t, "CSAPI.MustDo %s %s returned non-2xx code: %s - body: %s", method, res.Request.URL.String(), res.Status, string(body))
 	}
 	return res
 }
@@ -527,7 +499,7 @@ func (c *CSAPI) MustDo(t TestLike, method string, paths []string, opts ...Reques
 //			match.JSONKeyEqual("errcode", "M_INVALID_USERNAME"),
 //		},
 //	})
-func (c *CSAPI) Do(t TestLike, method string, paths []string, opts ...RequestOpt) *http.Response {
+func (c *CSAPI) Do(t ct.TestLike, method string, paths []string, opts ...RequestOpt) *http.Response {
 	t.Helper()
 	for i := range paths {
 		paths[i] = url.PathEscape(paths[i])
@@ -535,7 +507,7 @@ func (c *CSAPI) Do(t TestLike, method string, paths []string, opts ...RequestOpt
 	reqURL := c.BaseURL + "/" + strings.Join(paths, "/")
 	req, err := http.NewRequest(method, reqURL, nil)
 	if err != nil {
-		fatalf(t, "CSAPI.Do failed to create http.NewRequest: %s", err)
+		ct.Fatalf(t, "CSAPI.Do failed to create http.NewRequest: %s", err)
 	}
 	// set defaults before RequestOpts
 	if c.AccessToken != "" {
@@ -572,14 +544,14 @@ func (c *CSAPI) Do(t TestLike, method string, paths []string, opts ...RequestOpt
 		// Perform the HTTP request
 		res, err := c.Client.Do(req)
 		if err != nil {
-			fatalf(t, "CSAPI.Do response returned error: %s", err)
+			ct.Fatalf(t, "CSAPI.Do response returned error: %s", err)
 		}
 		// debug log the response
 		if c.Debug && res != nil {
 			var dump []byte
 			dump, err = httputil.DumpResponse(res, true)
 			if err != nil {
-				fatalf(t, "CSAPI.Do failed to dump response body: %s", err)
+				ct.Fatalf(t, "CSAPI.Do failed to dump response body: %s", err)
 			}
 			t.Logf("%s", string(dump))
 		}
@@ -592,7 +564,7 @@ func (c *CSAPI) Do(t TestLike, method string, paths []string, opts ...RequestOpt
 		if res.Body != nil {
 			resBody, err = io.ReadAll(res.Body)
 			if err != nil {
-				fatalf(t, "CSAPI.Do failed to read response body for RetryUntil check: %s", err)
+				ct.Fatalf(t, "CSAPI.Do failed to read response body for RetryUntil check: %s", err)
 			}
 			res.Body = io.NopCloser(bytes.NewBuffer(resBody))
 		}
@@ -603,7 +575,7 @@ func (c *CSAPI) Do(t TestLike, method string, paths []string, opts ...RequestOpt
 		}
 		// condition not satisfied, do we timeout yet?
 		if time.Since(now) > retryUntil.timeout {
-			fatalf(t, "CSAPI.Do RetryUntil: %v %v timed out after %v", method, req.URL, retryUntil.timeout)
+			ct.Fatalf(t, "CSAPI.Do RetryUntil: %v %v timed out after %v", method, req.URL, retryUntil.timeout)
 		}
 		t.Logf("CSAPI.Do RetryUntil: %v %v response condition not yet met, retrying", method, req.URL)
 		// small sleep to avoid tight-looping
@@ -612,7 +584,7 @@ func (c *CSAPI) Do(t TestLike, method string, paths []string, opts ...RequestOpt
 }
 
 // NewLoggedClient returns an http.Client which logs requests/responses
-func NewLoggedClient(t TestLike, hsName string, cli *http.Client) *http.Client {
+func NewLoggedClient(t ct.TestLike, hsName string, cli *http.Client) *http.Client {
 	t.Helper()
 	if cli == nil {
 		cli = &http.Client{
@@ -628,7 +600,7 @@ func NewLoggedClient(t TestLike, hsName string, cli *http.Client) *http.Client {
 }
 
 type loggedRoundTripper struct {
-	t      TestLike
+	t      ct.TestLike
 	hsName string
 	wrap   http.RoundTripper
 }
@@ -645,25 +617,25 @@ func (t *loggedRoundTripper) RoundTrip(req *http.Request) (*http.Response, error
 }
 
 // GetJSONFieldStr extracts a value from a byte-encoded JSON body given a search key
-func GetJSONFieldStr(t TestLike, body []byte, wantKey string) string {
+func GetJSONFieldStr(t ct.TestLike, body []byte, wantKey string) string {
 	t.Helper()
 	res := gjson.GetBytes(body, wantKey)
 	if !res.Exists() {
-		fatalf(t, "JSONFieldStr: key '%s' missing from %s", wantKey, string(body))
+		ct.Fatalf(t, "JSONFieldStr: key '%s' missing from %s", wantKey, string(body))
 	}
 	if res.Str == "" {
-		fatalf(t, "JSONFieldStr: key '%s' is not a string, body: %s", wantKey, string(body))
+		ct.Fatalf(t, "JSONFieldStr: key '%s' is not a string, body: %s", wantKey, string(body))
 	}
 	return res.Str
 }
 
-func GetJSONFieldStringArray(t TestLike, body []byte, wantKey string) []string {
+func GetJSONFieldStringArray(t ct.TestLike, body []byte, wantKey string) []string {
 	t.Helper()
 
 	res := gjson.GetBytes(body, wantKey)
 
 	if !res.Exists() {
-		fatalf(t, "JSONFieldStr: key '%s' missing from %s", wantKey, string(body))
+		ct.Fatalf(t, "JSONFieldStr: key '%s' missing from %s", wantKey, string(body))
 	}
 
 	arrLength := len(res.Array())
@@ -681,15 +653,15 @@ func GetJSONFieldStringArray(t TestLike, body []byte, wantKey string) []string {
 }
 
 // ParseJSON parses a JSON-encoded HTTP Response body into a byte slice
-func ParseJSON(t TestLike, res *http.Response) []byte {
+func ParseJSON(t ct.TestLike, res *http.Response) []byte {
 	t.Helper()
 	defer res.Body.Close()
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
-		fatalf(t, "MustParseJSON: reading HTTP response body returned %s", err)
+		ct.Fatalf(t, "MustParseJSON: reading HTTP response body returned %s", err)
 	}
 	if !gjson.ValidBytes(body) {
-		fatalf(t, "MustParseJSON: Response is not valid JSON")
+		ct.Fatalf(t, "MustParseJSON: Response is not valid JSON")
 	}
 	return body
 }
@@ -731,7 +703,7 @@ func SplitMxc(mxcUri string) (string, string) {
 //
 // The messages parameter is nested as follows:
 // user_id -> device_id -> content (map[string]interface{})
-func (c *CSAPI) MustSendToDeviceMessages(t TestLike, evType string, messages map[string]map[string]map[string]interface{}) {
+func (c *CSAPI) MustSendToDeviceMessages(t ct.TestLike, evType string, messages map[string]map[string]map[string]interface{}) {
 	t.Helper()
 	res := c.SendToDeviceMessages(t, evType, messages)
 	mustRespond2xx(t, res)
@@ -741,7 +713,7 @@ func (c *CSAPI) MustSendToDeviceMessages(t TestLike, evType string, messages map
 //
 // The messages parameter is nested as follows:
 // user_id -> device_id -> content (map[string]interface{})
-func (c *CSAPI) SendToDeviceMessages(t TestLike, evType string, messages map[string]map[string]map[string]interface{}) (errRes *http.Response) {
+func (c *CSAPI) SendToDeviceMessages(t ct.TestLike, evType string, messages map[string]map[string]map[string]interface{}) (errRes *http.Response) {
 	t.Helper()
 	txnID := int(atomic.AddInt64(&c.txnID, 1))
 	return c.Do(
@@ -757,11 +729,11 @@ func (c *CSAPI) SendToDeviceMessages(t TestLike, evType string, messages map[str
 	)
 }
 
-func mustRespond2xx(t TestLike, res *http.Response) {
+func mustRespond2xx(t ct.TestLike, res *http.Response) {
 	if res.StatusCode >= 200 && res.StatusCode < 300 {
 		return // 2xx
 	}
 	defer res.Body.Close()
 	body, _ := io.ReadAll(res.Body)
-	fatalf(t, "CSAPI.Must: %s %s returned non-2xx code: %s - body: %s", res.Request.Method, res.Request.URL.String(), res.Status, string(body))
+	ct.Fatalf(t, "CSAPI.Must: %s %s returned non-2xx code: %s - body: %s", res.Request.Method, res.Request.URL.String(), res.Status, string(body))
 }

--- a/client/sync.go
+++ b/client/sync.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/matrix-org/complement/ct"
 	"github.com/tidwall/gjson"
 )
 
@@ -88,7 +89,7 @@ type SyncReq struct {
 //
 // Will time out after CSAPI.SyncUntilTimeout. Returns the `next_batch` token from the final
 // response.
-func (c *CSAPI) MustSyncUntil(t TestLike, syncReq SyncReq, checks ...SyncCheckOpt) string {
+func (c *CSAPI) MustSyncUntil(t ct.TestLike, syncReq SyncReq, checks ...SyncCheckOpt) string {
 	t.Helper()
 	start := time.Now()
 	numResponsesReturned := 0
@@ -111,7 +112,7 @@ func (c *CSAPI) MustSyncUntil(t TestLike, syncReq SyncReq, checks ...SyncCheckOp
 	}
 	for {
 		if time.Since(start) > c.SyncUntilTimeout {
-			fatalf(t, "%s MustSyncUntil: timed out after %v. Seen %d /sync responses. %s", c.UserID, time.Since(start), numResponsesReturned, printErrors())
+			ct.Fatalf(t, "%s MustSyncUntil: timed out after %v. Seen %d /sync responses. %s", c.UserID, time.Since(start), numResponsesReturned, printErrors())
 		}
 		response, nextBatch := c.MustSync(t, syncReq)
 		syncReq.Since = nextBatch
@@ -141,7 +142,7 @@ func (c *CSAPI) MustSyncUntil(t TestLike, syncReq SyncReq, checks ...SyncCheckOp
 //
 // Fails the test if the /sync request does not return 200 OK.
 // Returns the top-level parsed /sync response JSON as well as the next_batch token from the response.
-func (c *CSAPI) MustSync(t TestLike, syncReq SyncReq) (gjson.Result, string) {
+func (c *CSAPI) MustSync(t ct.TestLike, syncReq SyncReq) (gjson.Result, string) {
 	t.Helper()
 	jsonBody, res := c.Sync(t, syncReq)
 	mustRespond2xx(t, res)
@@ -153,7 +154,7 @@ func (c *CSAPI) MustSync(t TestLike, syncReq SyncReq) (gjson.Result, string) {
 //
 // Always returns the HTTP response, even on non-2xx.
 // Returns the top-level parsed /sync response JSON on 2xx.
-func (c *CSAPI) Sync(t TestLike, syncReq SyncReq) (gjson.Result, *http.Response) {
+func (c *CSAPI) Sync(t ct.TestLike, syncReq SyncReq) (gjson.Result, *http.Response) {
 	t.Helper()
 	query := url.Values{
 		"timeout": []string{"1000"},

--- a/ct/test.go
+++ b/ct/test.go
@@ -1,0 +1,37 @@
+// package ct contains wrappers and interfaces around testing.T
+//
+// The intention is that _all_ complement functions deal with these wrapper interfaces
+// rather than the literal testing.T. This enables Complement to be run in environments
+// that aren't strictly via `go test`.
+package ct
+
+// TestLike is an interface that testing.T satisfies. All client functions accept a TestLike interface,
+// with the intention of a `testing.T` being passed into them. However, the client may be used in non-test
+// scenarios e.g benchmarks, which can then use the same client by just implementing this interface.
+type TestLike interface {
+	Helper()
+	Logf(msg string, args ...interface{})
+	Skipf(msg string, args ...interface{})
+	Error(args ...interface{})
+	Errorf(msg string, args ...interface{})
+	Fatalf(msg string, args ...interface{})
+	Failed() bool
+	Name() string
+}
+
+const ansiRedForeground = "\x1b[31m"
+const ansiResetForeground = "\x1b[39m"
+
+// Errorf is a wrapper around t.Errorf which prints the failing error message in red.
+func Errorf(t TestLike, format string, args ...any) {
+	t.Helper()
+	format = ansiRedForeground + format + ansiResetForeground
+	t.Errorf(format, args...)
+}
+
+// Fatalf is a wrapper around t.Fatalf which prints the failing error message in red.
+func Fatalf(t TestLike, format string, args ...any) {
+	t.Helper()
+	format = ansiRedForeground + format + ansiResetForeground
+	t.Fatalf(format, args...)
+}

--- a/federation/server.go
+++ b/federation/server.go
@@ -19,7 +19,6 @@ import (
 	"os"
 	"path"
 	"sync"
-	"testing"
 	"time"
 
 	"github.com/matrix-org/gomatrix"
@@ -31,6 +30,7 @@ import (
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/util"
 
+	"github.com/matrix-org/complement/ct"
 	"github.com/matrix-org/complement/internal/config"
 )
 
@@ -43,7 +43,7 @@ type FederationDeployment interface {
 // EXPERIMENTAL
 // Server represents a federation server
 type Server struct {
-	t *testing.T
+	t ct.TestLike
 
 	// Default: true
 	UnexpectedRequestsAreErrors bool
@@ -66,11 +66,11 @@ type Server struct {
 
 // EXPERIMENTAL
 // NewServer creates a new federation server with configured options.
-func NewServer(t *testing.T, deployment FederationDeployment, opts ...func(*Server)) *Server {
+func NewServer(t ct.TestLike, deployment FederationDeployment, opts ...func(*Server)) *Server {
 	// generate signing key
 	pub, priv, err := ed25519.GenerateKey(nil)
 	if err != nil {
-		t.Fatalf("federation.NewServer failed to generate ed25519 key: %s", err)
+		ct.Fatalf(t, "federation.NewServer failed to generate ed25519 key: %s", err)
 	}
 
 	srv := &Server{
@@ -113,7 +113,7 @@ func NewServer(t *testing.T, deployment FederationDeployment, opts ...func(*Serv
 	srv.mux.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		if srv.UnexpectedRequestsAreErrors {
 			body, _ := ioutil.ReadAll(req.Body)
-			t.Errorf("Server.UnexpectedRequestsAreErrors=true received unexpected request to server: %s %s\n%s", req.Method, req.URL.Path, string(body))
+			ct.Errorf(t, "Server.UnexpectedRequestsAreErrors=true received unexpected request to server: %s %s\n%s", req.Method, req.URL.Path, string(body))
 		} else {
 			t.Logf("Server.UnexpectedRequestsAreErrors=false received unexpected request to server: %s %s - sending 404 which may cause the HS to backoff from Complement", req.Method, req.URL.Path)
 		}
@@ -124,7 +124,7 @@ func NewServer(t *testing.T, deployment FederationDeployment, opts ...func(*Serv
 	// generate certs and an http.Server
 	httpServer, certPath, keyPath, err := federationServer(deployment.GetConfig(), srv.mux)
 	if err != nil {
-		t.Fatalf("complement: unable to create federation server and certificates: %s", err.Error())
+		ct.Fatalf(t, "complement: unable to create federation server and certificates: %s", err.Error())
 	}
 	srv.certPath = certPath
 	srv.keyPath = keyPath
@@ -144,7 +144,7 @@ func NewServer(t *testing.T, deployment FederationDeployment, opts ...func(*Serv
 // retrofitted into the server name so containers know how to route to it.
 func (s *Server) ServerName() string {
 	if !s.listening {
-		s.t.Fatalf("ServerName() called before Listen() - this is not supported because Listen() chooses a high-numbered port and thus changes the server name. Ensure you Listen() first!")
+		ct.Fatalf(s.t, "ServerName() called before Listen() - this is not supported because Listen() chooses a high-numbered port and thus changes the server name. Ensure you Listen() first!")
 	}
 	return s.serverName
 }
@@ -152,7 +152,7 @@ func (s *Server) ServerName() string {
 // UserID returns the complete user ID for the given localpart
 func (s *Server) UserID(localpart string) string {
 	if !s.listening {
-		s.t.Fatalf("UserID() called before Listen() - this is not supported because Listen() chooses a high-numbered port and thus changes the server name and thus changes the user ID. Ensure you Listen() first!")
+		ct.Fatalf(s.t, "UserID() called before Listen() - this is not supported because Listen() chooses a high-numbered port and thus changes the server name and thus changes the user ID. Ensure you Listen() first!")
 	}
 	return fmt.Sprintf("@%s:%s", localpart, s.serverName)
 }
@@ -162,7 +162,7 @@ func (s *Server) UserID(localpart string) string {
 // handle alias requests over federation.
 func (s *Server) MakeAliasMapping(aliasLocalpart, roomID string) string {
 	if !s.listening {
-		s.t.Fatalf("MakeAliasMapping() called before Listen() - this is not supported because Listen() chooses a high-numbered port and thus changes the server name and thus changes the room alias. Ensure you Listen() first!")
+		ct.Fatalf(s.t, "MakeAliasMapping() called before Listen() - this is not supported because Listen() chooses a high-numbered port and thus changes the server name and thus changes the room alias. Ensure you Listen() first!")
 	}
 	alias := fmt.Sprintf("#%s:%s", aliasLocalpart, s.serverName)
 	s.aliases[alias] = roomID
@@ -172,9 +172,9 @@ func (s *Server) MakeAliasMapping(aliasLocalpart, roomID string) string {
 
 // MustMakeRoom will add a room to this server so it is accessible to other servers when prompted via federation.
 // The `events` will be added to this room. Returns the created room.
-func (s *Server) MustMakeRoom(t *testing.T, roomVer gomatrixserverlib.RoomVersion, events []Event) *ServerRoom {
+func (s *Server) MustMakeRoom(t ct.TestLike, roomVer gomatrixserverlib.RoomVersion, events []Event) *ServerRoom {
 	if !s.listening {
-		s.t.Fatalf("MustMakeRoom() called before Listen() - this is not supported because Listen() chooses a high-numbered port and thus changes the server name and thus changes the room ID. Ensure you Listen() first!")
+		ct.Fatalf(s.t, "MustMakeRoom() called before Listen() - this is not supported because Listen() chooses a high-numbered port and thus changes the server name and thus changes the room ID. Ensure you Listen() first!")
 	}
 	// Generate a unique room ID, prefixed with an incrementing counter.
 	// This ensures that room IDs are not re-used across tests, even if a Complement server happens
@@ -199,7 +199,7 @@ func (s *Server) MustMakeRoom(t *testing.T, roomVer gomatrixserverlib.RoomVersio
 // The requests will be routed according to the deployment map in `deployment`, which satisfies the RoundTripper interface.
 func (s *Server) FederationClient(deployment FederationDeployment) fclient.FederationClient {
 	if !s.listening {
-		s.t.Fatalf("FederationClient() called before Listen() - this is not supported because Listen() chooses a high-numbered port and thus changes the server name and thus changes the way federation requests are signed. Ensure you Listen() first!")
+		ct.Fatalf(s.t, "FederationClient() called before Listen() - this is not supported because Listen() chooses a high-numbered port and thus changes the server name and thus changes the way federation requests are signed. Ensure you Listen() first!")
 	}
 	identity := fclient.SigningIdentity{
 		ServerName: spec.ServerName(s.ServerName()),
@@ -215,7 +215,7 @@ func (s *Server) FederationClient(deployment FederationDeployment) fclient.Feder
 
 // MustSendTransaction sends the given PDUs/EDUs to the target destination, returning an error if the /send fails or if the response contains an error
 // for any sent PDUs. Times out after 10 seconds.
-func (s *Server) MustSendTransaction(t *testing.T, deployment FederationDeployment, destination string, pdus []json.RawMessage, edus []gomatrixserverlib.EDU) {
+func (s *Server) MustSendTransaction(t ct.TestLike, deployment FederationDeployment, destination string, pdus []json.RawMessage, edus []gomatrixserverlib.EDU) {
 	t.Helper()
 	cli := s.FederationClient(deployment)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
@@ -228,11 +228,11 @@ func (s *Server) MustSendTransaction(t *testing.T, deployment FederationDeployme
 		EDUs:          edus,
 	})
 	if err != nil {
-		t.Fatalf("MustSendTransaction: %s", err)
+		ct.Fatalf(t, "MustSendTransaction: %s", err)
 	}
 	for eventID, e := range resp.PDUs {
 		if e.Error != "" {
-			t.Fatalf("MustSendTransaction: response for %s contained error: %s", eventID, e.Error)
+			ct.Fatalf(t, "MustSendTransaction: response for %s contained error: %s", eventID, e.Error)
 		}
 	}
 }
@@ -242,7 +242,7 @@ func (s *Server) MustSendTransaction(t *testing.T, deployment FederationDeployme
 // The requests will be routed according to the deployment map in `deployment`.
 func (s *Server) SendFederationRequest(
 	ctx context.Context,
-	t *testing.T,
+	t ct.TestLike,
 	deployment FederationDeployment,
 	req fclient.FederationRequest,
 	resBody interface{},
@@ -273,7 +273,7 @@ func (s *Server) SendFederationRequest(
 // The requests will be routed according to the deployment map in `deployment`.
 func (s *Server) DoFederationRequest(
 	ctx context.Context,
-	t *testing.T,
+	t ct.TestLike,
 	deployment FederationDeployment,
 	req fclient.FederationRequest) (*http.Response, error) {
 	if err := req.Sign(spec.ServerName(s.serverName), s.KeyID, s.Priv); err != nil {
@@ -301,17 +301,17 @@ func (s *Server) DoFederationRequest(
 
 // MustCreateEvent will create and sign a new latest event for the given room.
 // It does not insert this event into the room however. See ServerRoom.AddEvent for that.
-func (s *Server) MustCreateEvent(t *testing.T, room *ServerRoom, ev Event) gomatrixserverlib.PDU {
+func (s *Server) MustCreateEvent(t ct.TestLike, room *ServerRoom, ev Event) gomatrixserverlib.PDU {
 	t.Helper()
 	content, err := json.Marshal(ev.Content)
 	if err != nil {
-		t.Fatalf("MustCreateEvent: failed to marshal event content %s - %+v", err, ev.Content)
+		ct.Fatalf(t, "MustCreateEvent: failed to marshal event content %s - %+v", err, ev.Content)
 	}
 	var unsigned []byte
 	if ev.Unsigned != nil {
 		unsigned, err = json.Marshal(ev.Unsigned)
 		if err != nil {
-			t.Fatalf("MustCreateEvent: failed to marshal event unsigned: %s - %+v", err, ev.Unsigned)
+			ct.Fatalf(t, "MustCreateEvent: failed to marshal event unsigned: %s - %+v", err, ev.Unsigned)
 		}
 	}
 
@@ -341,36 +341,36 @@ func (s *Server) MustCreateEvent(t *testing.T, room *ServerRoom, ev Event) gomat
 		var stateNeeded gomatrixserverlib.StateNeeded
 		stateNeeded, err = gomatrixserverlib.StateNeededForProtoEvent(&proto)
 		if err != nil {
-			t.Fatalf("MustCreateEvent: failed to work out auth_events : %s", err)
+			ct.Fatalf(t, "MustCreateEvent: failed to work out auth_events : %s", err)
 		}
 		proto.AuthEvents = room.AuthEvents(stateNeeded)
 	}
 	verImpl, err := gomatrixserverlib.GetRoomVersion(room.Version)
 	if err != nil {
-		t.Fatalf("MustCreateEvent: invalid room version: %s", err)
+		ct.Fatalf(t, "MustCreateEvent: invalid room version: %s", err)
 	}
 	eb := verImpl.NewEventBuilderFromProtoEvent(&proto)
 	signedEvent, err := eb.Build(time.Now(), spec.ServerName(s.serverName), s.KeyID, s.Priv)
 	if err != nil {
-		t.Fatalf("MustCreateEvent: failed to sign event: %s", err)
+		ct.Fatalf(t, "MustCreateEvent: failed to sign event: %s", err)
 	}
 	return signedEvent
 }
 
 // MustJoinRoom will make the server send a make_join and a send_join to join a room
 // It returns the resultant room.
-func (s *Server) MustJoinRoom(t *testing.T, deployment FederationDeployment, remoteServer spec.ServerName, roomID string, userID string, partialState ...bool) *ServerRoom {
+func (s *Server) MustJoinRoom(t ct.TestLike, deployment FederationDeployment, remoteServer spec.ServerName, roomID string, userID string, partialState ...bool) *ServerRoom {
 	t.Helper()
 	origin := spec.ServerName(s.serverName)
 	fedClient := s.FederationClient(deployment)
 	makeJoinResp, err := fedClient.MakeJoin(context.Background(), origin, remoteServer, roomID, userID)
 	if err != nil {
-		t.Fatalf("MustJoinRoom: make_join failed: %v", err)
+		ct.Fatalf(t, "MustJoinRoom: make_join failed: %v", err)
 	}
 	roomVer := makeJoinResp.RoomVersion
 	verImpl, err := gomatrixserverlib.GetRoomVersion(makeJoinResp.RoomVersion)
 	if err != nil {
-		t.Fatalf("MustJoinRoom: invalid room version: %v", err)
+		ct.Fatalf(t, "MustJoinRoom: invalid room version: %v", err)
 	}
 
 	var senderID spec.SenderID
@@ -381,7 +381,7 @@ func (s *Server) MustJoinRoom(t *testing.T, deployment FederationDeployment, rem
 	case gomatrixserverlib.RoomVersionPseudoIDs:
 		_, key, err := ed25519.GenerateKey(nil)
 		if err != nil {
-			t.Fatalf("MustJoinRoom: failed generating senderID: %v", err)
+			ct.Fatalf(t, "MustJoinRoom: failed generating senderID: %v", err)
 		}
 		senderID, signingKey, err = spec.SenderIDFromPseudoIDKey(key), key, nil
 		keyID = "ed25519:1"
@@ -391,13 +391,13 @@ func (s *Server) MustJoinRoom(t *testing.T, deployment FederationDeployment, rem
 			UserID:      userID,
 		}
 		if err = mapping.Sign(origOrigin, s.KeyID, s.Priv); err != nil {
-			t.Fatalf("MustJoinRoom: failed signing mxid_mapping: %v", err)
+			ct.Fatalf(t, "MustJoinRoom: failed signing mxid_mapping: %v", err)
 		}
 
 		path := "mxid_mapping"
 		eventJSON, err := sjson.SetBytes(makeJoinResp.JoinEvent.Content, path, mapping)
 		if err != nil {
-			t.Fatalf("MustJoinRoom: failed setting mxid_mapping in content: %v", err)
+			ct.Fatalf(t, "MustJoinRoom: failed setting mxid_mapping in content: %v", err)
 		}
 		eventJSON = gomatrixserverlib.CanonicalJSONAssumeValid(eventJSON)
 		makeJoinResp.JoinEvent.Content = eventJSON
@@ -412,7 +412,7 @@ func (s *Server) MustJoinRoom(t *testing.T, deployment FederationDeployment, rem
 	eb := verImpl.NewEventBuilderFromProtoEvent(&makeJoinResp.JoinEvent)
 	joinEvent, err := eb.Build(time.Now(), origin, keyID, signingKey)
 	if err != nil {
-		t.Fatalf("MustJoinRoom: failed to sign event: %v", err)
+		ct.Fatalf(t, "MustJoinRoom: failed to sign event: %v", err)
 	}
 	var sendJoinResp fclient.RespSendJoin
 	if len(partialState) == 0 || !partialState[0] {
@@ -422,7 +422,7 @@ func (s *Server) MustJoinRoom(t *testing.T, deployment FederationDeployment, rem
 		sendJoinResp, err = fedClient.SendJoinPartialState(context.Background(), origOrigin, remoteServer, joinEvent)
 	}
 	if err != nil {
-		t.Fatalf("MustJoinRoom: send_join failed: %v", err)
+		ct.Fatalf(t, "MustJoinRoom: send_join failed: %v", err)
 	}
 	stateEvents := sendJoinResp.StateEvents.UntrustedEvents(roomVer)
 	room := newRoom(roomVer, roomID)
@@ -438,7 +438,7 @@ func (s *Server) MustJoinRoom(t *testing.T, deployment FederationDeployment, rem
 }
 
 // Leaves a room. If this is rejecting an invite then a make_leave request is made first, before send_leave.
-func (s *Server) MustLeaveRoom(t *testing.T, deployment FederationDeployment, remoteServer spec.ServerName, roomID string, userID string) {
+func (s *Server) MustLeaveRoom(t ct.TestLike, deployment FederationDeployment, remoteServer spec.ServerName, roomID string, userID string) {
 	t.Helper()
 	origin := spec.ServerName(s.serverName)
 	fedClient := s.FederationClient(deployment)
@@ -448,16 +448,16 @@ func (s *Server) MustLeaveRoom(t *testing.T, deployment FederationDeployment, re
 		// e.g rejecting an invite
 		makeLeaveResp, err := fedClient.MakeLeave(context.Background(), origin, remoteServer, roomID, userID)
 		if err != nil {
-			t.Fatalf("MustLeaveRoom: (rejecting invite) make_leave failed: %v", err)
+			ct.Fatalf(t, "MustLeaveRoom: (rejecting invite) make_leave failed: %v", err)
 		}
 		verImpl, err := gomatrixserverlib.GetRoomVersion(makeLeaveResp.RoomVersion)
 		if err != nil {
-			t.Fatalf("MustLeaveRoom: invalid room version: %v", err)
+			ct.Fatalf(t, "MustLeaveRoom: invalid room version: %v", err)
 		}
 		eb := verImpl.NewEventBuilderFromProtoEvent(&makeLeaveResp.LeaveEvent)
 		leaveEvent, err = eb.Build(time.Now(), origin, s.KeyID, s.Priv)
 		if err != nil {
-			t.Fatalf("MustLeaveRoom: (rejecting invite) failed to sign event: %v", err)
+			ct.Fatalf(t, "MustLeaveRoom: (rejecting invite) failed to sign event: %v", err)
 		}
 	} else {
 		// make the leave event
@@ -472,7 +472,7 @@ func (s *Server) MustLeaveRoom(t *testing.T, deployment FederationDeployment, re
 	}
 	err := fedClient.SendLeave(context.Background(), origin, remoteServer, leaveEvent)
 	if err != nil {
-		t.Fatalf("MustLeaveRoom: send_leave failed: %v", err)
+		ct.Fatalf(t, "MustLeaveRoom: send_leave failed: %v", err)
 	}
 	room.AddEvent(leaveEvent)
 	s.rooms[roomID] = room
@@ -482,14 +482,14 @@ func (s *Server) MustLeaveRoom(t *testing.T, deployment FederationDeployment, re
 
 // ValidFederationRequest is a wrapper around http.HandlerFunc which automatically validates the incoming
 // federation request and supports sending back JSON. Fails the test if the request is not valid.
-func (s *Server) ValidFederationRequest(t *testing.T, handler func(fr *fclient.FederationRequest, pathParams map[string]string) util.JSONResponse) http.HandlerFunc {
+func (s *Server) ValidFederationRequest(t ct.TestLike, handler func(fr *fclient.FederationRequest, pathParams map[string]string) util.JSONResponse) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		// Check federation signature
 		fedReq, errResp := fclient.VerifyHTTPRequest(
 			req, time.Now(), spec.ServerName(s.serverName), nil, s.keyRing,
 		)
 		if fedReq == nil {
-			t.Errorf(
+			ct.Errorf(t,
 				"complement: ValidFederationRequest: HTTP Code %d. Invalid http request: %s",
 				errResp.Code, errResp.JSON,
 			)
@@ -529,7 +529,7 @@ func (s *Server) Listen() (cancel func()) {
 
 	ln, err := net.Listen("tcp", ":0") //nolint
 	if err != nil {
-		s.t.Fatalf("ListenFederationServer: net.Listen failed: %s", err)
+		ct.Fatalf(s.t, "ListenFederationServer: net.Listen failed: %s", err)
 	}
 	port := ln.Addr().(*net.TCPAddr).Port
 	s.serverName += fmt.Sprintf(":%d", port)
@@ -549,7 +549,7 @@ func (s *Server) Listen() (cancel func()) {
 	return func() {
 		err := s.srv.Close()
 		if err != nil {
-			s.t.Fatalf("ListenFederationServer: failed to shutdown server: %s", err)
+			ct.Fatalf(s.t, "ListenFederationServer: failed to shutdown server: %s", err)
 		}
 		wg.Wait() // wait for the server to shutdown
 	}

--- a/federation/server_room.go
+++ b/federation/server_room.go
@@ -4,11 +4,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"sync"
-	"testing"
 
 	"github.com/matrix-org/gomatrixserverlib"
 
 	"github.com/matrix-org/complement/b"
+	"github.com/matrix-org/complement/ct"
 )
 
 type Event struct {
@@ -172,18 +172,18 @@ func (r *ServerRoom) AuthChainForEvents(events []gomatrixserverlib.PDU) (chain [
 }
 
 // Check that the user currently has the membership provided in this room. Fails the test if not.
-func (r *ServerRoom) MustHaveMembershipForUser(t *testing.T, userID, wantMembership string) {
+func (r *ServerRoom) MustHaveMembershipForUser(t ct.TestLike, userID, wantMembership string) {
 	t.Helper()
 	state := r.CurrentState("m.room.member", userID)
 	if state == nil {
-		t.Fatalf("no membership state for %s", userID)
+		ct.Fatalf(t, "no membership state for %s", userID)
 	}
 	m, err := state.Membership()
 	if err != nil {
-		t.Fatalf("m.room.member event exists for %s but cannot read membership field: %s", userID, err)
+		ct.Fatalf(t, "m.room.member event exists for %s but cannot read membership field: %s", userID, err)
 	}
 	if m != wantMembership {
-		t.Fatalf("incorrect membership state for %s: got %s, want %s", userID, m, wantMembership)
+		ct.Fatalf(t, "incorrect membership state for %s: got %s, want %s", userID, m, wantMembership)
 	}
 }
 

--- a/helpers/waiter.go
+++ b/helpers/waiter.go
@@ -3,8 +3,9 @@ package helpers
 import (
 	"fmt"
 	"sync"
-	"testing"
 	"time"
+
+	"github.com/matrix-org/complement/ct"
 )
 
 // Waiter is a simple primitive to wait for a signal asynchronously. It is preferred
@@ -28,21 +29,21 @@ func NewWaiter() *Waiter {
 
 // Wait blocks until Finish() is called or until the timeout is reached.
 // If the timeout is reached, the test is failed.
-func (w *Waiter) Wait(t *testing.T, timeout time.Duration) {
+func (w *Waiter) Wait(t ct.TestLike, timeout time.Duration) {
 	t.Helper()
 	w.Waitf(t, timeout, "Wait")
 }
 
 // Waitf blocks until Finish() is called or until the timeout is reached.
 // If the timeout is reached, the test is failed with the given error message.
-func (w *Waiter) Waitf(t *testing.T, timeout time.Duration, errFormat string, args ...interface{}) {
+func (w *Waiter) Waitf(t ct.TestLike, timeout time.Duration, errFormat string, args ...interface{}) {
 	t.Helper()
 	select {
 	case <-w.ch:
 		return
 	case <-time.After(timeout):
 		errmsg := fmt.Sprintf(errFormat, args...)
-		t.Fatalf("%s: timed out after %f seconds.", errmsg, timeout.Seconds())
+		ct.Fatalf(t, "%s: timed out after %f seconds.", errmsg, timeout.Seconds())
 	}
 }
 

--- a/must/must.go
+++ b/must/must.go
@@ -7,12 +7,12 @@ import (
 	"io"
 	"net/http"
 	"strings"
-	"testing"
 
 	"github.com/tidwall/gjson"
 
 	"github.com/matrix-org/gomatrixserverlib/fclient"
 
+	"github.com/matrix-org/complement/ct"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/should"
 )
@@ -20,175 +20,161 @@ import (
 const ansiRedForeground = "\x1b[31m"
 const ansiResetForeground = "\x1b[39m"
 
-// errorf is a wrapper around t.Errorf which prints the failing error message in red.
-func errorf(t *testing.T, format string, args ...any) {
-	t.Helper()
-	format = ansiRedForeground + format + ansiResetForeground
-	t.Errorf(format, args...)
-}
-
-// fatalf is a wrapper around t.Fatalf which prints the failing error message in red.
-func fatalf(t *testing.T, format string, args ...any) {
-	t.Helper()
-	format = ansiRedForeground + format + ansiResetForeground
-	t.Fatalf(format, args...)
-}
-
 // NotError will ensure `err` is nil else terminate the test with `msg`.
-func NotError(t *testing.T, msg string, err error) {
+func NotError(t ct.TestLike, msg string, err error) {
 	t.Helper()
 	if err != nil {
-		fatalf(t, "must.NotError: %s -> %s", msg, err)
+		ct.Fatalf(t, "must.NotError: %s -> %s", msg, err)
 	}
 }
 
 // EXPERIMENTAL
 // ParseJSON will ensure that the HTTP request/response body is valid JSON, then return the body, else terminate the test.
-func ParseJSON(t *testing.T, b io.ReadCloser) gjson.Result {
+func ParseJSON(t ct.TestLike, b io.ReadCloser) gjson.Result {
 	t.Helper()
 	res, err := should.ParseJSON(b)
 	if err != nil {
-		fatalf(t, err.Error())
+		ct.Fatalf(t, err.Error())
 	}
 	return res
 }
 
 // EXPERIMENTAL
 // MatchRequest consumes the HTTP request and performs HTTP-level assertions on it. Returns the raw response body.
-func MatchRequest(t *testing.T, req *http.Request, m match.HTTPRequest) []byte {
+func MatchRequest(t ct.TestLike, req *http.Request, m match.HTTPRequest) []byte {
 	t.Helper()
 	res, err := should.MatchRequest(req, m)
 	if err != nil {
-		fatalf(t, err.Error())
+		ct.Fatalf(t, err.Error())
 	}
 	return res
 }
 
 // EXPERIMENTAL
 // MatchSuccess consumes the HTTP response and fails if the response is non-2xx.
-func MatchSuccess(t *testing.T, res *http.Response) {
+func MatchSuccess(t ct.TestLike, res *http.Response) {
 	t.Helper()
 	if err := should.MatchSuccess(res); err != nil {
-		fatalf(t, err.Error())
+		ct.Fatalf(t, err.Error())
 	}
 }
 
 // EXPERIMENTAL
 // MatchFailure consumes the HTTP response and fails if the response is 2xx.
-func MatchFailure(t *testing.T, res *http.Response) {
+func MatchFailure(t ct.TestLike, res *http.Response) {
 	t.Helper()
 	if err := should.MatchFailure(res); err != nil {
-		fatalf(t, err.Error())
+		ct.Fatalf(t, err.Error())
 	}
 }
 
 // EXPERIMENTAL
 // MatchResponse consumes the HTTP response and performs HTTP-level assertions on it. Returns the raw response body.
-func MatchResponse(t *testing.T, res *http.Response, m match.HTTPResponse) []byte {
+func MatchResponse(t ct.TestLike, res *http.Response, m match.HTTPResponse) []byte {
 	t.Helper()
 	body, err := should.MatchResponse(res, m)
 	if err != nil {
-		fatalf(t, err.Error())
+		ct.Fatalf(t, err.Error())
 	}
 	return body
 }
 
 // MatchFederationRequest performs JSON assertions on incoming federation requests.
-func MatchFederationRequest(t *testing.T, fedReq *fclient.FederationRequest, matchers ...match.JSON) {
+func MatchFederationRequest(t ct.TestLike, fedReq *fclient.FederationRequest, matchers ...match.JSON) {
 	t.Helper()
 	err := should.MatchFederationRequest(fedReq)
 	if err != nil {
-		fatalf(t, err.Error())
+		ct.Fatalf(t, err.Error())
 	}
 }
 
 // EXPERIMENTAL
 // MatchGJSON performs JSON assertions on a gjson.Result object.
-func MatchGJSON(t *testing.T, jsonResult gjson.Result, matchers ...match.JSON) {
+func MatchGJSON(t ct.TestLike, jsonResult gjson.Result, matchers ...match.JSON) {
 	t.Helper()
 	err := should.MatchGJSON(jsonResult, matchers...)
 	if err != nil {
-		fatalf(t, err.Error())
+		ct.Fatalf(t, err.Error())
 	}
 }
 
 // EXPERIMENTAL
 // MatchJSONBytes performs JSON assertions on a raw json byte slice.
-func MatchJSONBytes(t *testing.T, rawJson []byte, matchers ...match.JSON) {
+func MatchJSONBytes(t ct.TestLike, rawJson []byte, matchers ...match.JSON) {
 	t.Helper()
 	err := should.MatchJSONBytes(rawJson, matchers...)
 	if err != nil {
-		fatalf(t, err.Error())
+		ct.Fatalf(t, err.Error())
 	}
 }
 
 // Equal ensures that got==want else logs an error.
 // The 'msg' is displayed with the error to provide extra context.
-func Equal[V comparable](t *testing.T, got, want V, msg string) {
+func Equal[V comparable](t ct.TestLike, got, want V, msg string) {
 	t.Helper()
 	if got != want {
-		errorf(t, "Equal %s: got '%v' want '%v'", msg, got, want)
+		ct.Errorf(t, "Equal %s: got '%v' want '%v'", msg, got, want)
 	}
 }
 
 // NotEqual ensures that got!=want else logs an error.
 // The 'msg' is displayed with the error to provide extra context.
-func NotEqual[V comparable](t *testing.T, got, want V, msg string) {
+func NotEqual[V comparable](t ct.TestLike, got, want V, msg string) {
 	t.Helper()
 	if got == want {
-		errorf(t, "NotEqual %s: got '%v', want '%v'", msg, got, want)
+		ct.Errorf(t, "NotEqual %s: got '%v', want '%v'", msg, got, want)
 	}
 }
 
 // EXPERIMENTAL
 // StartWithStr ensures that got starts with wantPrefix else logs an error.
-func StartWithStr(t *testing.T, got, wantPrefix, msg string) {
+func StartWithStr(t ct.TestLike, got, wantPrefix, msg string) {
 	t.Helper()
 	if !strings.HasPrefix(got, wantPrefix) {
-		errorf(t, "StartWithStr: %s: got '%s' without prefix '%s'", msg, got, wantPrefix)
+		ct.Errorf(t, "StartWithStr: %s: got '%s' without prefix '%s'", msg, got, wantPrefix)
 	}
 }
 
 // GetJSONFieldStr extracts the string value under `wantKey` or fails the test.
 // The format of `wantKey` is specified at https://godoc.org/github.com/tidwall/gjson#Get
-func GetJSONFieldStr(t *testing.T, body gjson.Result, wantKey string) string {
+func GetJSONFieldStr(t ct.TestLike, body gjson.Result, wantKey string) string {
 	t.Helper()
 	str, err := should.GetJSONFieldStr(body, wantKey)
 	if err != nil {
-		fatalf(t, err.Error())
+		ct.Fatalf(t, err.Error())
 	}
 	return str
 }
 
 // EXPERIMENTAL
 // HaveInOrder checks that the two slices match exactly, failing the test on mismatches or omissions.
-func HaveInOrder[V comparable](t *testing.T, gots []V, wants []V) {
+func HaveInOrder[V comparable](t ct.TestLike, gots []V, wants []V) {
 	t.Helper()
 	err := should.HaveInOrder(gots, wants)
 	if err != nil {
-		fatalf(t, err.Error())
+		ct.Fatalf(t, err.Error())
 	}
 }
 
 // EXPERIMENTAL
 // ContainSubset checks that every item in smaller is in larger, failing the test if at least 1 item isn't. Ignores extra elements
 // in larger. Ignores ordering.
-func ContainSubset[V comparable](t *testing.T, larger []V, smaller []V) {
+func ContainSubset[V comparable](t ct.TestLike, larger []V, smaller []V) {
 	t.Helper()
 	err := should.ContainSubset(larger, smaller)
 	if err != nil {
-		fatalf(t, err.Error())
+		ct.Fatalf(t, err.Error())
 	}
 }
 
 // EXPERIMENTAL
 // NotContainSubset checks that every item in smaller is NOT in larger, failing the test if at least 1 item is. Ignores extra elements
 // in larger. Ignores ordering.
-func NotContainSubset[V comparable](t *testing.T, larger []V, smaller []V) {
+func NotContainSubset[V comparable](t ct.TestLike, larger []V, smaller []V) {
 	t.Helper()
 	err := should.NotContainSubset(larger, smaller)
 	if err != nil {
-		fatalf(t, err.Error())
+		ct.Fatalf(t, err.Error())
 	}
 }
 
@@ -198,11 +184,11 @@ func NotContainSubset[V comparable](t *testing.T, larger []V, smaller []V) {
 // if an item is not present, the test is failed.
 // if an item not present in the want list is present, the test is failed.
 // Items are compared using match.JSONDeepEqual
-func CheckOffAll(t *testing.T, items []interface{}, wantItems []interface{}) {
+func CheckOffAll(t ct.TestLike, items []interface{}, wantItems []interface{}) {
 	t.Helper()
 	err := should.CheckOffAll(items, wantItems)
 	if err != nil {
-		fatalf(t, err.Error())
+		ct.Fatalf(t, err.Error())
 	}
 }
 
@@ -212,11 +198,11 @@ func CheckOffAll(t *testing.T, items []interface{}, wantItems []interface{}) {
 //
 // if an item is not present, the test is failed.
 // Items are compared using match.JSONDeepEqual
-func CheckOffAllAllowUnwanted(t *testing.T, items []interface{}, wantItems []interface{}) []interface{} {
+func CheckOffAllAllowUnwanted(t ct.TestLike, items []interface{}, wantItems []interface{}) []interface{} {
 	t.Helper()
 	result, err := should.CheckOffAllAllowUnwanted(items, wantItems)
 	if err != nil {
-		fatalf(t, err.Error())
+		ct.Fatalf(t, err.Error())
 	}
 	return result
 }
@@ -225,11 +211,11 @@ func CheckOffAllAllowUnwanted(t *testing.T, items []interface{}, wantItems []int
 // CheckOff an item from the list. If the item is not present the test is failed.
 // The updated list with the matched item removed from it is returned. Items are
 // compared using JSON deep equal.
-func CheckOff(t *testing.T, items []interface{}, wantItem interface{}) []interface{} {
+func CheckOff(t ct.TestLike, items []interface{}, wantItem interface{}) []interface{} {
 	t.Helper()
 	result, err := should.CheckOff(items, wantItem)
 	if err != nil {
-		fatalf(t, err.Error())
+		ct.Fatalf(t, err.Error())
 	}
 	return result
 }

--- a/runtime/hs.go
+++ b/runtime/hs.go
@@ -2,9 +2,9 @@ package runtime
 
 import (
 	"context"
-	"testing"
 
 	"github.com/docker/docker/client"
+	"github.com/matrix-org/complement/ct"
 )
 
 const (
@@ -32,7 +32,7 @@ var ContainerKillFunc = func(client *client.Client, containerID string) error {
 // implementation is added, a respective `hs_$name.go` needs to be created in this directory. This
 // file pairs together the tag name with a string constant declared in this package
 // e.g. dendrite_blacklist == runtime.Dendrite
-func SkipIf(t *testing.T, hses ...string) {
+func SkipIf(t ct.TestLike, hses ...string) {
 	t.Helper()
 	for _, hs := range hses {
 		if Homeserver == hs {

--- a/test_main.go
+++ b/test_main.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/matrix-org/complement/b"
+	"github.com/matrix-org/complement/ct"
 )
 
 var testPackage *TestPackage
@@ -44,10 +45,10 @@ func TestMainWithCleanup(m *testing.M, namespace string, cleanup func()) {
 // It will construct the blueprint if it doesn't already exist in the docker image cache.
 // This function is the main setup function for all tests as it provides a deployment with
 // which tests can interact with.
-func OldDeploy(t *testing.T, blueprint b.Blueprint) Deployment {
+func OldDeploy(t ct.TestLike, blueprint b.Blueprint) Deployment {
 	t.Helper()
 	if testPackage == nil {
-		t.Fatalf("Deploy: testPackage not set, did you forget to call complement.TestMain?")
+		ct.Fatalf(t, "Deploy: testPackage not set, did you forget to call complement.TestMain?")
 	}
 	return testPackage.OldDeploy(t, blueprint)
 }
@@ -55,10 +56,10 @@ func OldDeploy(t *testing.T, blueprint b.Blueprint) Deployment {
 // Deploy will deploy the given number of servers or terminate the test.
 // This function is the main setup function for all tests as it provides a deployment with
 // which tests can interact with.
-func Deploy(t *testing.T, numServers int) Deployment {
+func Deploy(t ct.TestLike, numServers int) Deployment {
 	t.Helper()
 	if testPackage == nil {
-		t.Fatalf("Deploy: testPackage not set, did you forget to call complement.TestMain?")
+		ct.Fatalf(t, "Deploy: testPackage not set, did you forget to call complement.TestMain?")
 	}
 	return testPackage.Deploy(t, numServers)
 }

--- a/test_package.go
+++ b/test_package.go
@@ -7,11 +7,11 @@ import (
 	"net/http"
 	"sync"
 	"sync/atomic"
-	"testing"
 	"time"
 
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/ct"
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/internal/config"
 	"github.com/matrix-org/complement/internal/docker"
@@ -21,41 +21,45 @@ import (
 // Deployment provides a way for tests to interact with a set of homeservers.
 type Deployment interface {
 	// UnauthenticatedClient returns a blank CSAPI client.
-	UnauthenticatedClient(t *testing.T, serverName string) *client.CSAPI
+	UnauthenticatedClient(t ct.TestLike, serverName string) *client.CSAPI
 	// Register a new user on the given server.
-	Register(t *testing.T, hsName string, opts helpers.RegistrationOpts) *client.CSAPI
+	Register(t ct.TestLike, hsName string, opts helpers.RegistrationOpts) *client.CSAPI
 	// Login to an existing user account on the given server. In order to make tests not hardcode full user IDs,
 	// an existing logged in client must be supplied.
-	Login(t *testing.T, hsName string, existing *client.CSAPI, opts helpers.LoginOpts) *client.CSAPI
+	Login(t ct.TestLike, hsName string, existing *client.CSAPI, opts helpers.LoginOpts) *client.CSAPI
 	// AppServiceUser returns a client for the given app service user ID. The HS in question must have an appservice
 	// hooked up to it already. TODO: REMOVE
-	AppServiceUser(t *testing.T, hsName, appServiceUserID string) *client.CSAPI
+	AppServiceUser(t ct.TestLike, hsName, appServiceUserID string) *client.CSAPI
 	// Restart a deployment. Restarts all homeservers in this deployment.
 	// This function is designed to be used to make assertions that servers are persisting information to disk.
-	Restart(t *testing.T) error
+	Restart(t ct.TestLike) error
 	// Stop the container running this HS. Fails the test if this is not possible.
 	// This function is designed to be used to make assertions when federated servers are unreachable.
 	// Do not use this function if you need the HS CSAPI URL to be stable, prefer PauseServer if you need this.
-	StopServer(t *testing.T, hsName string)
+	StopServer(t ct.TestLike, hsName string)
 	// Start the container running this HS. The HS must exist in this deployment already and it must be stopped already.
 	// Fails the test if this isn't true, or there was a problem.
 	// This function is designed to be used to start a server previously stopped via StopServer.
 	// Do not use this function if you need the HS CSAPI URL to be stable, prefer UnpauseServer if you need this.
-	StartServer(t *testing.T, hsName string)
+	StartServer(t ct.TestLike, hsName string)
 	// Pause a running homeserver. The HS will be suspended, preserving data in memory.
 	// Prefer this function over StopServer if you need to keep the port allocations stable across your test.
 	// This function is designed to be used to make assertions when federated servers are unreachable.
 	// Fails the test if there is a problem pausing.
 	// See https://docs.docker.com/engine/reference/commandline/pause/
-	PauseServer(t *testing.T, hsName string)
+	PauseServer(t ct.TestLike, hsName string)
 	// Unpause a running homeserver. The HS will be suspended, preserving data in memory.
 	// Fails the test if there is a problem unpausing.
 	// This function is designed to be used to make assertions when federated servers are unreachable.
 	// see https://docs.docker.com/engine/reference/commandline/unpause/
-	UnpauseServer(t *testing.T, hsName string)
+	UnpauseServer(t ct.TestLike, hsName string)
+	// ContainerID returns the container ID of the given HS. Fails the test if there is no container for the given
+	// HS name. This function is useful if you want to interact with the HS from the container runtime e.g to extract
+	// logs (docker logs), check memory consumption (docker stats),
+	ContainerID(t ct.TestLike, hsName string) string
 	// Destroy the entire deployment. Destroys all running containers. If `printServerLogs` is true,
 	// will print container logs before killing the container.
-	Destroy(t *testing.T)
+	Destroy(t ct.TestLike)
 	// Return the complement config current active for this deployment
 	GetConfig() *config.Complement
 	// Return an HTTP round tripper interface which can map HS names to the actual container:port
@@ -119,27 +123,27 @@ func (tp *TestPackage) Cleanup() {
 // It will construct the blueprint if it doesn't already exist in the docker image cache.
 // This function is the main setup function for all tests as it provides a deployment with
 // which tests can interact with.
-func (tp *TestPackage) OldDeploy(t *testing.T, blueprint b.Blueprint) Deployment {
+func (tp *TestPackage) OldDeploy(t ct.TestLike, blueprint b.Blueprint) Deployment {
 	t.Helper()
 	timeStartBlueprint := time.Now()
 	if err := tp.complementBuilder.ConstructBlueprintIfNotExist(blueprint); err != nil {
-		t.Fatalf("OldDeploy: Failed to construct blueprint: %s", err)
+		ct.Fatalf(t, "OldDeploy: Failed to construct blueprint: %s", err)
 	}
 	namespace := fmt.Sprintf("%d", atomic.AddUint64(&tp.namespaceCounter, 1))
 	d, err := docker.NewDeployer(namespace, tp.complementBuilder.Config)
 	if err != nil {
-		t.Fatalf("OldDeploy: NewDeployer returned error %s", err)
+		ct.Fatalf(t, "OldDeploy: NewDeployer returned error %s", err)
 	}
 	timeStartDeploy := time.Now()
 	dep, err := d.Deploy(context.Background(), blueprint.Name)
 	if err != nil {
-		t.Fatalf("OldDeploy: Deploy returned error %s", err)
+		ct.Fatalf(t, "OldDeploy: Deploy returned error %s", err)
 	}
 	t.Logf("OldDeploy times: %v blueprints, %v containers", timeStartDeploy.Sub(timeStartBlueprint), time.Since(timeStartDeploy))
 	return dep
 }
 
-func (tp *TestPackage) Deploy(t *testing.T, numServers int) Deployment {
+func (tp *TestPackage) Deploy(t ct.TestLike, numServers int) Deployment {
 	t.Helper()
 	if tp.Config.EnableDirtyRuns {
 		return tp.dirtyDeploy(t, numServers)
@@ -148,35 +152,35 @@ func (tp *TestPackage) Deploy(t *testing.T, numServers int) Deployment {
 	blueprint := mapServersToBlueprint(numServers)
 	timeStartBlueprint := time.Now()
 	if err := tp.complementBuilder.ConstructBlueprintIfNotExist(blueprint); err != nil {
-		t.Fatalf("Deploy: Failed to construct blueprint: %s", err)
+		ct.Fatalf(t, "Deploy: Failed to construct blueprint: %s", err)
 	}
 	namespace := fmt.Sprintf("%d", atomic.AddUint64(&tp.namespaceCounter, 1))
 	d, err := docker.NewDeployer(namespace, tp.complementBuilder.Config)
 	if err != nil {
-		t.Fatalf("Deploy: NewDeployer returned error %s", err)
+		ct.Fatalf(t, "Deploy: NewDeployer returned error %s", err)
 	}
 	timeStartDeploy := time.Now()
 	dep, err := d.Deploy(context.Background(), blueprint.Name)
 	if err != nil {
-		t.Fatalf("Deploy: Deploy returned error %s", err)
+		ct.Fatalf(t, "Deploy: Deploy returned error %s", err)
 	}
 	t.Logf("Deploy times: %v blueprints, %v containers", timeStartDeploy.Sub(timeStartBlueprint), time.Since(timeStartDeploy))
 	return dep
 }
 
-func (tp *TestPackage) dirtyDeploy(t *testing.T, numServers int) Deployment {
+func (tp *TestPackage) dirtyDeploy(t ct.TestLike, numServers int) Deployment {
 	tp.existingDeploymentMu.Lock()
 	defer tp.existingDeploymentMu.Unlock()
 	// do we even have a deployment?
 	if tp.existingDeployment == nil {
 		d, err := docker.NewDeployer("dirty", tp.complementBuilder.Config)
 		if err != nil {
-			t.Fatalf("dirtyDeploy: NewDeployer returned error %s", err)
+			ct.Fatalf(t, "dirtyDeploy: NewDeployer returned error %s", err)
 		}
 		// this creates a single hs1
 		tp.existingDeployment, err = d.CreateDirtyDeployment()
 		if err != nil {
-			t.Fatalf("CreateDirtyDeployment failed: %s", err)
+			ct.Fatalf(t, "CreateDirtyDeployment failed: %s", err)
 		}
 	}
 
@@ -188,7 +192,7 @@ func (tp *TestPackage) dirtyDeploy(t *testing.T, numServers int) Deployment {
 	// we need to scale up the dirty deployment to more servers
 	d, err := docker.NewDeployer("dirty", tp.complementBuilder.Config)
 	if err != nil {
-		t.Fatalf("dirtyDeploy: NewDeployer returned error %s", err)
+		ct.Fatalf(t, "dirtyDeploy: NewDeployer returned error %s", err)
 	}
 	for i := 1; i <= numServers; i++ {
 		hsName := fmt.Sprintf("hs%d", i)
@@ -199,7 +203,7 @@ func (tp *TestPackage) dirtyDeploy(t *testing.T, numServers int) Deployment {
 		// scale up
 		hsDep, err := d.CreateDirtyServer(hsName)
 		if err != nil {
-			t.Fatalf("dirtyDeploy: failed to add %s: %s", hsName, err)
+			ct.Fatalf(t, "dirtyDeploy: failed to add %s: %s", hsName, err)
 		}
 		tp.existingDeployment.HS[hsName] = hsDep
 	}


### PR DESCRIPTION
- The entire Complement API now no longer uses `t *testing.T`, instead opting for `ct.TestLike` which is an interface. In practice, this changes nothing. However, this enables Complement to be used in many more places where you do not have a `t *testing.T` object to use e.g benchmarks, scripts. This is of particular use for Complement-Crypto which has to run parts of the test as a standalone binary, and therefore has no `t *testing.T` to use.
- The entire Complement API now uses `ct.Fatalf` and `ct.Errorf` for highlighting test failures in red. This should make it significantly easier to skim for the test failure message.
- Add `Deployment.ContainerID(TestLike, hsName) string` to allow tests to interact with the container beyond the abilities of the Complement API e.g log extraction, memory use, CPU use.

