### PR TITLE
Annotate `client.CSAPI` with `.Password`

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -41,6 +41,7 @@ type CSAPI struct {
 	UserID      string
 	AccessToken string
 	DeviceID    string
+	Password    string // if provided
 	BaseURL     string
 	Client      *http.Client
 	// how long are we willing to wait for MustSyncUntil.... calls

--- a/internal/docker/deployment.go
+++ b/internal/docker/deployment.go
@@ -99,6 +99,7 @@ func (d *Deployment) Register(t ct.TestLike, hsName string, opts helpers.Registr
 		Client:           client.NewLoggedClient(t, hsName, nil),
 		SyncUntilTimeout: 5 * time.Second,
 		Debug:            d.Deployer.debugLogging,
+		Password:         opts.Password,
 	}
 	// Appending a slice is not thread-safe. Protect the write with a mutex.
 	dep.CSAPIClientsMutex.Lock()
@@ -147,6 +148,10 @@ func (d *Deployment) Login(t ct.TestLike, hsName string, existing *client.CSAPI,
 		Client:           client.NewLoggedClient(t, hsName, nil),
 		SyncUntilTimeout: 5 * time.Second,
 		Debug:            d.Deployer.debugLogging,
+		Password:         existing.Password,
+	}
+	if opts.Password != "" {
+		c.Password = opts.Password
 	}
 	// Appending a slice is not thread-safe. Protect the write with a mutex.
 	dep.CSAPIClientsMutex.Lock()

--- a/internal/docker/deployment.go
+++ b/internal/docker/deployment.go
@@ -108,6 +108,7 @@ func (d *Deployment) Register(t ct.TestLike, hsName string, opts helpers.Registr
 	password := opts.Password
 	if password == "" {
 		password = "complement_meets_min_password_req"
+		client.Password = password
 	}
 
 	localpart := fmt.Sprintf("user-%v", d.localpartCounter.Add(1))


### PR DESCRIPTION
This field isn't really used anywhere, but it is extremely useful to be tagged with the client itself when you want to derive a new client from an existing one. Mostly helpful for Complement Crypto currently.

### Pull Request Checklist

- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)

