### PR TITLE
Refactor the match.CheckOff API to use functional options

### DIFF
--- a/tests/csapi/apidoc_search_test.go
+++ b/tests/csapi/apidoc_search_test.go
@@ -256,9 +256,9 @@ func TestSearch(t *testing.T) {
 					match.JSONKeyArrayOfSize(sce+".results", 2),
 
 					// the results can be in either order: check that both are there and that the content is as expected
-					match.JSONCheckOff(sce+".results", []interface{}{eventBeforeUpgrade, eventAfterUpgrade}, func(res gjson.Result) interface{} {
+					match.JSONCheckOff(sce+".results", []interface{}{eventBeforeUpgrade, eventAfterUpgrade}, match.CheckOffMapper(func(res gjson.Result) interface{} {
 						return res.Get("result.event_id").Str
-					}, func(eventID interface{}, result gjson.Result) error {
+					}), match.CheckOffForEach(func(eventID interface{}, result gjson.Result) error {
 						matchers := []match.JSON{
 							match.JSONKeyEqual("result.type", "m.room.message"),
 							match.JSONKeyEqual("result.content.body", expectedEvents[eventID.(string)]),
@@ -269,7 +269,7 @@ func TestSearch(t *testing.T) {
 							}
 						}
 						return nil
-					}),
+					})),
 				},
 			})
 		})

--- a/tests/csapi/room_leave_test.go
+++ b/tests/csapi/room_leave_test.go
@@ -166,13 +166,13 @@ func TestLeftRoomFixture(t *testing.T) {
 					[]interface{}{
 						"m.room.member|" + alice.UserID + "|join",
 						"m.room.member|" + bob.UserID + "|leave",
-					}, func(result gjson.Result) interface{} {
+					}, match.CheckOffMapper(func(result gjson.Result) interface{} {
 						return strings.Join([]string{
 							result.Map()["type"].Str,
 							result.Map()["state_key"].Str,
 							result.Get("content.membership").Str,
 						}, "|")
-					}, nil),
+					})),
 			},
 		})
 	})
@@ -191,13 +191,13 @@ func TestLeftRoomFixture(t *testing.T) {
 					"m.room.message|" + beforeMessageOne + "|",
 					"m.room.message|" + beforeMessageTwo + "|",
 					"m.room.member||" + bob.UserID,
-				}, func(result gjson.Result) interface{} {
+				}, match.CheckOffMapper(func(result gjson.Result) interface{} {
 					return strings.Join([]string{
 						result.Map()["type"].Str,
 						result.Get("content.body").Str,
 						result.Map()["state_key"].Str,
 					}, "|")
-				}, nil),
+				})),
 			},
 		})
 	})

--- a/tests/csapi/room_members_test.go
+++ b/tests/csapi/room_members_test.go
@@ -52,7 +52,7 @@ func TestGetRoomMembers(t *testing.T) {
 				[]interface{}{
 					"m.room.member|" + alice.UserID,
 					"m.room.member|" + bob.UserID,
-				}, typeToStateKeyMapper, nil),
+				}, match.CheckOffMapper(typeToStateKeyMapper)),
 		},
 		StatusCode: 200,
 	})
@@ -111,7 +111,7 @@ func TestGetRoomMembersAtPoint(t *testing.T) {
 			match.JSONCheckOff("chunk",
 				[]interface{}{
 					"m.room.member|" + alice.UserID,
-				}, typeToStateKeyMapper, nil),
+				}, match.CheckOffMapper(typeToStateKeyMapper)),
 		},
 
 		StatusCode: 200,
@@ -158,7 +158,7 @@ func TestGetFilteredRoomMembers(t *testing.T) {
 				match.JSONCheckOff("chunk",
 					[]interface{}{
 						"m.room.member|" + alice.UserID,
-					}, typeToStateKeyMapper, nil),
+					}, match.CheckOffMapper(typeToStateKeyMapper)),
 			},
 			StatusCode: 200,
 		})
@@ -183,7 +183,7 @@ func TestGetFilteredRoomMembers(t *testing.T) {
 				match.JSONCheckOff("chunk",
 					[]interface{}{
 						"m.room.member|" + bob.UserID,
-					}, typeToStateKeyMapper, nil),
+					}, match.CheckOffMapper(typeToStateKeyMapper)),
 			},
 			StatusCode: 200,
 		})
@@ -208,7 +208,7 @@ func TestGetFilteredRoomMembers(t *testing.T) {
 				match.JSONCheckOff("chunk",
 					[]interface{}{
 						"m.room.member|" + alice.UserID,
-					}, typeToStateKeyMapper, nil),
+					}, match.CheckOffMapper(typeToStateKeyMapper)),
 			},
 			StatusCode: 200,
 		})

--- a/tests/csapi/room_relations_test.go
+++ b/tests/csapi/room_relations_test.go
@@ -74,7 +74,7 @@ func TestRelations(t *testing.T) {
 	must.MatchResponse(t, res, match.HTTPResponse{
 		StatusCode: http.StatusOK,
 		JSON: []match.JSON{
-			match.JSONCheckOff("chunk", []interface{}{
+			match.JSONCheckOffDeprecated("chunk", []interface{}{
 				threadEventID, dummyEventID, editEventID,
 			}, func(r gjson.Result) interface{} {
 				return r.Get("event_id").Str
@@ -88,7 +88,7 @@ func TestRelations(t *testing.T) {
 	must.MatchResponse(t, res, match.HTTPResponse{
 		StatusCode: http.StatusOK,
 		JSON: []match.JSON{
-			match.JSONCheckOff("chunk", []interface{}{
+			match.JSONCheckOffDeprecated("chunk", []interface{}{
 				threadEventID, dummyEventID,
 			}, func(r gjson.Result) interface{} {
 				return r.Get("event_id").Str
@@ -102,7 +102,7 @@ func TestRelations(t *testing.T) {
 	must.MatchResponse(t, res, match.HTTPResponse{
 		StatusCode: http.StatusOK,
 		JSON: []match.JSON{
-			match.JSONCheckOff("chunk", []interface{}{
+			match.JSONCheckOffDeprecated("chunk", []interface{}{
 				threadEventID,
 			}, func(r gjson.Result) interface{} {
 				return r.Get("event_id").Str
@@ -152,7 +152,7 @@ func TestRelationsPagination(t *testing.T) {
 	body := must.MatchResponse(t, res, match.HTTPResponse{
 		StatusCode: http.StatusOK,
 		JSON: []match.JSON{
-			match.JSONCheckOff("chunk", []interface{}{
+			match.JSONCheckOffDeprecated("chunk", []interface{}{
 				event_ids[9], event_ids[8], event_ids[7],
 			}, func(r gjson.Result) interface{} {
 				return r.Get("event_id").Str
@@ -167,7 +167,7 @@ func TestRelationsPagination(t *testing.T) {
 	must.MatchResponse(t, res, match.HTTPResponse{
 		StatusCode: http.StatusOK,
 		JSON: []match.JSON{
-			match.JSONCheckOff("chunk", []interface{}{
+			match.JSONCheckOffDeprecated("chunk", []interface{}{
 				event_ids[6], event_ids[5], event_ids[4],
 			}, func(r gjson.Result) interface{} {
 				return r.Get("event_id").Str
@@ -184,7 +184,7 @@ func TestRelationsPagination(t *testing.T) {
 	body = must.MatchResponse(t, res, match.HTTPResponse{
 		StatusCode: http.StatusOK,
 		JSON: []match.JSON{
-			match.JSONCheckOff("chunk", []interface{}{
+			match.JSONCheckOffDeprecated("chunk", []interface{}{
 				event_ids[0], event_ids[1], event_ids[2],
 			}, func(r gjson.Result) interface{} {
 				return r.Get("event_id").Str
@@ -199,7 +199,7 @@ func TestRelationsPagination(t *testing.T) {
 	must.MatchResponse(t, res, match.HTTPResponse{
 		StatusCode: http.StatusOK,
 		JSON: []match.JSON{
-			match.JSONCheckOff("chunk", []interface{}{
+			match.JSONCheckOffDeprecated("chunk", []interface{}{
 				event_ids[3], event_ids[4], event_ids[5],
 			}, func(r gjson.Result) interface{} {
 				return r.Get("event_id").Str
@@ -279,7 +279,7 @@ func TestRelationsPaginationSync(t *testing.T) {
 	body := must.MatchResponse(t, res, match.HTTPResponse{
 		StatusCode: http.StatusOK,
 		JSON: []match.JSON{
-			match.JSONCheckOff("chunk", []interface{}{
+			match.JSONCheckOffDeprecated("chunk", []interface{}{
 				event_ids[0], event_ids[1], event_ids[2],
 			}, func(r gjson.Result) interface{} {
 				return r.Get("event_id").Str
@@ -294,7 +294,7 @@ func TestRelationsPaginationSync(t *testing.T) {
 	must.MatchResponse(t, res, match.HTTPResponse{
 		StatusCode: http.StatusOK,
 		JSON: []match.JSON{
-			match.JSONCheckOff("chunk", []interface{}{
+			match.JSONCheckOffDeprecated("chunk", []interface{}{
 				event_ids[3], event_ids[4],
 			}, func(r gjson.Result) interface{} {
 				return r.Get("event_id").Str

--- a/tests/msc3874/room_messages_relation_filter_test.go
+++ b/tests/msc3874/room_messages_relation_filter_test.go
@@ -68,7 +68,7 @@ func TestFilterMessagesByRelType(t *testing.T) {
 	must.MatchResponse(t, res, match.HTTPResponse{
 		StatusCode: http.StatusOK,
 		JSON: []match.JSON{
-			match.JSONCheckOff("chunk", []interface{}{
+			match.JSONCheckOffDeprecated("chunk", []interface{}{
 				threadEventID,
 			}, func(r gjson.Result) interface{} {
 				return r.Get("event_id").Str
@@ -86,7 +86,7 @@ func TestFilterMessagesByRelType(t *testing.T) {
 	must.MatchResponse(t, res, match.HTTPResponse{
 		StatusCode: http.StatusOK,
 		JSON: []match.JSON{
-			match.JSONCheckOff("chunk", []interface{}{
+			match.JSONCheckOffDeprecated("chunk", []interface{}{
 				referenceEventID,
 			}, func(r gjson.Result) interface{} {
 				return r.Get("event_id").Str
@@ -104,7 +104,7 @@ func TestFilterMessagesByRelType(t *testing.T) {
 	must.MatchResponse(t, res, match.HTTPResponse{
 		StatusCode: http.StatusOK,
 		JSON: []match.JSON{
-			match.JSONCheckOff("chunk", []interface{}{
+			match.JSONCheckOffDeprecated("chunk", []interface{}{
 				threadEventID, referenceEventID,
 			}, func(r gjson.Result) interface{} {
 				return r.Get("event_id").Str
@@ -122,7 +122,7 @@ func TestFilterMessagesByRelType(t *testing.T) {
 	must.MatchResponse(t, res, match.HTTPResponse{
 		StatusCode: http.StatusOK,
 		JSON: []match.JSON{
-			match.JSONCheckOff("chunk", []interface{}{
+			match.JSONCheckOffDeprecated("chunk", []interface{}{
 				rootEventID, referenceEventID,
 			}, func(r gjson.Result) interface{} {
 				return r.Get("event_id").Str
@@ -140,7 +140,7 @@ func TestFilterMessagesByRelType(t *testing.T) {
 	must.MatchResponse(t, res, match.HTTPResponse{
 		StatusCode: http.StatusOK,
 		JSON: []match.JSON{
-			match.JSONCheckOff("chunk", []interface{}{
+			match.JSONCheckOffDeprecated("chunk", []interface{}{
 				rootEventID, threadEventID,
 			}, func(r gjson.Result) interface{} {
 				return r.Get("event_id").Str
@@ -158,7 +158,7 @@ func TestFilterMessagesByRelType(t *testing.T) {
 	must.MatchResponse(t, res, match.HTTPResponse{
 		StatusCode: http.StatusOK,
 		JSON: []match.JSON{
-			match.JSONCheckOff("chunk", []interface{}{
+			match.JSONCheckOffDeprecated("chunk", []interface{}{
 				rootEventID,
 			}, func(r gjson.Result) interface{} {
 				return r.Get("event_id").Str

--- a/tests/msc3902/federation_room_join_partial_state_test.go
+++ b/tests/msc3902/federation_room_join_partial_state_test.go
@@ -383,13 +383,13 @@ func TestPartialStateJoin(t *testing.T) {
 		}
 
 		// check that the state includes both charlie and derek.
-		matcher := match.JSONCheckOffAllowUnwanted("state.events",
+		matcher := match.JSONCheckOff("state.events",
 			[]interface{}{
 				"m.room.member|" + server.UserID("charlie"),
 				"m.room.member|" + server.UserID("derek"),
-			}, func(result gjson.Result) interface{} {
+			}, match.CheckOffMapper(func(result gjson.Result) interface{} {
 				return strings.Join([]string{result.Map()["type"].Str, result.Map()["state_key"].Str}, "|")
-			}, nil,
+			}), match.CheckOffAllowUnwanted(),
 		)
 		if err := matcher(roomRes); err != nil {
 			t.Errorf("Did not find expected state events in /sync response: %s", err)
@@ -799,8 +799,7 @@ func TestPartialStateJoin(t *testing.T) {
 				matcher := match.JSONCheckOff(
 					"device_lists.changed",
 					[]interface{}{derekUserId},
-					func(r gjson.Result) interface{} { return r.Str },
-					nil,
+					match.CheckOffMapper(func(r gjson.Result) interface{} { return r.Str }),
 				)
 				return matcher(res)
 			},
@@ -1203,9 +1202,9 @@ func TestPartialStateJoin(t *testing.T) {
 							"m.room.member|" + alice.UserID,
 							"m.room.member|" + server.UserID("charlie"),
 							"m.room.member|" + server.UserID("derek"),
-						}, func(result gjson.Result) interface{} {
+						}, match.CheckOffMapper(func(result gjson.Result) interface{} {
 							return strings.Join([]string{result.Map()["type"].Str, result.Map()["state_key"].Str}, "|")
-						}, nil),
+						})),
 				},
 			})
 		}
@@ -1414,16 +1413,16 @@ func TestPartialStateJoin(t *testing.T) {
 
 		timelineMatcher := match.JSONCheckOff("timeline.events",
 			[]interface{}{lastEventID},
-			func(result gjson.Result) interface{} {
+			match.CheckOffMapper(func(result gjson.Result) interface{} {
 				return result.Map()["event_id"].Str
-			}, nil,
+			}),
 		)
-		stateMatcher := match.JSONCheckOffAllowUnwanted("state.events",
+		stateMatcher := match.JSONCheckOff("state.events",
 			[]interface{}{
 				"m.room.member|" + server.UserID("derek"),
-			}, func(result gjson.Result) interface{} {
+			}, match.CheckOffMapper(func(result gjson.Result) interface{} {
 				return strings.Join([]string{result.Map()["type"].Str, result.Map()["state_key"].Str}, "|")
-			}, nil,
+			}), match.CheckOffAllowUnwanted(),
 		)
 		if err := timelineMatcher(roomRes); err != nil {
 			t.Errorf("Unexpected timeline events found in gappy /sync response: %s", err)
@@ -2897,11 +2896,11 @@ func TestPartialStateJoin(t *testing.T) {
 			must.MatchResponse(t, res, match.HTTPResponse{
 				StatusCode: 200,
 				JSON: []match.JSON{
-					match.JSONCheckOffAllowUnwanted(
+					match.JSONCheckOff(
 						section,
 						[]interface{}{expectedUserID},
-						func(r gjson.Result) interface{} { return r.Str },
-						nil,
+						match.CheckOffMapper(func(r gjson.Result) interface{} { return r.Str }),
+						match.CheckOffAllowUnwanted(),
 					),
 				},
 			})
@@ -3488,8 +3487,7 @@ func TestPartialStateJoin(t *testing.T) {
 				match.JSONCheckOff(
 					"servers",
 					[]interface{}{"hs1", server.ServerName()},
-					func(r gjson.Result) interface{} { return r.Str },
-					nil,
+					match.CheckOffMapper(func(r gjson.Result) interface{} { return r.Str }),
 				),
 			},
 		}

--- a/tests/restricted_room_hierarchy_test.go
+++ b/tests/restricted_room_hierarchy_test.go
@@ -22,7 +22,7 @@ func requestAndAssertSummary(t *testing.T, user *client.CSAPI, space string, exp
 	res := user.MustDo(t, "GET", []string{"_matrix", "client", "v1", "rooms", space, "hierarchy"})
 	must.MatchResponse(t, res, match.HTTPResponse{
 		JSON: []match.JSON{
-			match.JSONCheckOff("rooms", expected_rooms, func(r gjson.Result) interface{} {
+			match.JSONCheckOffDeprecated("rooms", expected_rooms, func(r gjson.Result) interface{} {
 				return r.Get("room_id").Str
 			}, nil),
 		},

--- a/tests/room_hierarchy_test.go
+++ b/tests/room_hierarchy_test.go
@@ -227,7 +227,7 @@ func TestClientSpacesSummary(t *testing.T) {
 		res := alice.MustDo(t, "GET", []string{"_matrix", "client", "v1", "rooms", root, "hierarchy"})
 		must.MatchResponse(t, res, match.HTTPResponse{
 			JSON: []match.JSON{
-				match.JSONCheckOff("rooms", []interface{}{
+				match.JSONCheckOffDeprecated("rooms", []interface{}{
 					root, r1, r2, r3, r4, ss1, ss2,
 				}, func(r gjson.Result) interface{} {
 					return r.Get("room_id").Str
@@ -248,7 +248,7 @@ func TestClientSpacesSummary(t *testing.T) {
 					return nil
 				}),
 				// Check that the links from Root down to other rooms and spaces exist.
-				match.JSONCheckOff(`rooms.#(room_type=="m.space")#")`, []interface{}{
+				match.JSONCheckOffDeprecated(`rooms.#(room_type=="m.space")#")`, []interface{}{
 					rootToR1 + ";" + rootToSS1 + ";" + rootToR2,
 					ss1ToSS2,
 					ss2ToR3 + ";" + ss2ToR4,
@@ -270,13 +270,13 @@ func TestClientSpacesSummary(t *testing.T) {
 		)
 		must.MatchResponse(t, res, match.HTTPResponse{
 			JSON: []match.JSON{
-				match.JSONCheckOff("rooms", []interface{}{
+				match.JSONCheckOffDeprecated("rooms", []interface{}{
 					root, r1, r2, ss1,
 				}, func(r gjson.Result) interface{} {
 					return r.Get("room_id").Str
 				}, nil),
 				// All of the links are still there.
-				match.JSONCheckOff(`rooms.#(room_type=="m.space")#`, []interface{}{
+				match.JSONCheckOffDeprecated(`rooms.#(room_type=="m.space")#`, []interface{}{
 					rootToR1 + ";" + rootToSS1 + ";" + rootToR2, ss1ToSS2,
 				}, roomToChildrenMapper, nil),
 			},
@@ -296,13 +296,13 @@ func TestClientSpacesSummary(t *testing.T) {
 		)
 		must.MatchResponse(t, res, match.HTTPResponse{
 			JSON: []match.JSON{
-				match.JSONCheckOff("rooms", []interface{}{
+				match.JSONCheckOffDeprecated("rooms", []interface{}{
 					root, r1, r2,
 				}, func(r gjson.Result) interface{} {
 					return r.Get("room_id").Str
 				}, nil),
 				// All of the links are still there.
-				match.JSONCheckOff(`rooms.#(room_type=="m.space")#`, []interface{}{
+				match.JSONCheckOffDeprecated(`rooms.#(room_type=="m.space")#`, []interface{}{
 					rootToR1 + ";" + rootToR2,
 				}, roomToChildrenMapper, nil),
 			},
@@ -322,7 +322,7 @@ func TestClientSpacesSummary(t *testing.T) {
 		)
 		body := must.MatchResponse(t, res, match.HTTPResponse{
 			JSON: []match.JSON{
-				match.JSONCheckOff("rooms", []interface{}{
+				match.JSONCheckOffDeprecated("rooms", []interface{}{
 					root, r1, ss1, ss2,
 				}, func(r gjson.Result) interface{} {
 					return r.Get("room_id").Str
@@ -341,7 +341,7 @@ func TestClientSpacesSummary(t *testing.T) {
 		)
 		must.MatchResponse(t, res, match.HTTPResponse{
 			JSON: []match.JSON{
-				match.JSONCheckOff("rooms", []interface{}{
+				match.JSONCheckOffDeprecated("rooms", []interface{}{
 					r3, r4, r2,
 				}, func(r gjson.Result) interface{} {
 					return r.Get("room_id").Str
@@ -360,12 +360,12 @@ func TestClientSpacesSummary(t *testing.T) {
 		res := alice.MustDo(t, "GET", []string{"_matrix", "client", "v1", "rooms", root, "hierarchy"})
 		must.MatchResponse(t, res, match.HTTPResponse{
 			JSON: []match.JSON{
-				match.JSONCheckOff("rooms", []interface{}{
+				match.JSONCheckOffDeprecated("rooms", []interface{}{
 					root, r1, r2,
 				}, func(r gjson.Result) interface{} {
 					return r.Get("room_id").Str
 				}, nil),
-				match.JSONCheckOff(`rooms.#(room_type=="m.space")#`, []interface{}{
+				match.JSONCheckOffDeprecated(`rooms.#(room_type=="m.space")#`, []interface{}{
 					rootToR1 + ";" + rootToR2,
 				}, roomToChildrenMapper, nil),
 			},
@@ -475,12 +475,12 @@ func TestClientSpacesSummaryJoinRules(t *testing.T) {
 	res := bob.MustDo(t, "GET", []string{"_matrix", "client", "v1", "rooms", root, "hierarchy"})
 	must.MatchResponse(t, res, match.HTTPResponse{
 		JSON: []match.JSON{
-			match.JSONCheckOff("rooms", []interface{}{
+			match.JSONCheckOffDeprecated("rooms", []interface{}{
 				root,
 			}, func(r gjson.Result) interface{} {
 				return r.Get("room_id").Str
 			}, nil),
-			match.JSONCheckOff(`rooms.#(room_type=="m.space")#`, []interface{}{
+			match.JSONCheckOffDeprecated(`rooms.#(room_type=="m.space")#`, []interface{}{
 				rootToR1 + ";" + rootToSS1,
 			}, roomToChildrenMapper, nil),
 		},
@@ -493,12 +493,12 @@ func TestClientSpacesSummaryJoinRules(t *testing.T) {
 	res = bob.MustDo(t, "GET", []string{"_matrix", "client", "v1", "rooms", root, "hierarchy"})
 	must.MatchResponse(t, res, match.HTTPResponse{
 		JSON: []match.JSON{
-			match.JSONCheckOff("rooms", []interface{}{
+			match.JSONCheckOffDeprecated("rooms", []interface{}{
 				root, r1,
 			}, func(r gjson.Result) interface{} {
 				return r.Get("room_id").Str
 			}, nil),
-			match.JSONCheckOff(`rooms.#(room_type=="m.space")#`, []interface{}{
+			match.JSONCheckOffDeprecated(`rooms.#(room_type=="m.space")#`, []interface{}{
 				rootToR1 + ";" + rootToSS1,
 			}, roomToChildrenMapper, nil),
 		},
@@ -510,12 +510,12 @@ func TestClientSpacesSummaryJoinRules(t *testing.T) {
 	res = bob.MustDo(t, "GET", []string{"_matrix", "client", "v1", "rooms", root, "hierarchy"})
 	must.MatchResponse(t, res, match.HTTPResponse{
 		JSON: []match.JSON{
-			match.JSONCheckOff("rooms", []interface{}{
+			match.JSONCheckOffDeprecated("rooms", []interface{}{
 				root, r1, ss1, r2, r3,
 			}, func(r gjson.Result) interface{} {
 				return r.Get("room_id").Str
 			}, nil),
-			match.JSONCheckOff(`rooms.#(room_type=="m.space")#`, []interface{}{
+			match.JSONCheckOffDeprecated(`rooms.#(room_type=="m.space")#`, []interface{}{
 				rootToR1 + ";" + rootToSS1, ss1ToR2 + ";" + ss1ToR3,
 			}, roomToChildrenMapper, nil),
 		},
@@ -641,7 +641,7 @@ func TestFederatedClientSpaces(t *testing.T) {
 	res := alice.MustDo(t, "GET", []string{"_matrix", "client", "v1", "rooms", root, "hierarchy"})
 	must.MatchResponse(t, res, match.HTTPResponse{
 		JSON: []match.JSON{
-			match.JSONCheckOff("rooms", []interface{}{
+			match.JSONCheckOffDeprecated("rooms", []interface{}{
 				root, r1, r2, r3, r4, ss1, ss2,
 			}, func(r gjson.Result) interface{} {
 				return r.Get("room_id").Str

--- a/tests/room_timestamp_to_event_test.go
+++ b/tests/room_timestamp_to_event_test.go
@@ -222,9 +222,9 @@ func TestJumpToDateEndpoint(t *testing.T) {
 				// Make sure both messages are visible
 				must.MatchResponse(t, messagesRes, match.HTTPResponse{
 					JSON: []match.JSON{
-						match.JSONCheckOffAllowUnwanted("chunk", []interface{}{eventA.EventID, eventB.EventID}, func(r gjson.Result) interface{} {
+						match.JSONCheckOff("chunk", []interface{}{eventA.EventID, eventB.EventID}, match.CheckOffMapper(func(r gjson.Result) interface{} {
 							return r.Get("event_id").Str
-						}, nil),
+						}), match.CheckOffAllowUnwanted()),
 					},
 				})
 			})


### PR DESCRIPTION
This means you don't need to tack on `, nil` all the time, and can optionally specify when you want to allow unwanted items, obviating the need for `JSONCheckOffAllowUnwanted`. This composes better and supports adding additional functionality e.g allowing duplicate items.
