### PR TITLE
Test for MSC4115 support

### DIFF
--- a/tests/msc4115/main_test.go
+++ b/tests/msc4115/main_test.go
@@ -1,0 +1,11 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/matrix-org/complement"
+)
+
+func TestMain(m *testing.M) {
+	complement.TestMain(m, "msc4115")
+}

--- a/tests/msc4115/msc4115_test.go
+++ b/tests/msc4115/msc4115_test.go
@@ -1,0 +1,64 @@
+package tests
+
+import (
+	"github.com/matrix-org/complement/b"
+	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/runtime"
+	"testing"
+
+	"github.com/matrix-org/complement"
+	"github.com/matrix-org/complement/helpers"
+)
+
+// MSC4115: membership information on events
+//
+// Alice sends one message before bob joins, then one after. Bob reads both messages, and checks the membership state
+// on each.
+func TestMSC4115(t *testing.T) {
+	runtime.SkipIf(t, runtime.Dendrite) // not yet implemented
+
+	deployment := complement.Deploy(t, 1)
+	defer deployment.Destroy(t)
+
+	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+
+	roomID := alice.MustCreateRoom(t, map[string]interface{}{"preset": "public_chat"})
+	preJoinEventID := alice.SendEventSynced(t, roomID, b.Event{Type: "m.room.message",
+		Content: map[string]interface{}{
+			"msgtype": "m.text",
+			"body":    "prejoin",
+		}})
+	bob.MustJoinRoom(t, roomID, []string{"hs1"})
+	postJoinEventID := alice.SendEventSynced(t, roomID, b.Event{Type: "m.room.message",
+		Content: map[string]interface{}{
+			"msgtype": "m.text",
+			"body":    "postjoin",
+		}})
+
+	// Now Bob syncs, to get the messages
+	syncResult, _ := bob.MustSync(t, client.SyncReq{})
+	if err := client.SyncTimelineHasEventID(roomID, preJoinEventID)(alice.UserID, syncResult); err != nil {
+		t.Fatalf("Sync response lacks prejoin event: %s", err)
+	}
+	if err := client.SyncTimelineHasEventID(roomID, postJoinEventID)(alice.UserID, syncResult); err != nil {
+		t.Fatalf("Sync response lacks prejoin event: %s", err)
+	}
+
+	// ... and we check the membership value for each event. Should be "leave" for each event until the join.
+	haveSeenJoin := false
+	roomSyncResult := syncResult.Get("rooms.join." + client.GjsonEscape(roomID))
+	for _, ev := range roomSyncResult.Get("timeline.events").Array() {
+		if ev.Get("type").Str == "m.room.member" && ev.Get("state_key").Str == bob.UserID {
+			haveSeenJoin = true
+		}
+		membership := ev.Get("unsigned." + client.GjsonEscape("io.element.msc4115.membership")).Str
+		expectedMembership := "leave"
+		if haveSeenJoin {
+			expectedMembership = "join"
+		}
+		if membership != expectedMembership {
+			t.Errorf("Incorrect membership for event %s; got %s, want %s", ev, membership, expectedMembership)
+		}
+	}
+}


### PR DESCRIPTION
[MSC4115](https://github.com/matrix-org/matrix-spec-proposals/pull/4115) adds a "membership" field to each event served over the CS API. This PR adds tests for it.

Requires https://github.com/element-hq/synapse/pull/17104