### PR TITLE
Add conduwuit

### DIFF
--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -8,3 +8,4 @@ duplication, we now point to dockerfiles in respective repositories rather than 
 - Dendrite: https://github.com/matrix-org/dendrite/blob/v0.8.2/build/scripts/Complement.Dockerfile
 - Synapse: https://github.com/matrix-org/synapse/blob/develop/docker/complement/Dockerfile
 - Conduit: https://gitlab.com/famedly/conduit/-/blob/next/tests/Complement.Dockerfile
+- conduwuit: https://conduwuit.puppyirl.gay/development/testing.html

--- a/runtime/hs.go
+++ b/runtime/hs.go
@@ -8,9 +8,10 @@ import (
 )
 
 const (
-	Dendrite = "dendrite"
-	Synapse  = "synapse"
-	Conduit  = "conduit"
+	Dendrite  = "dendrite"
+	Synapse   = "synapse"
+	Conduit   = "conduit"
+	Conduwuit = "conduwuit"
 )
 
 var Homeserver string

--- a/runtime/hs_conduwuit.go
+++ b/runtime/hs_conduwuit.go
@@ -1,0 +1,10 @@
+//go:build conduwuit_blacklist || conduit_blacklist
+// +build conduwuit_blacklist conduit_blacklist
+
+// for now, a couple skipped conduit tests still apply to conduwuit. this will change in the future
+
+package runtime
+
+func init() {
+	Homeserver = Conduwuit
+}

--- a/tests/media_filename_test.go
+++ b/tests/media_filename_test.go
@@ -121,11 +121,11 @@ func TestMediaFilenames(t *testing.T) {
 			})
 
 			t.Run("Will serve safe media types as inline", func(t *testing.T) {
-				if runtime.Homeserver != runtime.Synapse {
+				if runtime.Homeserver != runtime.Synapse && runtime.Homeserver != runtime.Conduwuit {
 					// We need to check that this security behaviour is being correctly run in
-					// Synapse, but since this is not part of the Matrix spec we do not assume
+					// Synapse or conduwuit, but since this is not part of the Matrix spec we do not assume
 					// other homeservers are doing so.
-					t.Skip("Skipping test of Content-Disposition header requirements on non-Synapse homeserver")
+					t.Skip("Skipping test of Content-Disposition header requirements on non-Synapse and non-conduwuit homeserver")
 				}
 				t.Parallel()
 
@@ -139,11 +139,11 @@ func TestMediaFilenames(t *testing.T) {
 			})
 
 			t.Run("Will serve safe media types with parameters as inline", func(t *testing.T) {
-				if runtime.Homeserver != runtime.Synapse {
+				if runtime.Homeserver != runtime.Synapse && runtime.Homeserver != runtime.Conduwuit {
 					// We need to check that this security behaviour is being correctly run in
-					// Synapse, but since this is not part of the Matrix spec we do not assume
+					// Synapse or conduwuit, but since this is not part of the Matrix spec we do not assume
 					// other homeservers are doing so.
-					t.Skip("Skipping test of Content-Disposition header requirements on non-Synapse homeserver")
+					t.Skip("Skipping test of Content-Disposition header requirements on non-Synapse and non-conduwuit homeserver")
 				}
 				t.Parallel()
 
@@ -158,11 +158,11 @@ func TestMediaFilenames(t *testing.T) {
 			})
 
 			t.Run("Will serve unsafe media types as attachments", func(t *testing.T) {
-				if runtime.Homeserver != runtime.Synapse {
+				if runtime.Homeserver != runtime.Synapse && runtime.Homeserver != runtime.Conduwuit {
 					// We need to check that this security behaviour is being correctly run in
-					// Synapse, but since this is not part of the Matrix spec we do not assume
+					// Synapse or conduwuit, but since this is not part of the Matrix spec we do not assume
 					// other homeservers are doing so.
-					t.Skip("Skipping test of Content-Disposition header requirements on non-Synapse homeserver")
+					t.Skip("Skipping test of Content-Disposition header requirements on non-Synapse and non-conduwuit homeserver")
 				}
 				t.Parallel()
 


### PR DESCRIPTION
conduwuit has:
- fully working [Complement support via Nix/Lix flake](https://github.com/girlbossceo/conduwuit/tree/main/nix/pkgs/complement), building the OCI image, [Complement as a flake input](https://github.com/girlbossceo/conduwuit/blob/main/flake.nix#L4)
- Has a [helper script](https://github.com/girlbossceo/conduwuit/blob/main/bin/complement)
- Complement with conduwuit does not require a reverse proxy if using the helper script and Nix/Lix flake for Complement PKI
- [integrated into our CI](https://github.com/girlbossceo/conduwuit/blob/main/.github/workflows/ci.yml#L101-L144) and uploads the OCI image used as an [artifact (`complement_oci_image.tar.gz`)](https://github.com/girlbossceo/conduwuit/actions/runs/9049542800)
- [publishes test results](https://github.com/girlbossceo/conduwuit/blob/main/tests/test_results/complement/test_results.jsonl)
- CI does a `diff` between the results and [outputs them in CI workflow summary](https://github.com/girlbossceo/conduwuit/actions/runs/9049542800#summary-24863774160)
- [documents how to use it with Nix/Lix or downloading the OCI image artifact from CI](https://conduwuit.puppyirl.gay/development/testing.html)

conduwuit also performs the necessary Content-Disposition checks: https://github.com/girlbossceo/conduwuit/compare/e4e1636da8d87a1fcaf5a65ce9ad14ac69d8f23a...154b2ab49051bf14ca62a143e5d2edf9e0ef5c93  (and thanks to this Complement test we found one more bad Content-Type being allowed)

(I am not a Go developer so if something needs to be changed about this PR, walk me through :>)