### PR TITLE
Add a basic test fetching thumbnail from `_matrix/federation/v1/media/thumbnail`

### DIFF
--- a/tests/media_thumbnail_test.go
+++ b/tests/media_thumbnail_test.go
@@ -132,6 +132,7 @@ func TestFederationThumbnail(t *testing.T) {
 		t.Fatalf("failed to parse multipart response: %s", err)
 	}
 
+	foundImage := false
 	reader := multipart.NewReader(resp.Body, params["boundary"])
 	for {
 		p, err := reader.NextPart()
@@ -151,7 +152,11 @@ func TestFederationThumbnail(t *testing.T) {
 			if !bytes.Equal(imageBody, body) {
 				t.Fatalf("body does not match uploaded file")
 			}
+			foundImage = true
 		}
+	}
+	if !foundImage {
+		t.Fatalf("No image was found in response.")
 	}
 }
 


### PR DESCRIPTION
As the title states. https://github.com/element-hq/synapse/issues/17518 was missed because Synapse does not request thumbnails via this endpoint, rather fetches the media over the `/download` endpoint and then generates the thumbnails. This PR adds a test to ensure the basic functionality of the `/thumbnail` endpoint. 
