### PR TITLE
fix: Use latest data structure for acccount testing

### DIFF
--- a/tests/csapi/account_change_password_test.go
+++ b/tests/csapi/account_change_password_test.go
@@ -108,8 +108,11 @@ func changePassword(t *testing.T, passwordClient *client.CSAPI, oldPassword stri
 	t.Helper()
 	reqBody := client.WithJSONBody(t, map[string]interface{}{
 		"auth": map[string]interface{}{
-			"type":     "m.login.password",
-			"user":     passwordClient.UserID,
+			"type": "m.login.password",
+			"identifier": map[string]interface{}{
+				"type": "m.id.user",
+				"user": passwordClient.UserID,
+			},
 			"password": oldPassword,
 		},
 		"new_password": newPassword,

--- a/tests/csapi/account_change_password_test.go
+++ b/tests/csapi/account_change_password_test.go
@@ -83,8 +83,11 @@ func TestChangePassword(t *testing.T) {
 		_, sessionOptional := createSession(t, deployment, passwordClient.UserID, password2)
 		reqBody := client.WithJSONBody(t, map[string]interface{}{
 			"auth": map[string]interface{}{
-				"type":     "m.login.password",
-				"user":     passwordClient.UserID,
+				"type": "m.login.password",
+				"identifier": map[string]interface{}{
+					"type": "m.id.user",
+					"user": passwordClient.UserID,
+				},
 				"password": password2,
 			},
 			"new_password":   "new_optional_password",

--- a/tests/csapi/account_deactivate_test.go
+++ b/tests/csapi/account_deactivate_test.go
@@ -95,7 +95,10 @@ func TestDeactivateAccount(t *testing.T) {
 		reqBody := client.WithJSONBody(t, map[string]interface{}{
 			"identifier": map[string]interface{}{
 				"type": "m.id.user",
-				"user": authedClient.UserID,
+				"identifier": map[string]interface{}{
+					"type": "m.id.user",
+					"user": authedClient.UserID,
+				},
 			},
 			"type":     "m.login.password",
 			"password": password,
@@ -111,8 +114,11 @@ func deactivateAccount(t *testing.T, authedClient *client.CSAPI, password string
 	t.Helper()
 	reqBody := client.WithJSONBody(t, map[string]interface{}{
 		"auth": map[string]interface{}{
-			"type":     "m.login.password",
-			"user":     authedClient.UserID,
+			"type": "m.login.password",
+			"identifier": map[string]interface{}{
+				"type": "m.id.user",
+				"user": authedClient.UserID,
+			},
 			"password": password,
 		},
 	})

--- a/tests/csapi/account_deactivate_test.go
+++ b/tests/csapi/account_deactivate_test.go
@@ -95,10 +95,7 @@ func TestDeactivateAccount(t *testing.T) {
 		reqBody := client.WithJSONBody(t, map[string]interface{}{
 			"identifier": map[string]interface{}{
 				"type": "m.id.user",
-				"identifier": map[string]interface{}{
-					"type": "m.id.user",
-					"user": authedClient.UserID,
-				},
+				"user": authedClient.UserID,
 			},
 			"type":     "m.login.password",
 			"password": password,

--- a/tests/csapi/apidoc_room_create_test.go
+++ b/tests/csapi/apidoc_room_create_test.go
@@ -118,7 +118,7 @@ func TestRoomCreate(t *testing.T) {
 
 			res := alice.CreateRoom(t, map[string]interface{}{
 				"visibility":   "private",
-				"room_version": "1",
+				"room_version": 1,
 				"preset":       "public_chat",
 			})
 			must.MatchResponse(t, res, match.HTTPResponse{

--- a/tests/csapi/apidoc_room_create_test.go
+++ b/tests/csapi/apidoc_room_create_test.go
@@ -118,7 +118,7 @@ func TestRoomCreate(t *testing.T) {
 
 			res := alice.CreateRoom(t, map[string]interface{}{
 				"visibility":   "private",
-				"room_version": 1,
+				"room_version": "1",
 				"preset":       "public_chat",
 			})
 			must.MatchResponse(t, res, match.HTTPResponse{


### PR DESCRIPTION
Hello,
I am using Rust to develop a matrix server-side [Palpo](https://github.com/palpo-matrix-server/palpo), which is based on another web framework I maintain, [Salvo](https://github.com/salvo-rs/salvo/). When using complement for testing, I found that several places seemed to use the old data format, which caused some of my tests to fail. I am not sure whether it needs to be fixed.

Signed-off-by: Chrislearn Young <chris@acroidea.com>