### PR TITLE
Update references from matrix-org/dendrite to element-hq/dendrite

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ jobs:
             timeout: 20m
 
           - homeserver: Dendrite
-            repo: matrix-org/dendrite
+            repo: element-hq/dendrite
             tags: dendrite_blacklist
             packages: ""
             env: "COMPLEMENT_ENABLE_DIRTY_RUNS=1"

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Docker image format is needed because OCI format doesn't support the HEALTHCHECK
 For instance, for Dendrite:
 ```
 # build a docker image for Dendrite...
-$ git clone https://github.com/matrix-org/dendrite
+$ git clone https://github.com/element-hq/dendrite
 $ (cd dendrite && docker build -t complement-dendrite -f build/scripts/Complement.Dockerfile .)
 # ...and test it
 $ COMPLEMENT_BASE_IMAGE=complement-dendrite:latest go test -v ./tests/...
@@ -114,7 +114,7 @@ from the host to the container. This is set via `COMPLEMENT_HOST_MOUNTS`, on the
 For example, for Dendrite on Linux with the default location of `$GOPATH`, do a one-time setup:
 
 ```shellsession
-$ git clone https://github.com/matrix-org/dendrite ../dendrite
+$ git clone https://github.com/element-hq/dendrite ../dendrite
 $ (cd ../dendrite && docker build -t complement-dendrite-local -f build/scripts/ComplementLocal.Dockerfile .)
 $ mkdir -p ../complement-go-build-cache
 $ export COMPLEMENT_BASE_IMAGE=complement-dendrite-local

--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -5,7 +5,7 @@ However, this doesn't work nicely when running Complement with local checkouts, 
 end up copying the Dockerfiles in this directory to their own repository. In an effort to reduce
 duplication, we now point to dockerfiles in respective repositories rather than have them directly here.
 
-- Dendrite: https://github.com/matrix-org/dendrite/blob/v0.8.2/build/scripts/Complement.Dockerfile
+- Dendrite: https://github.com/element-hq/dendrite/blob/11b48749bf96fb1f7761df6d7a21cf1cd8484e20/build/scripts/Complement.Dockerfile
 - Synapse: https://github.com/matrix-org/synapse/blob/develop/docker/complement/Dockerfile
 - Conduit: https://gitlab.com/famedly/conduit/-/blob/next/tests/Complement.Dockerfile
 - conduwuit: https://conduwuit.puppyirl.gay/development/testing.html


### PR DESCRIPTION
At least where it makes sense.