### PR TITLE
TestAsyncUpload: download with authentication

### DIFF
--- a/tests/csapi/media_async_uploads_test.go
+++ b/tests/csapi/media_async_uploads_test.go
@@ -62,7 +62,7 @@ func TestAsyncUpload(t *testing.T) {
 	})
 
 	t.Run("Download media", func(t *testing.T) {
-		content, contentType := alice.DownloadContent(t, mxcURI)
+		content, contentType := alice.DownloadContentAuthenticated(t, mxcURI)
 		if !bytes.Equal(data.MatrixPng, content) {
 			t.Fatalf("uploaded and downloaded content doesn't match: want %v\ngot\n%v", data.MatrixPng, content)
 		}


### PR DESCRIPTION
This fixes support with homeservers that enforce authenticated media, such as Synapse in https://github.com/element-hq/synapse/pull/17889

### Pull Request Checklist

- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)

Signed-off-by: Olivier 'reivilibre' <oliverw@element.io>