### PR TITLE
Test for passing through `unsigned` data in `/keys/query`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,9 +42,9 @@ jobs:
           - homeserver: Synapse
             repo: element-hq/synapse
             tags: synapse_blacklist
-            packages: |-
-              ./tests/msc3874
-              ./tests/msc3902
+            packages: \
+              ./tests/msc3874 \
+              ./tests/msc3902 \
               ./tests/msc4229
             env: "COMPLEMENT_ENABLE_DIRTY_RUNS=1 COMPLEMENT_SHARE_ENV_PREFIX=PASS_ PASS_SYNAPSE_COMPLEMENT_DATABASE=sqlite"
             timeout: 20m

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,10 @@ jobs:
           - homeserver: Synapse
             repo: element-hq/synapse
             tags: synapse_blacklist
-            packages: ./tests/msc3874 ./tests/msc3902
+            packages: |-
+              ./tests/msc3874
+              ./tests/msc3902
+              ./tests/msc4229
             env: "COMPLEMENT_ENABLE_DIRTY_RUNS=1 COMPLEMENT_SHARE_ENV_PREFIX=PASS_ PASS_SYNAPSE_COMPLEMENT_DATABASE=sqlite"
             timeout: 20m
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,9 +42,9 @@ jobs:
           - homeserver: Synapse
             repo: element-hq/synapse
             tags: synapse_blacklist
-            packages: \
-              ./tests/msc3874 \
-              ./tests/msc3902 \
+            packages: >-
+              ./tests/msc3874
+              ./tests/msc3902
               ./tests/msc4229
             env: "COMPLEMENT_ENABLE_DIRTY_RUNS=1 COMPLEMENT_SHARE_ENV_PREFIX=PASS_ PASS_SYNAPSE_COMPLEMENT_DATABASE=sqlite"
             timeout: 20m

--- a/tests/msc4229/main_test.go
+++ b/tests/msc4229/main_test.go
@@ -1,0 +1,11 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/matrix-org/complement"
+)
+
+func TestMain(m *testing.M) {
+	complement.TestMain(m, "msc4229")
+}

--- a/tests/msc4229/msc4229_test.go
+++ b/tests/msc4229/msc4229_test.go
@@ -1,0 +1,63 @@
+package tests
+
+import (
+	"fmt"
+	"github.com/matrix-org/complement"
+	"testing"
+
+	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/helpers"
+	"github.com/matrix-org/complement/match"
+	"github.com/matrix-org/complement/must"
+)
+
+// Create two homeservers, one of which has a user that uploads device-keys data with
+// "unsigned" data.
+//
+// Check that users on both servers see the unsigned data.
+func TestUnsignedDeviceDataIsReturned(t *testing.T) {
+	deployment := complement.Deploy(t, 2)
+	defer deployment.Destroy(t)
+	hs1user := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	hs2user := deployment.Register(t, "hs2", helpers.RegistrationOpts{})
+
+	hs1userDeviceKeys, _ := hs1user.MustGenerateOneTimeKeys(t, 0)
+	hs1userDeviceKeys["unsigned"] = map[string]interface{}{"a": "b"}
+	hs1user.MustUploadKeys(t, hs1userDeviceKeys, nil)
+
+	// Have each user request the keys, and check the unsigned data is there
+	for _, user := range []*client.CSAPI{hs1user, hs2user} {
+		res := user.MustDo(t, "POST", []string{"_matrix", "client", "v3", "keys", "query"},
+			client.WithJSONBody(t, map[string]any{"device_keys": map[string]any{hs1user.UserID: []string{}}}),
+		)
+		must.MatchResponse(t, res, match.HTTPResponse{
+			JSON: []match.JSON{
+				match.JSONKeyPresent(fmt.Sprintf(
+					"device_keys.%s.%s", hs1user.UserID, hs1user.DeviceID,
+				)),
+				match.JSONKeyEqual(fmt.Sprintf(
+					"device_keys.%s.%s.unsigned", hs1user.UserID, hs1user.DeviceID,
+				), map[string]interface{}{"a": "b"}),
+			},
+		})
+	}
+
+	// If a displayname is set, that is added tp the unsigned data, for the local user's query only
+	hs1user.MustDo(t, "PUT", []string{"_matrix", "client", "v3", "devices", hs1user.DeviceID},
+		client.WithJSONBody(t, map[string]any{"display_name": "complement"}),
+	)
+
+	res := hs1user.MustDo(t, "POST", []string{"_matrix", "client", "v3", "keys", "query"},
+		client.WithJSONBody(t, map[string]any{"device_keys": map[string]any{hs1user.UserID: []string{}}}),
+	)
+	must.MatchResponse(t, res, match.HTTPResponse{
+		JSON: []match.JSON{
+			match.JSONKeyPresent(fmt.Sprintf(
+				"device_keys.%s.%s", hs1user.UserID, hs1user.DeviceID,
+			)),
+			match.JSONKeyEqual(fmt.Sprintf(
+				"device_keys.%s.%s.unsigned", hs1user.UserID, hs1user.DeviceID,
+			), map[string]interface{}{"a": "b"}),
+		},
+	})
+}

--- a/tests/msc4229/msc4229_test.go
+++ b/tests/msc4229/msc4229_test.go
@@ -57,7 +57,7 @@ func TestUnsignedDeviceDataIsReturned(t *testing.T) {
 			)),
 			match.JSONKeyEqual(fmt.Sprintf(
 				"device_keys.%s.%s.unsigned", hs1user.UserID, hs1user.DeviceID,
-			), map[string]interface{}{"a": "b", "display_name": "complement"}),
+			), map[string]interface{}{"a": "b", "device_display_name": "complement"}),
 		},
 	})
 }

--- a/tests/msc4229/msc4229_test.go
+++ b/tests/msc4229/msc4229_test.go
@@ -57,7 +57,7 @@ func TestUnsignedDeviceDataIsReturned(t *testing.T) {
 			)),
 			match.JSONKeyEqual(fmt.Sprintf(
 				"device_keys.%s.%s.unsigned", hs1user.UserID, hs1user.DeviceID,
-			), map[string]interface{}{"a": "b"}),
+			), map[string]interface{}{"a": "b", "display_name": "complement"}),
 		},
 	})
 }


### PR DESCRIPTION
We'd like a mechanism by which a client can add "unsigned" data to their device keys, and have it be accessible by other clients involved in E2EE discussions.

An MSC for this behaviour is pending, but will be matrix-org/matrix-spec-proposals#4229.

This PR adds a test for that functionality. It tests functionality added in https://github.com/element-hq/synapse/pull/17951.

Part of element-hq/element-meta#2467.