### PR TITLE
Make restricted room join tests clearer

### DIFF
--- a/tests/restricted_rooms_test.go
+++ b/tests/restricted_rooms_test.go
@@ -99,8 +99,6 @@ func checkRestrictedRoom(t *testing.T, alice *client.CSAPI, bob *client.CSAPI, a
 				Content: map[string]interface{}{
 					"membership":  "join",
 					"displayname": "Bobby",
-					// This should be ignored since this is a join -> join transition.
-					"join_authorised_via_users_server": "unused",
 				},
 			},
 		)

--- a/tests/restricted_rooms_test.go
+++ b/tests/restricted_rooms_test.go
@@ -99,6 +99,8 @@ func checkRestrictedRoom(t *testing.T, alice *client.CSAPI, bob *client.CSAPI, a
 				Content: map[string]interface{}{
 					"membership":  "join",
 					"displayname": "Bobby",
+					// This should be ignored by the server since this is a join -> join transition
+					"join_authorised_via_users_server": "@unused:unused.local",
 				},
 			},
 		)

--- a/tests/restricted_rooms_test.go
+++ b/tests/restricted_rooms_test.go
@@ -64,7 +64,7 @@ func checkRestrictedRoom(t *testing.T, alice *client.CSAPI, bob *client.CSAPI, a
 
 	t.Run("Join should succeed when joined to allowed room", func(t *testing.T) {
 		// Join the allowed room.
-		bob.JoinRoom(t, allowed_room, []string{"hs1"})
+		bob.MustJoinRoom(t, allowed_room, []string{"hs1"})
 
 		// Confirm that we joined the allowed room by changing displayname and
 		// waiting for confirmation in the /sync response. (This is an attempt
@@ -86,7 +86,7 @@ func checkRestrictedRoom(t *testing.T, alice *client.CSAPI, bob *client.CSAPI, a
 		)
 
 		// We should now be able to join the restricted room.
-		bob.JoinRoom(t, room, []string{"hs1"})
+		bob.MustJoinRoom(t, room, []string{"hs1"})
 
 		// Joining the same room again should work fine (e.g. to change your display name).
 		bob.SendEventSynced(
@@ -115,6 +115,15 @@ func checkRestrictedRoom(t *testing.T, alice *client.CSAPI, bob *client.CSAPI, a
 		// has processed the leave before Bob tries rejoining, so that it rejects his
 		// attempt to join the room.
 		alice.MustSyncUntil(t, client.SyncReq{}, client.SyncTimelineHas(
+			room, func(ev gjson.Result) bool {
+				if ev.Get("type").Str != "m.room.member" || ev.Get("sender").Str != bob.UserID {
+					return false
+				}
+
+				return ev.Get("content").Get("membership").Str == "leave"
+			}))
+
+		alice.MustSyncUntil(t, client.SyncReq{}, client.SyncTimelineHas(
 			allowed_room, func(ev gjson.Result) bool {
 				if ev.Get("type").Str != "m.room.member" || ev.Get("sender").Str != bob.UserID {
 					return false
@@ -130,11 +139,11 @@ func checkRestrictedRoom(t *testing.T, alice *client.CSAPI, bob *client.CSAPI, a
 	t.Run("Join should succeed when invited", func(t *testing.T) {
 		// Invite the user and joining should work.
 		alice.MustInviteRoom(t, room, bob.UserID)
-		bob.JoinRoom(t, room, []string{"hs1"})
+		bob.MustJoinRoom(t, room, []string{"hs1"})
 
 		// Leave the room again, and join the allowed room.
 		bob.MustLeaveRoom(t, room)
-		bob.JoinRoom(t, allowed_room, []string{"hs1"})
+		bob.MustJoinRoom(t, allowed_room, []string{"hs1"})
 	})
 
 	t.Run("Join should fail with mangled join rules", func(t *testing.T) {


### PR DESCRIPTION
Firstly this PR makes the tests work on more implementations, for example ruma and GMS won't really understand `join_authorised_via_users_server` not looking like a user id, similar to what https://github.com/matrix-org/complement/pull/224 tried to do

Making it a user id that isn't correct still makes sure that the server can handle clients updating the member event directly with /myroomnick or similar

Some errors were also silently being ignored, which made it harder to tell which part of the test was actually failing

### Pull Request Checklist

- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
