### PR TITLE
Fix being able to re-use request path parts in `MustDo`/`Do`

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -572,10 +572,11 @@ func (c *CSAPI) MustDo(t ct.TestLike, method string, paths []string, opts ...Req
 //	})
 func (c *CSAPI) Do(t ct.TestLike, method string, paths []string, opts ...RequestOpt) *http.Response {
 	t.Helper()
+	escapedPaths := make([]string, len(paths))
 	for i := range paths {
-		paths[i] = url.PathEscape(paths[i])
+		escapedPaths[i] = url.PathEscape(paths[i])
 	}
-	reqURL := c.BaseURL + "/" + strings.Join(paths, "/")
+	reqURL := c.BaseURL + "/" + strings.Join(escapedPaths, "/")
 	req, err := http.NewRequest(method, reqURL, nil)
 	if err != nil {
 		ct.Fatalf(t, "CSAPI.Do failed to create http.NewRequest: %s", err)


### PR DESCRIPTION
Fix being able to re-use request path parts in `MustDo`/`Do`

Previously, this example wouldn't work:

```go
alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
roomID := alice.MustCreateRoom(t, map[string]interface{}{
	"preset": "public_chat",
})

requestPathParts := []string{"_matrix", "client", "v3", "directory", "list", "room", roomID}
alice.MustDo(t, "GET", requestPathParts)
// 404 because the path is already escaped and will be escaped again
alice.MustDo(t, "GET", requestPathParts)
```

```
    client.go:685: [CSAPI] GET hs1/_matrix/client/v3/directory/list/room/!DolNGvQqgiKnDmimTj:hs1 => 200 OK (3.324405ms)
    client.go:685: [CSAPI] GET hs1/_matrix/client/v3/directory/list/room/%21DolNGvQqgiKnDmimTj:hs1 => 404 Not Found (3.030919ms)
```

### Pull Request Checklist

- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)

Signed-off-by: Eric Eastwood <erice@element.io>
