### PR TITLE
fix: Use `bob.Do` in test `Rejects invalid device keys`

### DIFF
--- a/tests/csapi/upload_keys_test.go
+++ b/tests/csapi/upload_keys_test.go
@@ -66,7 +66,7 @@ func TestUploadKey(t *testing.T) {
 				},
 				"one_time_keys": oneTimeKeys,
 			})
-			resp := bob.MustDo(t, "POST", []string{"_matrix", "client", "v3", "keys", "upload"}, reqBody)
+			resp := bob.Do(t, "POST", []string{"_matrix", "client", "v3", "keys", "upload"}, reqBody)
 			must.MatchResponse(t, resp, match.HTTPResponse{
 				StatusCode: http.StatusBadRequest,
 				JSON: []match.JSON{


### PR DESCRIPTION
It seems that `MustDo` is used incorrectly here, causing the test to fail.

Signed-off-by: Chrislearn Young [chris@acroidea.com](mailto:chris@acroidea.com)