### PR TITLE
Add ServerRoomImpl to allow tests to reuse helpers with custom code

### DIFF
--- a/federation/handle.go
+++ b/federation/handle.go
@@ -59,7 +59,7 @@ func MakeJoinRequestsHandler(s *Server, w http.ResponseWriter, req *http.Request
 // or dealing with HTTP responses itself.
 func MakeRespMakeJoin(s *Server, room *ServerRoom, userID string) (resp fclient.RespMakeJoin, err error) {
 	// Generate a join event
-	proto, err := room.ProtoEventCreator(room, Event{
+	proto, err := room.ProtoEventCreator(Event{
 		Type:     "m.room.member",
 		StateKey: &userID,
 		Content: map[string]interface{}{
@@ -84,7 +84,7 @@ func MakeRespMakeJoin(s *Server, room *ServerRoom, userID string) (resp fclient.
 // or dealing with HTTP responses itself.
 func MakeRespMakeKnock(s *Server, room *ServerRoom, userID string) (resp fclient.RespMakeKnock, err error) {
 	// Generate a knock event
-	proto, err := room.ProtoEventCreator(room, Event{
+	proto, err := room.ProtoEventCreator(Event{
 		Type:     "m.room.member",
 		StateKey: &userID,
 		Content: map[string]interface{}{
@@ -159,40 +159,8 @@ func SendJoinRequestsHandler(s *Server, w http.ResponseWriter, req *http.Request
 		return
 	}
 
-	// build the state list *before* we insert the new event
-	var stateEvents []gomatrixserverlib.PDU
-	room.StateMutex.RLock()
-	for _, ev := range room.State {
-		// filter out non-critical memberships if this is a partial-state join
-		if expectPartialState {
-			if ev.Type() == "m.room.member" && ev.StateKey() != event.StateKey() {
-				continue
-			}
-		}
-		stateEvents = append(stateEvents, ev)
-	}
-	room.StateMutex.RUnlock()
-
-	authEvents := room.AuthChainForEvents(stateEvents)
-
-	// get servers in room *before* the join event
-	serversInRoom := []string{s.serverName}
-	if !omitServersInRoom {
-		serversInRoom = room.ServersInRoom()
-	}
-
-	// insert the join event into the room state
-	room.AddEvent(event)
-	log.Printf("Received send-join of event %s", event.EventID())
-
-	// return state and auth chain
-	b, err := json.Marshal(fclient.RespSendJoin{
-		Origin:         spec.ServerName(s.serverName),
-		AuthEvents:     gomatrixserverlib.NewEventJSONsFromEvents(authEvents),
-		StateEvents:    gomatrixserverlib.NewEventJSONsFromEvents(stateEvents),
-		MembersOmitted: expectPartialState,
-		ServersInRoom:  serversInRoom,
-	})
+	resp := room.GenerateSendJoinResponse(s, event, expectPartialState, omitServersInRoom)
+	b, err := json.Marshal(resp)
 	if err != nil {
 		w.WriteHeader(500)
 		w.Write([]byte("complement: HandleMakeSendJoinRequests send_join cannot marshal RespSendJoin: " + err.Error()))
@@ -396,7 +364,7 @@ func HandleEventAuthRequests() func(*Server) {
 
 			authEvents := room.AuthChainForEvents([]gomatrixserverlib.PDU{event})
 			resp := fclient.RespEventAuth{
-				gomatrixserverlib.NewEventJSONsFromEvents(authEvents),
+				AuthEvents: gomatrixserverlib.NewEventJSONsFromEvents(authEvents),
 			}
 			respJSON, err := json.Marshal(resp)
 			if err != nil {
@@ -576,8 +544,8 @@ func HandleTransactionRequests(pduCallback func(gomatrixserverlib.PDU), eduCallb
 				verImpl, err := gomatrixserverlib.GetRoomVersion(room.Version)
 				if err != nil {
 					log.Printf(
-						"complement: Transaction '%s': Failed to get room version '%s': %s",
-						transaction.TransactionID, event.EventID(), err.Error(),
+						"complement: Transaction '%s': Failed to get room version: %s",
+						transaction.TransactionID, err.Error(),
 					)
 					continue
 				}

--- a/federation/server.go
+++ b/federation/server.go
@@ -303,11 +303,11 @@ func (s *Server) DoFederationRequest(
 // It does not insert this event into the room however. See ServerRoom.AddEvent for that.
 func (s *Server) MustCreateEvent(t ct.TestLike, room *ServerRoom, ev Event) gomatrixserverlib.PDU {
 	t.Helper()
-	proto, err := room.ProtoEventCreator(room, ev)
+	proto, err := room.ProtoEventCreator(ev)
 	if err != nil {
 		ct.Fatalf(t, "MustCreateEvent: failed to create proto event: %v", err)
 	}
-	pdu, err := room.EventCreator(s, room, proto)
+	pdu, err := room.EventCreator(s, proto)
 	if err != nil {
 		ct.Fatalf(t, "MustCreateEvent: failed to create PDU: %v", err)
 	}
@@ -381,12 +381,8 @@ func (s *Server) MustJoinRoom(t ct.TestLike, deployment FederationDeployment, re
 	if err != nil {
 		ct.Fatalf(t, "MustJoinRoom: send_join failed: %v", err)
 	}
-	stateEvents := sendJoinResp.StateEvents.UntrustedEvents(roomVer)
 	room := NewServerRoom(roomVer, roomID)
-	for _, ev := range stateEvents {
-		room.ReplaceCurrentState(ev)
-	}
-	room.AddEvent(joinEvent)
+	room.PopulateFromSendJoinResponse(joinEvent, sendJoinResp)
 	s.rooms[roomID] = room
 
 	t.Logf("Server.MustJoinRoom joined room ID %s", roomID)

--- a/federation/server.go
+++ b/federation/server.go
@@ -303,58 +303,15 @@ func (s *Server) DoFederationRequest(
 // It does not insert this event into the room however. See ServerRoom.AddEvent for that.
 func (s *Server) MustCreateEvent(t ct.TestLike, room *ServerRoom, ev Event) gomatrixserverlib.PDU {
 	t.Helper()
-	content, err := json.Marshal(ev.Content)
+	proto, err := room.ProtoEventCreator(room, ev)
 	if err != nil {
-		ct.Fatalf(t, "MustCreateEvent: failed to marshal event content %s - %+v", err, ev.Content)
+		ct.Fatalf(t, "MustCreateEvent: failed to create proto event: %v", err)
 	}
-	var unsigned []byte
-	if ev.Unsigned != nil {
-		unsigned, err = json.Marshal(ev.Unsigned)
-		if err != nil {
-			ct.Fatalf(t, "MustCreateEvent: failed to marshal event unsigned: %s - %+v", err, ev.Unsigned)
-		}
-	}
-
-	var prevEvents interface{}
-	if ev.PrevEvents != nil {
-		// We deliberately want to set the prev events.
-		prevEvents = ev.PrevEvents
-	} else {
-		// No other prev events were supplied so we'll just
-		// use the forward extremities of the room, which is
-		// the usual behaviour.
-		prevEvents = room.ForwardExtremities
-	}
-	proto := gomatrixserverlib.ProtoEvent{
-		SenderID:   ev.Sender,
-		Depth:      int64(room.Depth + 1), // depth starts at 1
-		Type:       ev.Type,
-		StateKey:   ev.StateKey,
-		Content:    content,
-		RoomID:     room.RoomID,
-		PrevEvents: prevEvents,
-		Unsigned:   unsigned,
-		AuthEvents: ev.AuthEvents,
-		Redacts:    ev.Redacts,
-	}
-	if proto.AuthEvents == nil {
-		var stateNeeded gomatrixserverlib.StateNeeded
-		stateNeeded, err = gomatrixserverlib.StateNeededForProtoEvent(&proto)
-		if err != nil {
-			ct.Fatalf(t, "MustCreateEvent: failed to work out auth_events : %s", err)
-		}
-		proto.AuthEvents = room.AuthEvents(stateNeeded)
-	}
-	verImpl, err := gomatrixserverlib.GetRoomVersion(room.Version)
+	pdu, err := room.EventCreator(s, room, proto)
 	if err != nil {
-		ct.Fatalf(t, "MustCreateEvent: invalid room version: %s", err)
+		ct.Fatalf(t, "MustCreateEvent: failed to create PDU: %v", err)
 	}
-	eb := verImpl.NewEventBuilderFromProtoEvent(&proto)
-	signedEvent, err := eb.Build(time.Now(), spec.ServerName(s.serverName), s.KeyID, s.Priv)
-	if err != nil {
-		ct.Fatalf(t, "MustCreateEvent: failed to sign event: %s", err)
-	}
-	return signedEvent
+	return pdu
 }
 
 // MustJoinRoom will make the server send a make_join and a send_join to join a room


### PR DESCRIPTION
With the addition of https://github.com/matrix-org/complement/pull/765 it's now possible for tests to add a range of good/bad/broken rooms to Complement's internal federation server. However, these rooms cannot reuse any of the existing helper functions. To aid this, logic which was once part of the federation server itself (e.g mapping `/send_join` responses to internal `ServerRoom` state) is now transferred to a new `ServerRoomImpl` interface. The federation server's helper functions call this interface, allowing tests to swap out functions for their broken rooms.

For example, we may want to reuse the very convenient `HandleMakeSendJoinRequests` but modify the join proto event to include malformed fields. Before this PR this simply wasn't possible as we hard-coded the happy case. Tests can now do:
```go
room := federation.NewServerRoom(gomatrixserverlib.RoomVersionV1, "!foo:localhost")
room.ServerRoomImpl = &federation.ServerRoomImplCustom{
	ServerRoomImplDefault: federation.ServerRoomImplDefault{Room: room},
	ProtoEventCreatorFn: func(def federation.ServerRoomImpl, ev federation.Event) (*gomatrixserverlib.ProtoEvent, error) {
		if ev.Type == spec.MRoomMember {
			ev.Unsigned = map[string]any{"something": "custom"}
		}
		return def.ProtoEventCreator(ev)
	},
}
```