### PR TITLE
Allow setting architecture of containers

### DIFF
--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -16,6 +16,15 @@ If 1, always prints the Homeserver container logs even on success. When used wit
 This allows you to override the base image used for a particular named homeserver. For example, `COMPLEMENT_BASE_IMAGE_HS1=complement-dendrite:latest` would use `complement-dendrite:latest` for the `hs1` homeserver in blueprints, but not any other homeserver (e.g `hs2`). This matching is case-insensitive. This allows Complement to test how different homeserver implementations work with each other.  
 - Type: `map[string]string`
 
+#### `COMPLEMENT_BASE_ARCH`
+This allows you to override the architecture of the Docker image to use as a base homeserver when generating blueprints. This can be used to emulate a particular architecture with a multi-platform image. If "", the architecture of the host running Complement is used.
+- Type: `string`
+- Default: ""
+
+#### `COMPLEMENT_BASE_ARCH_*`
+This allows you to set the architecture of the base image used for a particular named homeserver. For example, `COMPLEMENT_BASE_ARCH_HS1=arm64` would use an `arm64` for the `hs1` homeserver in blueprints, but not any other homeserver (e.g `hs2`). This matching is case-insensitive.
+- Type: `map[string]string`
+
 #### `COMPLEMENT_DEBUG`
 If 1, prints out more verbose logging such as HTTP request/response bodies.  
 - Type: `bool`

--- a/b/blueprints.go
+++ b/b/blueprints.go
@@ -55,6 +55,8 @@ type Homeserver struct {
 	ApplicationServices []ApplicationService
 	// Optionally override the baseImageURI for blueprint creation
 	BaseImageURI *string
+	// Optionally override the baseImageArch for blueprint creation
+	BaseImageArch *string
 }
 
 type User struct {

--- a/internal/docker/builder.go
+++ b/internal/docker/builder.go
@@ -398,18 +398,23 @@ func (d *Builder) constructHomeserver(blueprintName string, runner *instruction.
 func (d *Builder) deployBaseImage(blueprintName string, hs b.Homeserver, contextStr, networkName string) (*HomeserverDeployment, error) {
 	asIDToRegistrationMap := asIDToRegistrationFromLabels(labelsForApplicationServices(hs))
 	var baseImageURI string
+	var baseImageArch string
 	if hs.BaseImageURI == nil {
 		baseImageURI = d.Config.BaseImageURI
 		// Use HS specific base image if defined
 		if uri, ok := d.Config.BaseImageURIs[hs.Name]; ok {
 			baseImageURI = uri
 		}
+		if arch, ok := d.Config.BaseImageArchs[hs.Name]; ok {
+			baseImageArch = arch
+		}
 	} else {
 		baseImageURI = *hs.BaseImageURI
+		baseImageArch = *hs.BaseImageArch
 	}
 
 	return deployImage(
-		d.Docker, baseImageURI, fmt.Sprintf("complement_%s", contextStr),
+		d.Docker, baseImageURI, baseImageArch, fmt.Sprintf("complement_%s", contextStr),
 		d.Config.PackageNamespace, blueprintName, hs.Name, asIDToRegistrationMap, contextStr,
 		networkName, d.Config,
 	)


### PR DESCRIPTION
Support creating containers of multi-platform images for an architecture other than that of the host running Complement.

Signed-off-by: Andrew Ferrazzutti <andrewf@element.io>

### Pull Request Checklist

- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)

