### PR TITLE
Don't PublishAllPorts as we already explicitly do :8008/8448

### DIFF
--- a/internal/docker/deployer.go
+++ b/internal/docker/deployer.go
@@ -380,8 +380,7 @@ func deployImage(
 			"complement_hs_name":   hsName,
 		},
 	}, &container.HostConfig{
-		CapAdd:          []string{"NET_ADMIN"}, // TODO : this should be some sort of option
-		PublishAllPorts: true,
+		CapAdd: []string{"NET_ADMIN"}, // TODO : this should be some sort of option
 		PortBindings: nat.PortMap{
 			nat.Port("8008/tcp"): []nat.PortBinding{
 				{


### PR DESCRIPTION
This may break use cases which want extra ports to be exposed. This may fix issues where Complement sporadically decides that there are port conflicts, causing CI flakes.
