### PR TITLE
Fix Complement not using `HSPortBindingIP` (`127.0.0.1`) for the homeserver `BaseURL`

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -106,6 +106,7 @@ type Complement struct {
 	// disable this behaviour being added later, once this has stablised.
 	EnableDirtyRuns bool
 
+	// The hostname that will be used to bind the homeserver ports to, e.g. `127.0.0.1`
 	HSPortBindingIP string
 
 	// Name: COMPLEMENT_POST_TEST_SCRIPT

--- a/config/config.go
+++ b/config/config.go
@@ -106,14 +106,13 @@ type Complement struct {
 	// disable this behaviour being added later, once this has stablised.
 	EnableDirtyRuns bool
 
-	// The IP that will be used to bind the homeserver ports to, e.g. `127.0.0.1`  (only
-	// allow localhost access), `0.0.0.0` (bind to all available interfaces).
+	// The IP that is used to connect to the running homeserver from the host.
 	//
 	// For Complement tests, this is always configured as `127.0.0.1` but can be
 	// overridden by homerunner to allow binding to a different IP address
 	// (`HOMERUNNER_HS_PORTBINDING_IP`).
 	//
-	// This field is also used for the host-accessible homeserver URLs (as the hostname)
+	// This field is used for the host-accessible homeserver URLs (as the hostname)
 	// so clients in your tests can access the homeserver.
 	HSPortBindingIP string
 

--- a/config/config.go
+++ b/config/config.go
@@ -106,7 +106,15 @@ type Complement struct {
 	// disable this behaviour being added later, once this has stablised.
 	EnableDirtyRuns bool
 
-	// The hostname that will be used to bind the homeserver ports to, e.g. `127.0.0.1`
+	// The IP that will be used to bind the homeserver ports to, e.g. `127.0.0.1`  (only
+	// allow localhost access), `0.0.0.0` (bind to all available interfaces).
+	//
+	// For Complement tests, this is always configured as `127.0.0.1` but can be
+	// overridden by homerunner to allow binding to a different IP address
+	// (`HOMERUNNER_HS_PORTBINDING_IP`).
+	//
+	// This field is also used for the host-accessible homeserver URLs (as the hostname)
+	// so clients in your tests can access the homeserver.
 	HSPortBindingIP string
 
 	// Name: COMPLEMENT_POST_TEST_SCRIPT

--- a/internal/docker/builder.go
+++ b/internal/docker/builder.go
@@ -539,7 +539,7 @@ func printPortBindingsOfAllComplementContainers(docker *client.Client, contextSt
 	log.Printf("=============== %s : END ALL COMPLEMENT DOCKER PORT BINDINGS ===============\n\n\n", contextStr)
 }
 
-// Transform the homeserver ports into the base URL and federation base URL.
+// endpoints transforms the homeserver ports into the base URL and federation base URL.
 func endpoints(p nat.PortMap, hsPortBindingIP string, csPort, ssPort int) (baseURL, fedBaseURL string, err error) {
 	csapiPortBinding, err := findPortBinding(p, hsPortBindingIP, csPort)
 	if err != nil {
@@ -555,7 +555,7 @@ func endpoints(p nat.PortMap, hsPortBindingIP string, csPort, ssPort int) (baseU
 	return
 }
 
-// Find a matching port binding for the given host/port in the `nat.PortMap`.
+// findPortBinding finds a matching port binding for the given host/port in the `nat.PortMap`.
 //
 // This function will return the first port binding that matches the given host IP. If a
 // `0.0.0.0` binding is found, we will assume that it is listening on all interfaces,

--- a/internal/docker/builder.go
+++ b/internal/docker/builder.go
@@ -539,6 +539,7 @@ func printPortBindingsOfAllComplementContainers(docker *client.Client, contextSt
 	log.Printf("=============== %s : END ALL COMPLEMENT DOCKER PORT BINDINGS ===============\n\n\n", contextStr)
 }
 
+// Transform the homeserver ports into the base URL and federation base URL.
 func endpoints(p nat.PortMap, hsPortBindingIP string, csPort, ssPort int) (baseURL, fedBaseURL string, err error) {
 	csapiPortBinding, err := findPortBinding(p, hsPortBindingIP, csPort)
 	if err != nil {
@@ -554,7 +555,12 @@ func endpoints(p nat.PortMap, hsPortBindingIP string, csPort, ssPort int) (baseU
 	return
 }
 
-// Find a matching port binding for the given host/port in the nat.PortMap.
+// Find a matching port binding for the given host/port in the `nat.PortMap`.
+//
+// This function will return the first port binding that matches the given host IP. If a
+// `0.0.0.0` binding is found, we will assume that it is listening on all interfaces,
+// including the `hsPortBindingIP`, and return a binding with the `hsPortBindingIP` as
+// the host IP.
 func findPortBinding(p nat.PortMap, hsPortBindingIP string, port int) (portBinding nat.PortBinding, err error) {
 	portString := fmt.Sprintf("%d/tcp", port)
 	portBindings, ok := p[nat.Port(portString)]

--- a/internal/docker/builder.go
+++ b/internal/docker/builder.go
@@ -581,6 +581,13 @@ func findPortBinding(p nat.PortMap, hsPortBindingIP string, port int) (portBindi
 				HostIP:   hsPortBindingIP,
 				HostPort: pb.HostPort,
 			}, nil
+		} else if pb.HostIP == "" && hsPortBindingIP == "127.0.0.1" {
+			// `HostIP` can be empty in certain environments (observed with podman v4.3.1). We
+			// will assume this is only a binding for `127.0.0.1`.
+			return nat.PortBinding{
+				HostIP:   hsPortBindingIP,
+				HostPort: pb.HostPort,
+			}, nil
 		}
 	}
 

--- a/internal/docker/builder.go
+++ b/internal/docker/builder.go
@@ -591,7 +591,7 @@ func findPortBinding(p nat.PortMap, hsPortBindingIP string, port int) (portBindi
 		}
 	}
 
-	return portBindings[0], nil
+	return nat.PortBinding{}, fmt.Errorf("unable to find matching port binding for %s %s: %+v", hsPortBindingIP, portString, p)
 }
 
 type result struct {

--- a/internal/docker/deployer.go
+++ b/internal/docker/deployer.go
@@ -598,7 +598,7 @@ func (e *containerInspectionError) Error() string { return e.msg }
 
 // inspectContainer inspects the container with the given ID and returns response.
 //
-// Returns a `containerInspectionError` representing the underlying error and indicates
+// On failure, returns a `containerInspectionError` representing the underlying error and indicates
 // `err.Fatal: true` if the container is no longer running.
 func inspectContainer(
 	ctx context.Context,

--- a/internal/docker/deployer.go
+++ b/internal/docker/deployer.go
@@ -313,7 +313,7 @@ func (d *Deployer) StartServer(hsDep *HomeserverDeployment) error {
 	}
 
 	// Wait for the container to be ready.
-	err = waitForPorts(ctx, d.Docker, hsDep.ContainerID)
+	err = waitForContainer(ctx, d.Docker, hsDep.ContainerID)
 	if err != nil {
 		return fmt.Errorf("failed to wait for ports on container %s: %s", hsDep.ContainerID, err)
 	}
@@ -455,7 +455,7 @@ func deployImage(
 	}
 
 	// Wait for the container to be ready.
-	err = waitForPorts(ctx, docker, containerID)
+	err = waitForContainer(ctx, docker, containerID)
 	if err != nil {
 		return stubDeployment, fmt.Errorf("%s: failed to wait for ports on container %s: %w", contextStr, containerID, err)
 	}
@@ -564,8 +564,8 @@ func getHostAccessibleHomeserverURLs(ctx context.Context, docker *client.Client,
 	return baseURL, fedBaseURL, nil
 }
 
-// waitForPorts waits until a homeserver container has NAT ports assigned.
-func waitForPorts(ctx context.Context, docker *client.Client, containerID string) (err error) {
+// waitForContainer waits until a homeserver container has NAT ports assigned.
+func waitForContainer(ctx context.Context, docker *client.Client, containerID string) (err error) {
 	// We need to hammer the inspect endpoint until the ports show up, they don't appear immediately.
 	inspectStartTime := time.Now()
 	for time.Since(inspectStartTime) < time.Second {

--- a/internal/docker/deployer.go
+++ b/internal/docker/deployer.go
@@ -313,7 +313,7 @@ func (d *Deployer) StartServer(hsDep *HomeserverDeployment) error {
 	}
 
 	// Wait for the container to be ready.
-	err = waitForPorts(ctx, d.Docker, hsDep.ContainerID)
+	err = waitForPorts(ctx, d.Docker, hsDep.ContainerID, d.config.HSPortBindingIP)
 	if err != nil {
 		return fmt.Errorf("failed to wait for ports on container %s: %s", hsDep.ContainerID, err)
 	}
@@ -455,7 +455,7 @@ func deployImage(
 	}
 
 	// Wait for the container to be ready.
-	err = waitForPorts(ctx, docker, containerID)
+	err = waitForPorts(ctx, docker, containerID, cfg.HSPortBindingIP)
 	if err != nil {
 		return stubDeployment, fmt.Errorf("%s: failed to wait for ports on container %s: %w", contextStr, containerID, err)
 	}

--- a/internal/docker/deployer.go
+++ b/internal/docker/deployer.go
@@ -538,8 +538,8 @@ func assertHostnameEqual(inputUrl string, expectedHostname string) error {
 	return nil
 }
 
-// Returns URLs that are accessible from the host machine (outside the container) for
-// the homeserver's client API and federation API.
+// getHostAccessibleHomeserverURLs returns URLs that are accessible from the host
+// machine (outside the container) for the homeserver's client API and federation API.
 func getHostAccessibleHomeserverURLs(ctx context.Context, docker *client.Client, containerID string, hsPortBindingIP string) (baseURL string, fedBaseURL string, err error) {
 	inspectResponse, err := inspectContainer(ctx, docker, containerID)
 	if err != nil {
@@ -564,7 +564,7 @@ func getHostAccessibleHomeserverURLs(ctx context.Context, docker *client.Client,
 	return baseURL, fedBaseURL, nil
 }
 
-// Waits until a homeserver container has NAT ports assigned.
+// waitForPorts waits until a homeserver container has NAT ports assigned.
 func waitForPorts(ctx context.Context, docker *client.Client, containerID string) (err error) {
 	// We need to hammer the inspect endpoint until the ports show up, they don't appear immediately.
 	inspectStartTime := time.Now()
@@ -619,7 +619,7 @@ func inspectContainer(
 	return inspectResponse, nil
 }
 
-// Waits until a homeserver deployment is ready to serve requests.
+// waitForContainer waits until a homeserver deployment is ready to serve requests.
 func waitForContainer(ctx context.Context, docker *client.Client, hsDep *HomeserverDeployment, stopTime time.Time) (iterCount int, lastErr error) {
 	iterCount = 0
 

--- a/internal/docker/deployer.go
+++ b/internal/docker/deployer.go
@@ -317,7 +317,7 @@ func (d *Deployer) StartServer(hsDep *HomeserverDeployment) error {
 	if err != nil {
 		return fmt.Errorf("failed to wait for ports on container %s: %s", hsDep.ContainerID, err)
 	}
-	baseURL, fedBaseURL, err := getHostAccessibleHomeserverUrls(ctx, d.Docker, hsDep.ContainerID, d.config.HSPortBindingIP)
+	baseURL, fedBaseURL, err := getHostAccessibleHomeserverURLs(ctx, d.Docker, hsDep.ContainerID, d.config.HSPortBindingIP)
 	if err != nil {
 		return fmt.Errorf("failed to get host accessible homeserver URL's from container %s: %s", hsDep.ContainerID, err)
 	}
@@ -450,7 +450,7 @@ func deployImage(
 	if err != nil {
 		return stubDeployment, fmt.Errorf("%s: failed to wait for ports on container %s: %w", contextStr, containerID, err)
 	}
-	baseURL, fedBaseURL, err := getHostAccessibleHomeserverUrls(ctx, docker, containerID, cfg.HSPortBindingIP)
+	baseURL, fedBaseURL, err := getHostAccessibleHomeserverURLs(ctx, docker, containerID, cfg.HSPortBindingIP)
 	if err != nil {
 		return stubDeployment, fmt.Errorf(
 			"%s: failed to get host accessible homeserver URL's from container %s: %s",
@@ -529,9 +529,9 @@ func assertHostnameEqual(inputUrl string, expectedHostname string) error {
 	return nil
 }
 
-// Returns URL's that are accessible from the host machine (outside the container) for
+// Returns URLs that are accessible from the host machine (outside the container) for
 // the homeserver's client API and federation API.
-func getHostAccessibleHomeserverUrls(ctx context.Context, docker *client.Client, containerID string, hsPortBindingIP string) (baseURL string, fedBaseURL string, err error) {
+func getHostAccessibleHomeserverURLs(ctx context.Context, docker *client.Client, containerID string, hsPortBindingIP string) (baseURL string, fedBaseURL string, err error) {
 	inspectResponse, err := inspectPortsOnContainer(ctx, docker, containerID)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to inspect ports: %w", err)
@@ -539,7 +539,7 @@ func getHostAccessibleHomeserverUrls(ctx context.Context, docker *client.Client,
 
 	baseURL, fedBaseURL, err = endpoints(inspectResponse.NetworkSettings.Ports, hsPortBindingIP, 8008, 8448)
 
-	// Sanity check that the URL's match the expected configured binding hostname. It's
+	// Sanity check that the URLs match the expected configured binding hostname. It's
 	// also important that we use the canonical publicly accessible hostname for the
 	// homeserver for some situations like SSO/OIDC login where important cookies are set
 	// for the domain.

--- a/internal/docker/deployer.go
+++ b/internal/docker/deployer.go
@@ -313,7 +313,7 @@ func (d *Deployer) StartServer(hsDep *HomeserverDeployment) error {
 	}
 
 	// Wait for the container to be ready.
-	err = waitForContainer(ctx, d.Docker, hsDep.ContainerID)
+	err = waitForPorts(ctx, d.Docker, hsDep.ContainerID)
 	if err != nil {
 		return fmt.Errorf("failed to wait for ports on container %s: %s", hsDep.ContainerID, err)
 	}
@@ -455,7 +455,7 @@ func deployImage(
 	}
 
 	// Wait for the container to be ready.
-	err = waitForContainer(ctx, docker, containerID)
+	err = waitForPorts(ctx, docker, containerID)
 	if err != nil {
 		return stubDeployment, fmt.Errorf("%s: failed to wait for ports on container %s: %w", contextStr, containerID, err)
 	}
@@ -564,8 +564,8 @@ func getHostAccessibleHomeserverURLs(ctx context.Context, docker *client.Client,
 	return baseURL, fedBaseURL, nil
 }
 
-// waitForContainer waits until a homeserver container has NAT ports assigned.
-func waitForContainer(ctx context.Context, docker *client.Client, containerID string) (err error) {
+// waitForPorts waits until a homeserver container has NAT ports assigned.
+func waitForPorts(ctx context.Context, docker *client.Client, containerID string) (err error) {
 	// We need to hammer the inspect endpoint until the ports show up, they don't appear immediately.
 	inspectStartTime := time.Now()
 	for time.Since(inspectStartTime) < time.Second {

--- a/internal/docker/deployer.go
+++ b/internal/docker/deployer.go
@@ -574,7 +574,7 @@ func waitForPorts(ctx context.Context, docker *client.Client, containerID string
 			break
 		}
 
-		if inspectionErr, ok := err.(*ContainerInspectionError); ok && inspectionErr.Fatal {
+		if inspectionErr, ok := err.(*containerInspectionError); ok && inspectionErr.Fatal {
 			// If the error is fatal, we should not retry.
 			return fmt.Errorf("Fatal inspection error: %s", err)
 		}
@@ -582,7 +582,7 @@ func waitForPorts(ctx context.Context, docker *client.Client, containerID string
 	return nil
 }
 
-type ContainerInspectionError struct {
+type containerInspectionError struct {
 	// Error message
 	msg string
 	// Indicates whether the caller should stop retrying to inspect the container because
@@ -590,11 +590,11 @@ type ContainerInspectionError struct {
 	Fatal bool
 }
 
-func (e *ContainerInspectionError) Error() string { return e.msg }
+func (e *containerInspectionError) Error() string { return e.msg }
 
 // inspectContainer inspects the container with the given ID and returns response.
 //
-// Returns a `ContainerInspectionError` representing the underlying error and indicates
+// Returns a `containerInspectionError` representing the underlying error and indicates
 // `err.Fatal: true` if the container is no longer running.
 func inspectContainer(
 	ctx context.Context,
@@ -603,14 +603,14 @@ func inspectContainer(
 ) (inspectResponse container.InspectResponse, err error) {
 	inspectResponse, err = docker.ContainerInspect(ctx, containerID)
 	if err != nil {
-		return container.InspectResponse{}, &ContainerInspectionError{
+		return container.InspectResponse{}, &containerInspectionError{
 			msg:   err.Error(),
 			Fatal: false,
 		}
 	}
 	if inspectResponse.State != nil && !inspectResponse.State.Running {
 		// the container exited, bail out with a container ID for logs
-		return container.InspectResponse{}, &ContainerInspectionError{
+		return container.InspectResponse{}, &containerInspectionError{
 			msg:   fmt.Sprintf("container (%s) is not running, state=%v", containerID, inspectResponse.State.Status),
 			Fatal: true,
 		}


### PR DESCRIPTION
Fix Complement not using `config.HSPortBindingIP` (`127.0.0.1`) for the homeserver `BaseURL`.

Regressed in https://github.com/matrix-org/complement/pull/776 which started using the Docker default `HostIP` (`0.0.0.0`) because we removed the specific `HSPortBindingIP` port bindings for `8008` and `8448` (see "Root cause" section below).

### Problem

This caused downstream issues in some of our out-of-repo Complement tests (Element internal) which stress some SSO/OIDC login flows with Synapse. 

Before https://github.com/matrix-org/complement/pull/776, [`SsoRedirectServlet`](https://github.com/element-hq/synapse/blob/33ba8860c43d4770ea119a09a4fcbbf366f3b32e/synapse/rest/client/login.py#L645-L683) received a request like this `http://127.0.0.1:8008/_matrix/client/v3/login/sso/redirect/oidc-test_idp?redirectUrl=http%3A%2F%2Fapp.my-fake-client.io%2Fclient-callback`. But now it's seeing `http://0.0.0.0:8008/_matrix/client/v3/login/sso/redirect/oidc-test_idp?redirectUrl=http%3A%2F%2Fapp.my-fake-client.io%2Fclient-callback` and tries to redirect to the canonical `http://127.0.0.1:8008/` address which would then go to the step we expect in the tests (authorization endpoint).

Basically, the `host` header in the request used to be set to `127.0.0.1:8008` but now it's `0.0.0.0:8008`. Synapse wants to use the canonical URL so the cookies are available so it redirects you to the canonical `public_baseurl` version first. Relevant Synapse code that cares about using the canonical URL to get cookies back -> [`SsoRedirectServlet`](https://github.com/element-hq/synapse/blob/33ba8860c43d4770ea119a09a4fcbbf366f3b32e/synapse/rest/client/login.py#L645-L683)

We could alternatively, update our out-of-repo tests to account for this extra redirect but it seems more appropriate to update Complement to use the the configured `HSPortBindingIP` as expected.


### Root cause

The host name used in the requests during the Complement tests is from the `client.BaseURL` which is sourced from the [Docker container port mapping/bindings](https://github.com/matrix-org/complement/blob/28a09014afd1f9c75a3549b4cd9d8fc480ba1149/internal/docker/deployer.go#L521) in Complement.

In https://github.com/matrix-org/complement/pull/776, we removed the explicit port bindings for `8008` with `HSPortBindingIP` ([`127.0.0.1`](https://github.com/matrix-org/complement/blob/28a09014afd1f9c75a3549b4cd9d8fc480ba1149/config/config.go#L180)) so now it uses Docker's default `0.0.0.0`.

```patch
diff --git a/internal/docker/deployer.go b/internal/docker/deployer.go
index cdcf51a5..a186b30d 100644
--- a/internal/docker/deployer.go
+++ b/internal/docker/deployer.go
@@ -382,20 +380,8 @@ func deployImage(
 	}, &container.HostConfig{
 		CapAdd:          []string{"NET_ADMIN"}, // TODO : this should be some sort of option
 		PublishAllPorts: true,
-		PortBindings: nat.PortMap{
-			nat.Port("8008/tcp"): []nat.PortBinding{
-				{
-					HostIP: cfg.HSPortBindingIP,
-				},
-			},
-			nat.Port("8448/tcp"): []nat.PortBinding{
-				{
-					HostIP: cfg.HSPortBindingIP,
-				},
-			},
-		},
```


### Dev notes

#### Locally link Complement package into your tests

See https://thewebivore.com/using-replace-in-go-mod-to-point-to-your-local-module/

So you can edit the Complement source code and use it in the tests.

 1. Add the following to `complement/go.mod`
    ```
    // TODO: Remove as this is only for local development
    replace github.com/matrix-org/complement => /home/eric/Documents/github/element/complement
    ```
 1. `cd complement && go mod tidy && cd ..`
 1. Run Complement how you normally would


### Pull Request Checklist

- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)

