### PR TITLE
Prevent re-interpreting errors if they have placeholder patterns

### DIFF
--- a/ct/test.go
+++ b/ct/test.go
@@ -14,6 +14,7 @@ type TestLike interface {
 	Skipf(msg string, args ...interface{})
 	Error(args ...interface{})
 	Errorf(msg string, args ...interface{})
+	Fatal(msg string)
 	Fatalf(msg string, args ...interface{})
 	Failed() bool
 	Name() string
@@ -27,6 +28,13 @@ func Errorf(t TestLike, format string, args ...any) {
 	t.Helper()
 	format = ansiRedForeground + format + ansiResetForeground
 	t.Errorf(format, args...)
+}
+
+// Fatal is a wrapper around t.Fatal which prints the failing error message in red.
+func Fatal(t TestLike, format string) {
+	t.Helper()
+	format = ansiRedForeground + format + ansiResetForeground
+	t.Fatal(format)
 }
 
 // Fatalf is a wrapper around t.Fatalf which prints the failing error message in red.

--- a/must/must.go
+++ b/must/must.go
@@ -34,7 +34,7 @@ func ParseJSON(t ct.TestLike, b io.ReadCloser) gjson.Result {
 	t.Helper()
 	res, err := should.ParseJSON(b)
 	if err != nil {
-		ct.Fatalf(t, err.Error())
+		ct.Fatal(t, err.Error())
 	}
 	return res
 }
@@ -45,7 +45,7 @@ func MatchRequest(t ct.TestLike, req *http.Request, m match.HTTPRequest) []byte 
 	t.Helper()
 	res, err := should.MatchRequest(req, m)
 	if err != nil {
-		ct.Fatalf(t, err.Error())
+		ct.Fatal(t, err.Error())
 	}
 	return res
 }
@@ -55,7 +55,7 @@ func MatchRequest(t ct.TestLike, req *http.Request, m match.HTTPRequest) []byte 
 func MatchSuccess(t ct.TestLike, res *http.Response) {
 	t.Helper()
 	if err := should.MatchSuccess(res); err != nil {
-		ct.Fatalf(t, err.Error())
+		ct.Fatal(t, err.Error())
 	}
 }
 
@@ -64,7 +64,7 @@ func MatchSuccess(t ct.TestLike, res *http.Response) {
 func MatchFailure(t ct.TestLike, res *http.Response) {
 	t.Helper()
 	if err := should.MatchFailure(res); err != nil {
-		ct.Fatalf(t, err.Error())
+		ct.Fatal(t, err.Error())
 	}
 }
 
@@ -74,7 +74,7 @@ func MatchResponse(t ct.TestLike, res *http.Response, m match.HTTPResponse) []by
 	t.Helper()
 	body, err := should.MatchResponse(res, m)
 	if err != nil {
-		ct.Fatalf(t, err.Error())
+		ct.Fatal(t, err.Error())
 	}
 	return body
 }
@@ -84,7 +84,7 @@ func MatchFederationRequest(t ct.TestLike, fedReq *fclient.FederationRequest, ma
 	t.Helper()
 	err := should.MatchFederationRequest(fedReq)
 	if err != nil {
-		ct.Fatalf(t, err.Error())
+		ct.Fatal(t, err.Error())
 	}
 }
 
@@ -94,7 +94,7 @@ func MatchGJSON(t ct.TestLike, jsonResult gjson.Result, matchers ...match.JSON) 
 	t.Helper()
 	err := should.MatchGJSON(jsonResult, matchers...)
 	if err != nil {
-		ct.Fatalf(t, err.Error())
+		ct.Fatal(t, err.Error())
 	}
 }
 
@@ -104,7 +104,7 @@ func MatchJSONBytes(t ct.TestLike, rawJson []byte, matchers ...match.JSON) {
 	t.Helper()
 	err := should.MatchJSONBytes(rawJson, matchers...)
 	if err != nil {
-		ct.Fatalf(t, err.Error())
+		ct.Fatal(t, err.Error())
 	}
 }
 
@@ -141,7 +141,7 @@ func GetJSONFieldStr(t ct.TestLike, body gjson.Result, wantKey string) string {
 	t.Helper()
 	str, err := should.GetJSONFieldStr(body, wantKey)
 	if err != nil {
-		ct.Fatalf(t, err.Error())
+		ct.Fatal(t, err.Error())
 	}
 	return str
 }
@@ -152,7 +152,7 @@ func HaveInOrder[V comparable](t ct.TestLike, gots []V, wants []V) {
 	t.Helper()
 	err := should.HaveInOrder(gots, wants)
 	if err != nil {
-		ct.Fatalf(t, err.Error())
+		ct.Fatal(t, err.Error())
 	}
 }
 
@@ -163,7 +163,7 @@ func ContainSubset[V comparable](t ct.TestLike, larger []V, smaller []V) {
 	t.Helper()
 	err := should.ContainSubset(larger, smaller)
 	if err != nil {
-		ct.Fatalf(t, err.Error())
+		ct.Fatal(t, err.Error())
 	}
 }
 
@@ -174,7 +174,7 @@ func NotContainSubset[V comparable](t ct.TestLike, larger []V, smaller []V) {
 	t.Helper()
 	err := should.NotContainSubset(larger, smaller)
 	if err != nil {
-		ct.Fatalf(t, err.Error())
+		ct.Fatal(t, err.Error())
 	}
 }
 
@@ -188,7 +188,7 @@ func CheckOffAll(t ct.TestLike, items []interface{}, wantItems []interface{}) {
 	t.Helper()
 	err := should.CheckOffAll(items, wantItems)
 	if err != nil {
-		ct.Fatalf(t, err.Error())
+		ct.Fatal(t, err.Error())
 	}
 }
 
@@ -202,7 +202,7 @@ func CheckOffAllAllowUnwanted(t ct.TestLike, items []interface{}, wantItems []in
 	t.Helper()
 	result, err := should.CheckOffAllAllowUnwanted(items, wantItems)
 	if err != nil {
-		ct.Fatalf(t, err.Error())
+		ct.Fatal(t, err.Error())
 	}
 	return result
 }
@@ -215,7 +215,7 @@ func CheckOff(t ct.TestLike, items []interface{}, wantItem interface{}) []interf
 	t.Helper()
 	result, err := should.CheckOff(items, wantItem)
 	if err != nil {
-		ct.Fatalf(t, err.Error())
+		ct.Fatal(t, err.Error())
 	}
 	return result
 }


### PR DESCRIPTION
In my out-of-tree Complement tests, I was seeing instances of `%!F(MISSING)` appearing in my Complement logs when a matcher failed. It turns out that this was due to things that looked like `printf` placeholders existing in my test data. Specifically, the URL `https://127.0.0.1:6560/oauth2/authorize?response_type=code&amp;client_id=test_idp_client_id&amp;redirect_uri=http%3A%2F%2F127.0.0.1%3A8008%2F_synapse%2Fclient%2Foidc%2Fcallback&amp;scope=read%3Auser` has things like `%3A` and `%2F` in it as there's a url-encoded URL in a query parameter.

When the test failed and Complement went to print this out to me, it ended up re-interpreting the string with `t.Fatalf`, yet providing no arguments for the placeholders. This then results in the `%3A` being replaced by `%!A(MISSING)` as go could not find a corresponding variable.

In this PR, I've replaced calls to `t.Fatalf` that had no argument with `t.Fatal` instead. The result is below.

Before:

```html
my_test.go:336: MatchResponse got status 200 want 302 - http://127.0.0.1:33236/_matrix/client/v3/auth/m.login.sso/fallback/web?session=IZAVpTVdxHUnboGcTiBNnkJf => <!DOCTYPE html>
<!-- snip -->
<a href="https://127.0.0.1:6560/oauth2/authorize?response_type=code&amp;client_id=test_idp_client_id&amp;redirect_uri=http%!A(MISSING)%!F(MISSING)%!F(MISSING)127.0.0.1%!A(MISSING)8008%!F(MISSING)_synapse%!F(MISSING)client%!F(MISSING)oidc%!F(MISSING)callback&amp;scope=read%!A(MISSING)user&amp;state=DUMv68wL2LWVjc3FMMjFECdtUNVtiv&amp;nonce=YxvUxS2iU7NwC32i2XTJ4MOVwhROctDy" class="primary-button">
```

After:

```html
<a href="https://127.0.0.1:6560/oauth2/authorize?response_type=code&amp;client_id=test_idp_client_id&amp;redirect_uri=http%3A%2F%2F127.0.0.1%3A8008%2F_synapse%2Fclient%2Foidc%2Fcallback&amp;scope=read%3Auser&amp;state=Cgc5nQkiLZX4ehOeAeQgFhf4vt9yzs&amp;nonce=gjr8eoj5AHdQ2m5W2N16s7W1yk5YCLsN" class="primary-button">
```

This works in my use case, though I'm not entirely sure if this would affect any other output. Notably, I think one would still have the same issue if they tried to use `must.NotError`, as that requires the use of `ct.Fatalf`. Feedback welcome.


### Pull Request Checklist

- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)

