### PR TITLE
Add tests for rich topic handling (previously MSC3765)

### DIFF
--- a/tests/csapi/apidoc_room_create_test.go
+++ b/tests/csapi/apidoc_room_create_test.go
@@ -86,7 +86,7 @@ func TestRoomCreate(t *testing.T) {
 			// The mime type must be unset or text/plain
 			mime := content.Get("m\\.topic.m\\.text.0.mimetype")
 			if mime.Exists() {
-				must.Equal(t, mime.String(), "text/plain", "no m.topic content block")
+				must.Equal(t, mime.String(), "text/plain", "expected rich topic mimetype to be unset (defaults to text/plain) or explicitly set as text/plain")
 			}
 		})
 		// POST /createRoom makes a room with a topic via initial_state
@@ -143,7 +143,7 @@ func TestRoomCreate(t *testing.T) {
 			// The mime type must be unset or text/plain
 			mime := content.Get("m\\.topic.m\\.text.0.mimetype")
 			if mime.Exists() {
-				must.Equal(t, mime.String(), "text/plain", "no m.topic content block")
+				must.Equal(t, mime.String(), "text/plain", "expected rich topic mimetype to be unset (defaults to text/plain) or explicitly set as text/plain")
 			}
 		})
 		// sytest: POST /createRoom makes a room with a name


### PR DESCRIPTION
Rich topics landed with Matrix 1.15. These tests were broken out from https://github.com/element-hq/synapse/pull/18195/files#r2170245892.

### Pull Request Checklist

- [X] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)

