### PR TITLE
Test that invites can be rescinded over federation

### DIFF
--- a/tests/federation_rooms_invite_test.go
+++ b/tests/federation_rooms_invite_test.go
@@ -156,16 +156,12 @@ func TestFederationRoomsInvite(t *testing.T) {
 				"invite": []string{bob.UserID},
 			})
 			bob.MustSyncUntil(t, client.SyncReq{}, client.SyncInvitedTo(bob.UserID, roomID))
-			resp := alice.Do(t, "POST", []string{"_matrix", "client", "v3", "rooms", roomID, "kick"},
+			alice.MustDo(t, "POST", []string{"_matrix", "client", "v3", "rooms", roomID, "kick"},
 				client.WithJSONBody(t, map[string]interface{}{
 					"user_id": bob.UserID,
 					"reason":  "testing",
 				}),
 			)
-
-			must.MatchResponse(t, resp, match.HTTPResponse{
-				StatusCode: 200,
-			})
 
 			bob.MustSyncUntil(t, client.SyncReq{Filter: includeLeaveSyncFilter}, client.SyncLeftFrom(bob.UserID, roomID))
 		})

--- a/tests/federation_rooms_invite_test.go
+++ b/tests/federation_rooms_invite_test.go
@@ -149,7 +149,7 @@ func TestFederationRoomsInvite(t *testing.T) {
 			alice.MustSyncUntil(t, client.SyncReq{Filter: includeLeaveSyncFilter}, client.SyncLeftFrom(bob2.UserID, roomID))
 		})
 
-		t.Run("Invitee user can rescind invite over federation", func(t *testing.T) {
+		t.Run("Inviter user can rescind invite over federation", func(t *testing.T) {
 			t.Parallel()
 			roomID := alice.MustCreateRoom(t, map[string]interface{}{
 				"preset": "private_chat",


### PR DESCRIPTION
c.f. https://github.com/element-hq/synapse/pull/18823