### PR TITLE
Fix up "Test that invites can be rescinded over federation"

### DIFF
--- a/tests/federation_rooms_invite_test.go
+++ b/tests/federation_rooms_invite_test.go
@@ -168,7 +168,7 @@ func TestFederationRoomsInvite(t *testing.T) {
 			bob.MustSyncUntil(t, client.SyncReq{Filter: includeLeaveSyncFilter}, client.SyncLeftFrom(bob.UserID, roomID))
 		})
 
-		t.Run("Non-invitee user cannot rescind invite over federation", func(t *testing.T) {
+		t.Run("Non-inviter user cannot rescind invite over federation", func(t *testing.T) {
 			t.Parallel()
 
 			// First create a room that Bob is in. This is so that later we can
@@ -193,7 +193,9 @@ func TestFederationRoomsInvite(t *testing.T) {
 			bob.MustSyncUntil(t, client.SyncReq{}, client.SyncInvitedTo(bob.UserID, roomID2))
 
 			// Alice, not the original inviter, kicks bob. This does not result
-			// in bob seeing the rescission.
+			// in bob seeing the rescission. Ideally we would see the
+			// rescission, but currently we have no way to auth that over
+			// federation.
 			alice.MustDo(t, "POST", []string{"_matrix", "client", "v3", "rooms", roomID2, "kick"},
 				client.WithJSONBody(t, map[string]interface{}{
 					"user_id": bob.UserID,

--- a/tests/federation_rooms_invite_test.go
+++ b/tests/federation_rooms_invite_test.go
@@ -20,13 +20,14 @@ import (
 )
 
 func TestFederationRoomsInvite(t *testing.T) {
-	deployment := complement.Deploy(t, 2)
+	deployment := complement.Deploy(t, 3)
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{LocalpartSuffix: "alice"})
 	alice2 := deployment.Register(t, "hs1", helpers.RegistrationOpts{LocalpartSuffix: "alice2"})
 	bob := deployment.Register(t, "hs2", helpers.RegistrationOpts{LocalpartSuffix: "bob"})
 	bob2 := deployment.Register(t, "hs2", helpers.RegistrationOpts{LocalpartSuffix: "bob2"})
+	charlie := deployment.Register(t, "hs3", helpers.RegistrationOpts{LocalpartSuffix: "charlie"})
 
 	includeLeaveSyncFilterBytes, err := json.Marshal(map[string]interface{}{
 		"room": map[string]interface{}{
@@ -190,6 +191,58 @@ func TestFederationRoomsInvite(t *testing.T) {
 			alice2.MustJoinRoom(t, roomID2, []spec.ServerName{})
 
 			alice2.MustInviteRoom(t, roomID2, bob.UserID)
+			bob.MustSyncUntil(t, client.SyncReq{}, client.SyncInvitedTo(bob.UserID, roomID2))
+
+			// Alice, not the original inviter, kicks bob. This does not result
+			// in bob seeing the rescission. Ideally we would see the
+			// rescission, but currently we have no way to auth that over
+			// federation.
+			alice.MustDo(t, "POST", []string{"_matrix", "client", "v3", "rooms", roomID2, "kick"},
+				client.WithJSONBody(t, map[string]interface{}{
+					"user_id": bob.UserID,
+					"reason":  "testing",
+				}),
+			)
+
+			// Check bob *doesn't* see the rescission. We do this by sending a
+			// message in room1 and checking that once Bob receives that message
+			// he still hasn't seen the leave.
+			eventID := alice.SendEventSynced(t, roomID1, b.Event{
+				Type: "m.room.message",
+				Content: map[string]interface{}{
+					"body":    "1",
+					"msgtype": "m.text",
+				},
+				Sender: alice.UserID,
+			})
+			bob.MustSyncUntil(t, client.SyncReq{Since: since}, client.SyncTimelineHasEventID(roomID1, eventID))
+
+			// Check bob is still invited by doing an initial sync
+			bob.MustSyncUntil(t, client.SyncReq{}, client.SyncInvitedTo(bob.UserID, roomID2))
+		})
+
+		t.Run("Non-inviter user cannot rescind invite over federation on different server", func(t *testing.T) {
+			t.Parallel()
+
+			// First create a room that Bob is in. This is so that later we can
+			// send a message to test that Bob doesn't see the rescission.
+			roomID1 := alice.MustCreateRoom(t, map[string]interface{}{
+				"preset": "private_chat",
+				"invite": []string{bob.UserID},
+			})
+			since := bob.MustSyncUntil(t, client.SyncReq{}, client.SyncInvitedTo(bob.UserID, roomID1))
+			bob.MustJoinRoom(t, roomID1, []spec.ServerName{})
+
+			// Second room which Alice and Charlie join, Charlie invites Bob and
+			// then Alice kicks him.
+			roomID2 := alice.MustCreateRoom(t, map[string]interface{}{
+				"preset": "private_chat",
+				"invite": []string{charlie.UserID},
+			})
+			charlie.MustSyncUntil(t, client.SyncReq{}, client.SyncInvitedTo(charlie.UserID, roomID2))
+			charlie.MustJoinRoom(t, roomID2, []spec.ServerName{})
+
+			charlie.MustInviteRoom(t, roomID2, bob.UserID)
 			bob.MustSyncUntil(t, client.SyncReq{}, client.SyncInvitedTo(bob.UserID, roomID2))
 
 			// Alice, not the original inviter, kicks bob. This does not result


### PR DESCRIPTION
Follows on from #797, which I merged Too Soon