### PR TITLE
Use `deployment.GetFullyQualifiedHomeserverName(t, hsName)` helper on `m.room.server_acl` events

### DIFF
--- a/tests/federation_acl_test.go
+++ b/tests/federation_acl_test.go
@@ -59,7 +59,9 @@ func TestACLs(t *testing.T) {
 		Content: map[string]interface{}{
 			"allow":             []string{"*"},
 			"allow_ip_literals": true,
-			"deny":              []string{"hs2"},
+			"deny": []string{
+				string(deployment.GetFullyQualifiedHomeserverName(t, "hs2")),
+			},
 		},
 	})
 	// wait for the ACL to show up on hs2
@@ -111,7 +113,9 @@ func TestACLs(t *testing.T) {
 		content := user.MustGetStateEventContent(t, roomID, "m.room.server_acl", "")
 		must.MatchGJSON(t, content,
 			match.JSONKeyEqual("allow", []string{"*"}),
-			match.JSONKeyEqual("deny", []string{"hs2"}),
+			match.JSONKeyEqual("deny", []string{
+				string(deployment.GetFullyQualifiedHomeserverName(t, "hs2")),
+			}),
 			match.JSONKeyEqual("allow_ip_literals", true),
 		)
 	}


### PR DESCRIPTION
Found a new event that should be using the `deployment.GetFullyQualifiedHomeserverName(t, hsName)` helper -> `m.room.server_acl` events

Follow-up to https://github.com/matrix-org/complement/pull/780

### Pull Request Checklist

- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)

Signed-off-by: Eric Eastwood <erice@element.io>