### PR TITLE
Add require `signatures` field to `/keys/upload` call

### DIFF
--- a/tests/csapi/device_lists_test.go
+++ b/tests/csapi/device_lists_test.go
@@ -49,6 +49,7 @@ func TestDeviceListUpdates(t *testing.T) {
 						ed25519KeyID:    ed25519Key,
 						curve25519KeyID: curve25519Key,
 					},
+					"signatures": map[string]interface{}{},
 				},
 			}),
 		)


### PR DESCRIPTION
This field is required by the spec: https://spec.matrix.org/v1.16/client-server-api/#post_matrixclientv3keysupload

Was causing failing tests on https://github.com/element-hq/synapse/pull/17097.