### PR TITLE
Exclude `.devenv` directory from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ complement
 # For direnv users
 /.envrc
 .direnv/
+
+# devenv users
+.devenv/


### PR DESCRIPTION
Exclude the directory created by [devenv](https://github.com/cachix/devenv) from tracked git changes.