### PR TITLE
Add tests for room creators being able to join v12 room that everyone has left

### DIFF
--- a/tests/v12_test.go
+++ b/tests/v12_test.go
@@ -52,6 +52,26 @@ func TestMSC4289PrivilegedRoomCreators(t *testing.T) {
 		)
 	}
 
+	t.Run("Room creator can re-join room after everyone left", func(t *testing.T) {
+		roomID := alice.MustCreateRoom(t, map[string]interface{}{
+			"room_version": roomVersion12,
+		})
+		alice.MustLeaveRoom(t, roomID)
+		alice.MustJoinRoom(t, roomID, nil)
+	})
+
+	t.Run("Additional room creator can re-join room after everyone left", func(t *testing.T) {
+		roomID := alice.MustCreateRoom(t, map[string]interface{}{
+			"room_version": roomVersion12,
+			"creation_content": map[string]any{
+				"additional_creators": []string{bob.UserID},
+			},
+		})
+		alice.MustLeaveRoom(t, roomID)
+		bob.MustLeaveRoom(t, roomID)
+		bob.MustJoinRoom(t, roomID, nil)
+	})
+
 	t.Run("PL event is missing creator in users map", func(t *testing.T) {
 		roomID := alice.MustCreateRoom(t, map[string]interface{}{
 			"room_version": roomVersion12,


### PR DESCRIPTION
Add tests for room creators being able to join v12 room that everyone has left

Spawning from [discussion](https://matrix.to/#/!SGNQGPGUwtcPBUotTL:matrix.org/$QkN7VrZWE5nzhOaVBKNIezbq7IH9uClddIWLj9jUExs?via=jki.re&via=element.io&via=matrix.org) with @ara4n where we both thought this kind of thing should work.

Both tests fail with Synapse:
```
COMPLEMENT_DIR=../complement ./scripts-dev/complement.sh -p 1 ./tests -run 'TestMSC4289PrivilegedRoomCreators$'
```

:x: `POST http://127.0.0.1:33116/_matrix/client/v3/join/{roomId}` -> `404 Not Found` with `{"errcode":"M_UNKNOWN","error":"Can't join remote room because no servers that are in the room have been provided."}`

---


Refer to [MSC4289](https://github.com/matrix-org/matrix-spec-proposals/pull/4289)

### Pull Request Checklist

- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)

