### PR TITLE
Add a dependabot config to the repo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,75 @@
+# This file is adapted from the same file in element-hq/synapse:
+# https://github.com/element-hq/synapse/blob/2e9b8202f0a1a8ceba9f02bb5ec227498d51dcbd/.github/dependabot.yml
+# But updated to remove `pip` and `cargo` ecosystems, and introduce `gomod`.
+version: 2
+# As dependabot is currently only run on a weekly basis, we raise the
+# open-pull-requests-limit to 10 (from the default of 5) to better ensure we
+# don't continuously grow a backlog of updates.
+updates:
+    package-ecosystem: "gomod"
+    directory: "/"
+    open-pull-requests-limit: 10
+    schedule:
+      interval: "weekly"
+    # Group patch updates to packages together into a single PR, as they rarely
+    # if ever contain breaking changes that need to be reviewed separately.
+    #
+    # Less PRs means a streamlined review process.
+    #
+    # The Go ecosystem is special in that breaking changes are often introduced
+    # in minor version bumps, as packages typically stay pre-1.0 for a long time.
+    # Thus we specifically keep minor version bumps separate in their own PRs.
+    groups:
+      minor-and-patches:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    # Prevent pulling packages that were recently updated to help mitigate
+    # supply chain attacks. 14 days was taken from the recommendation at
+    # https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns
+    # where the author noted that 9/10 attacks would have been mitigated by a
+    # two week cooldown.
+    #
+    # The cooldown only applies to general updates; security updates will still
+    # be pulled in as soon as possible.
+    cooldown:
+      default-days: 14
+
+  - package-ecosystem: "docker"
+    directory: "/complement/cmd/homerunner"
+    open-pull-requests-limit: 10
+    schedule:
+      interval: "weekly"
+    # For container versions, breaking changes are also typically only introduced in major
+    # package bumps.
+    groups:
+      minor-and-patches:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    cooldown:
+      default-days: 14
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    open-pull-requests-limit: 10
+    schedule:
+      interval: "weekly"
+    # Similarly for GitHub Actions, breaking changes are typically only introduced in major
+    # package bumps.
+    groups:
+      minor-and-patches:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    cooldown:
+      default-days: 14

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ version: 2
 # open-pull-requests-limit to 10 (from the default of 5) to better ensure we
 # don't continuously grow a backlog of updates.
 updates:
-    package-ecosystem: "gomod"
+  - package-ecosystem: "gomod"
     directory: "/"
     open-pull-requests-limit: 10
     schedule:


### PR DESCRIPTION
Add a dependabot config adapted from [the one in element-hq/synapse](https://github.com/element-hq/synapse/blob/2e9b8202f0a1a8ceba9f02bb5ec227498d51dcbd/.github/dependabot.yml).

Despite Complement not being a network service, it's still a tool run on sensitive developer machines and in CI. We should aim to keep our dependencies up to date.

Note: You've likely [already seen dependabot updates on this repo](https://github.com/matrix-org/complement/pull/846). By default, dependabot will generate *security* updates. No config file required. If you want generic *version* updates however, then you'll need a config file.

Keeping up to date on our dependencies is generally desirable, especially as many other repos are now installing Complement into their own repositories (for in-repo tests).

### Pull Request Checklist

- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)

Signed-off-by: Andrew Morgan (andrew@element.io)
