### PR TITLE
feat: support for room v11

### DIFF
--- a/federation/server_room.go
+++ b/federation/server_room.go
@@ -333,15 +333,20 @@ func InitialRoomEvents(roomVer gomatrixserverlib.RoomVersion, creator string) []
 			Type:     "m.room.create",
 			StateKey: b.Ptr(""),
 			Sender:   creator,
-			Content: map[string]interface{}{
-				"creator":      creator,
-				"room_version": roomVer,
-				// We have to add randomness to the create event, else if you create 2x v12+ rooms in the same millisecond
-				// they will get the same room ID, clobbering internal data structures and causing extremely confusing
-				// behaviour. By adding this entropy, we ensure that even if rooms are created in the same millisecond, their
-				// hashes will not be the same.
-				"complement_entropy": util.RandomString(18),
-			},
+			Content: func() map[string]interface{} {
+				content := map[string]interface{}{
+					"room_version": roomVer,
+					// We have to add randomness to the create event, else if you create 2x v12+ rooms in the same millisecond
+					// they will get the same room ID, clobbering internal data structures and causing extremely confusing
+					// behaviour. By adding this entropy, we ensure that even if rooms are created in the same millisecond, their
+					// hashes will not be the same.
+					"complement_entropy": util.RandomString(18),
+				}
+				if gomatrixserverlib.MustGetRoomVersion(gomatrixserverlib.RoomVersion(roomVer)).CreatorInCreateEvent() {
+					content["creator"] = creator
+				}
+				return content
+			}(),
 		},
 		{
 			Type:     "m.room.member",

--- a/federation/server_room.go
+++ b/federation/server_room.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"strconv"
 	"sync"
 	"time"
 
@@ -333,15 +334,22 @@ func InitialRoomEvents(roomVer gomatrixserverlib.RoomVersion, creator string) []
 			Type:     "m.room.create",
 			StateKey: b.Ptr(""),
 			Sender:   creator,
-			Content: map[string]interface{}{
-				"creator":      creator,
-				"room_version": roomVer,
-				// We have to add randomness to the create event, else if you create 2x v12+ rooms in the same millisecond
-				// they will get the same room ID, clobbering internal data structures and causing extremely confusing
-				// behaviour. By adding this entropy, we ensure that even if rooms are created in the same millisecond, their
-				// hashes will not be the same.
-				"complement_entropy": util.RandomString(18),
-			},
+			Content: func() map[string]interface{} {
+				content := map[string]interface{}{
+					"room_version": roomVer,
+					// We have to add randomness to the create event, else if you create 2x v12+ rooms in the same millisecond
+					// they will get the same room ID, clobbering internal data structures and causing extremely confusing
+					// behaviour. By adding this entropy, we ensure that even if rooms are created in the same millisecond, their
+					// hashes will not be the same.
+					"complement_entropy": util.RandomString(18),
+				}
+				// The creator field was removed in room version 11 (MSC4239).
+				n, err := strconv.Atoi(string(roomVer))
+				if err != nil || n < 11 {
+					content["creator"] = creator
+				}
+				return content
+			}(),
 		},
 		{
 			Type:     "m.room.member",

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/docker/go-connections v0.4.0
 	github.com/gorilla/mux v1.8.0
 	github.com/matrix-org/gomatrix v0.0.0-20220926102614-ceba4d9f7530
-	github.com/matrix-org/gomatrixserverlib v0.0.0-20250813150445-9f5070a65744
+	github.com/matrix-org/gomatrixserverlib v0.0.0-20260506075950-c9c468727353
 	github.com/matrix-org/util v0.0.0-20221111132719-399730281e66
 	github.com/sirupsen/logrus v1.9.3
 	github.com/tidwall/gjson v1.18.0

--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,8 @@ github.com/matrix-org/gomatrix v0.0.0-20220926102614-ceba4d9f7530 h1:kHKxCOLcHH8
 github.com/matrix-org/gomatrix v0.0.0-20220926102614-ceba4d9f7530/go.mod h1:/gBX06Kw0exX1HrwmoBibFA98yBk/jxKpGVeyQbff+s=
 github.com/matrix-org/gomatrixserverlib v0.0.0-20250813150445-9f5070a65744 h1:5GvC2FD9O/PhuyY95iJQdNYHbDioEhMWdeMP9maDUL8=
 github.com/matrix-org/gomatrixserverlib v0.0.0-20250813150445-9f5070a65744/go.mod h1:b6KVfDjXjA5Q7vhpOaMqIhFYvu5BuFVZixlNeTV/CLc=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20260506075950-c9c468727353 h1:BdGU/8sF4ZaqGhfYN+eFEzc/whU4LpKvEDdM6i0Oqqs=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20260506075950-c9c468727353/go.mod h1:b6KVfDjXjA5Q7vhpOaMqIhFYvu5BuFVZixlNeTV/CLc=
 github.com/matrix-org/util v0.0.0-20221111132719-399730281e66 h1:6z4KxomXSIGWqhHcfzExgkH3Z3UkIXry4ibJS4Aqz2Y=
 github.com/matrix-org/util v0.0.0-20221111132719-399730281e66/go.mod h1:iBI1foelCqA09JJgPV0FYz4qA5dUXYOxMi57FxKBdd4=
 github.com/miekg/dns v1.1.66 h1:FeZXOS3VCVsKnEAd+wBkjMC3D2K+ww66Cq3VnCINuJE=

--- a/tests/csapi/rooms_state_test.go
+++ b/tests/csapi/rooms_state_test.go
@@ -4,7 +4,6 @@
 package csapi_tests
 
 import (
-	"strconv"
 	"testing"
 	"time"
 
@@ -16,6 +15,7 @@ import (
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
+	"github.com/matrix-org/gomatrixserverlib"
 )
 
 func TestRoomCreationReportsEventsToMyself(t *testing.T) {
@@ -28,7 +28,6 @@ func TestRoomCreationReportsEventsToMyself(t *testing.T) {
 		Password:        "bobpassword",
 	})
 	defaultVer := alice.GetDefaultRoomVersion(t)
-	defaultVerN, _ := strconv.Atoi(string(defaultVer))
 	roomID := alice.MustCreateRoom(t, map[string]interface{}{})
 
 	t.Run("parallel", func(t *testing.T) {
@@ -42,7 +41,7 @@ func TestRoomCreationReportsEventsToMyself(t *testing.T) {
 				}
 				must.Equal(t, ev.Get("sender").Str, alice.UserID, "wrong sender")
 				// The creator field was removed in room version 11 (MSC4239).
-				if defaultVerN < 11 {
+				if gomatrixserverlib.MustGetRoomVersion(defaultVer).CreatorInCreateEvent() {
 					must.Equal(t, ev.Get("content").Get("creator").Str, alice.UserID, "wrong content.creator")
 				}
 				return true

--- a/tests/csapi/rooms_state_test.go
+++ b/tests/csapi/rooms_state_test.go
@@ -4,6 +4,7 @@
 package csapi_tests
 
 import (
+	"strconv"
 	"testing"
 	"time"
 
@@ -26,6 +27,8 @@ func TestRoomCreationReportsEventsToMyself(t *testing.T) {
 		LocalpartSuffix: "bob",
 		Password:        "bobpassword",
 	})
+	defaultVer := alice.GetDefaultRoomVersion(t)
+	defaultVerN, _ := strconv.Atoi(string(defaultVer))
 	roomID := alice.MustCreateRoom(t, map[string]interface{}{})
 
 	t.Run("parallel", func(t *testing.T) {
@@ -38,7 +41,10 @@ func TestRoomCreationReportsEventsToMyself(t *testing.T) {
 					return false
 				}
 				must.Equal(t, ev.Get("sender").Str, alice.UserID, "wrong sender")
-				must.Equal(t, ev.Get("content").Get("creator").Str, alice.UserID, "wrong content.creator")
+				// The creator field was removed in room version 11 (MSC4239).
+				if defaultVerN < 11 {
+					must.Equal(t, ev.Get("content").Get("creator").Str, alice.UserID, "wrong content.creator")
+				}
 				return true
 			}))
 		})

--- a/tests/federation_room_get_missing_events_test.go
+++ b/tests/federation_room_get_missing_events_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -497,6 +498,22 @@ func TestOutboundFederationEventSizeGetMissingEvents(t *testing.T) {
 	}).Methods("POST")
 
 	ver := alice.GetDefaultRoomVersion(t)
+	// This test crafts a "bad" event which state_key is 280 bytes but only 70
+	// codepoints.
+	//
+	// Room version 11 in Synapse switched from using codepoints to using
+	// bytes. Which means the 280-byte state_key would be rejected immediately.
+	// Use room version 10 in that case so the codepoint-based limit is in effect.
+	//
+	// Since upgrading a room (for example from v10 to v11) won't carry the event
+	// (a new room is created), we don't have to worry about v10 room events in a v11
+	// room.
+	//
+	// So this test is essentially skipped for any default room v11 or higher.
+	verNum, _ := strconv.Atoi(string(ver))
+	if verNum >= 11 {
+		ver = gomatrixserverlib.RoomVersion("10")
+	}
 	charlie := srv.UserID("charlie")
 	room := srv.MustMakeRoom(t, ver, federation.InitialRoomEvents(ver, charlie))
 	roomAlias := srv.MakeAliasMapping("flibble", room.RoomID)

--- a/tests/federation_room_get_missing_events_test.go
+++ b/tests/federation_room_get_missing_events_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -510,8 +509,7 @@ func TestOutboundFederationEventSizeGetMissingEvents(t *testing.T) {
 	// room.
 	//
 	// So this test is essentially skipped for any default room v11 or higher.
-	verNum, _ := strconv.Atoi(string(ver))
-	if verNum >= 11 {
+	if gomatrixserverlib.MustGetRoomVersion(ver).StrictEventByteLimits() {
 		ver = gomatrixserverlib.RoomVersion("10")
 	}
 	charlie := srv.UserID("charlie")

--- a/tests/federation_room_get_missing_events_test.go
+++ b/tests/federation_room_get_missing_events_test.go
@@ -504,11 +504,6 @@ func TestOutboundFederationEventSizeGetMissingEvents(t *testing.T) {
 	// bytes. Which means the 280-byte state_key would be rejected immediately.
 	// Use room version 10 in that case so the codepoint-based limit is in effect.
 	//
-	// Since upgrading a room (for example from v10 to v11) won't carry the event
-	// (a new room is created), we don't have to worry about v10 room events in a v11
-	// room.
-	//
-	// So this test is essentially skipped for any default room v11 or higher.
 	if gomatrixserverlib.MustGetRoomVersion(ver).StrictEventByteLimits() {
 		ver = gomatrixserverlib.RoomVersion("10")
 	}


### PR DESCRIPTION
- Rooms v11 and above don't have the `creator` field anymore during room creation, which broke the tests.
- Synapse changed the way it counted the `state_key` length in events (from codepoints to bytes) at room v11, which broke the tests.

This PR fixes those issues, making complement work with room v11 as default.

Related to https://github.com/element-hq/synapse/pull/18680