### PR TITLE
De-flake TestPartialStateJoin/Outgoing_device_list_updates/Device_list_updates_reach_all_servers_in_partial_state_rooms

### DIFF
--- a/federation/handle.go
+++ b/federation/handle.go
@@ -568,6 +568,8 @@ func HandleTransactionRequests(pduCallback func(gomatrixserverlib.PDU), eduCallb
 				// Add this PDU as a success to the response
 				response.PDUs[event.EventID()] = fclient.PDUResult{}
 
+				/////// <--- Interrupted
+
 				// Run the PDU callback function with this event
 				if pduCallback != nil {
 					pduCallback(event)

--- a/tests/msc3902/federation_room_join_partial_state_test.go
+++ b/tests/msc3902/federation_room_join_partial_state_test.go
@@ -128,6 +128,10 @@ func (s *server) WithWaitForLeave(
 	t *testing.T, room *federation.ServerRoom, userID string, leaveAction func(),
 ) {
 	leaveChannel := make(chan gomatrixserverlib.PDU, 10)
+
+	// Register a PDU handler to make it so that we 'expect' the leave event
+	// Without this PDU handler being registered, the test fails upon encountering
+	// the unexpected leave event.
 	removePDUHandler := s.AddPDUHandler(
 		func(e gomatrixserverlib.PDU) bool {
 			if membership, _ := e.Membership(); e.Type() == "m.room.member" &&
@@ -141,23 +145,33 @@ func (s *server) WithWaitForLeave(
 	)
 	defer removePDUHandler()
 
+	// HAZARD: Check state _before_ triggering the `leaveAction`.
+	//
+	// If we trigger the `leaveAction` first, it's possible for the leave to proceed quickly enough that
+	// the current state gets updated _before_ we start waiting for the PDU handler to fire,
+	// leading us to remove the PDU handler and trigger the 'unhandled PDU' test failure.
+	memberEvent := room.CurrentState("m.room.member", userID)
+	if memberEvent == nil {
+		// NOTE: despite the test server not having a view of the membership yet, the
+		// `TestPartialStateJoin/Outgoing_device_list_updates/Device_list_updates_reach_newly_joined_servers_in_partial_state_rooms`
+		// test still relies on the `leaveAction` being triggered here.
+		t.Logf("WithWaitForLeave: %s has no membership in room %s, from the perspective of %s.", userID, room.RoomID, s.ServerName())
+	} else {
+		membership, _ := memberEvent.Membership()
+		if membership == "leave" {
+			t.Logf("WithWaitForLeave: %s has already left test room %s, from the perspective of %s.", userID, room.RoomID, s.ServerName())
+			return
+		}
+	}
+
 	leaveAction()
 
-	memberEvent := room.CurrentState("m.room.member", userID)
-	membership := ""
-	if memberEvent != nil {
-		membership, _ = memberEvent.Membership()
-	}
-	if membership == "leave" {
-		t.Logf("%s has already seen %s leave test room %s.", s.ServerName(), userID, room.RoomID)
-	} else {
-		select {
-		case <-leaveChannel:
-			t.Logf("%s saw %s leave test room %s.", s.ServerName(), userID, room.RoomID)
-			break
-		case <-time.After(1 * time.Second):
-			t.Errorf("%s timed out waiting for %s to leave test room %s.", s.ServerName(), userID, room.RoomID)
-		}
+	select {
+	case <-leaveChannel:
+		t.Logf("%s saw %s leave test room %s.", s.ServerName(), userID, room.RoomID)
+		break
+	case <-time.After(1 * time.Second):
+		t.Errorf("%s timed out waiting for %s to leave test room %s.", s.ServerName(), userID, room.RoomID)
 	}
 }
 
@@ -2232,7 +2246,7 @@ func TestPartialStateJoin(t *testing.T) {
 
 		// test that device list updates are sent to the remote homeservers listed in the
 		// `/send_join` response in a room with partial state.
-		t.Run("Device list updates reach all servers in partial state rooms", func(t *testing.T) {
+		t.Run("Device list updates reach all servers in partial state rooms", func(t *testing.T) { // FAILS
 			alice, server1, server2, deviceListUpdateChannel1, deviceListUpdateChannel2, room, cleanup := setupOutgoingDeviceListUpdateTest(t, deployment, "t23alice")
 			defer cleanup()
 


### PR DESCRIPTION
Relevant log excerpt:

```
##[group][0;31m❌ TestPartialStateJoin[0;37m (5m31.91s)[0m
2026/04/14 14:59:37 Sharing [SERVER_NAME=hs1 SYNAPSE_WORKER_TYPES= SYNAPSE_LOG_TESTING=1 SYNAPSE_COMPLEMENT_USE_WORKERS=true SYNAPSE_COMPLEMENT_DATABASE=postgres] host environment variables with container
##[endgroup]

##[group][0;31m❌ TestPartialStateJoin/Outgoing_device_list_updates[0;37m (43.43s)[0m
##[endgroup]

##[group][0;31m❌ TestPartialStateJoin/Outgoing_device_list_updates/Device_list_updates_reach_all_servers_in_partial_state_rooms[0;37m (2.91s)[0m
client.go:860: [CSAPI] POST hs1/_matrix/client/v3/register => 200 OK (45.64605ms)
client.go:860: [CSAPI] GET hs1/_matrix/client/v3/capabilities => 200 OK (5.257425ms)
server.go:210: Creating room !0-kUVViXDbt5jK1ZLeyD:host.docker.internal:40461 with version 10
2026/04/14 15:03:14 Received send-join of event $FydKVRA6ZZ8JXTKeKzKhapBvI8GDgqTSecRfXetOng4
federation_room_join_partial_state_test.go:2241: Server.MustJoinRoom joined room ID !0-kUVViXDbt5jK1ZLeyD:host.docker.internal:40461
federation_room_join_partial_state_test.go:4499: Registered state_ids handler for event $FydKVRA6ZZ8JXTKeKzKhapBvI8GDgqTSecRfXetOng4
federation_room_join_partial_state_test.go:4540: Registered /state handler for event $FydKVRA6ZZ8JXTKeKzKhapBvI8GDgqTSecRfXetOng4
2026/04/14 15:03:14 Received send-join of event $qmW_FthIQ5V2AObNLda7mtEZQkHaWV7_uhlSm6JcI3c
federation_room_join_partial_state_test.go:4478: Incoming state_ids request for event [$FydKVRA6ZZ8JXTKeKzKhapBvI8GDgqTSecRfXetOng4] in room !0-kUVViXDbt5jK1ZLeyD:host.docker.internal:40461
client.go:860: [CSAPI] POST hs1/_matrix/client/v3/join/!0-kUVViXDbt5jK1ZLeyD:host.docker.internal:40461 => 200 OK (221.443899ms)
federation_room_join_partial_state_test.go:4393: /join request completed
client.go:860: [CSAPI] PUT hs1/_matrix/client/v3/devices/ODEVNAPXUT => 200 OK (32.073627ms)
federation_room_join_partial_state_test.go:2255: @user-32-t23alice:hs1 sent device list update.
federation_room_join_partial_state_test.go:2156: Complement server received m.device_list_update: {"device_display_name":"A new device name 1","device_id":"ODEVNAPXUT","prev_id":[],"stream_id":36,"user_id":"@user-32-t23alice:hs1"}
federation_room_join_partial_state_test.go:2156: Complement server received m.device_list_update: {"device_display_name":"A new device name 1","device_id":"ODEVNAPXUT","prev_id":[],"stream_id":36,"user_id":"@user-32-t23alice:hs1"}
federation_room_join_partial_state_test.go:2258: @charlie, @derek and @elsie received device list update.
federation_room_join_partial_state_test.go:4485: Replying to /state_ids request for event [$FydKVRA6ZZ8JXTKeKzKhapBvI8GDgqTSecRfXetOng4]
federation_room_join_partial_state_test.go:4518: Incoming state request for event [$FydKVRA6ZZ8JXTKeKzKhapBvI8GDgqTSecRfXetOng4] in room !0-kUVViXDbt5jK1ZLeyD:host.docker.internal:40461
federation_room_join_partial_state_test.go:4526: Replying to /state request for event [$FydKVRA6ZZ8JXTKeKzKhapBvI8GDgqTSecRfXetOng4]
client.go:860: [CSAPI] GET hs1/_matrix/client/v3/rooms/!0-kUVViXDbt5jK1ZLeyD:host.docker.internal:40461/members => 200 OK (395.5475ms)
federation_room_join_partial_state_test.go:2262: @user-32-t23alice:hs1's partial state join to !0-kUVViXDbt5jK1ZLeyD:host.docker.internal:40461 completed.
client.go:860: [CSAPI] PUT hs1/_matrix/client/v3/devices/ODEVNAPXUT => 200 OK (18.581802ms)
federation_room_join_partial_state_test.go:2265: @user-32-t23alice:hs1 sent device list update.
federation_room_join_partial_state_test.go:2156: Complement server received m.device_list_update: {"device_display_name":"A new device name 2","device_id":"ODEVNAPXUT","prev_id":[36],"stream_id":38,"user_id":"@user-32-t23alice:hs1"}
federation_room_join_partial_state_test.go:2156: Complement server received m.device_list_update: {"device_display_name":"A new device name 2","device_id":"ODEVNAPXUT","prev_id":[36],"stream_id":38,"user_id":"@user-32-t23alice:hs1"}
federation_room_join_partial_state_test.go:2268: @charlie, @derek and @elsie received device list update.
federation_room_join_partial_state_test.go:4416: Cleaning up after test...
client.go:860: [CSAPI] GET hs1/_matrix/client/v3/rooms/!0-kUVViXDbt5jK1ZLeyD:host.docker.internal:40461/members => 200 OK (4.730351ms)
federation_room_join_partial_state_test.go:4418: @user-32-t23alice:hs1's partial state join to !0-kUVViXDbt5jK1ZLeyD:host.docker.internal:40461 completed.
client.go:860: [CSAPI] POST hs1/_matrix/client/v3/rooms/!0-kUVViXDbt5jK1ZLeyD:host.docker.internal:40461/leave => 200 OK (87.453123ms)
federation_room_join_partial_state_test.go:156: host.docker.internal:40461 saw @user-32-t23alice:hs1 leave test room !0-kUVViXDbt5jK1ZLeyD:host.docker.internal:40461.
federation_room_join_partial_state_test.go:152: host.docker.internal:35905 has already seen @user-32-t23alice:hs1 leave test room !0-kUVViXDbt5jK1ZLeyD:host.docker.internal:40461.
federation_room_join_partial_state_test.go:77: Received unexpected PDU: {"auth_events":["$1rCrkHRZDs36OPehqF2phl0eNpppMibhlhMFX_9Twf0","$h4mh1gIqih3pgcQ4I6W9yV1Smr6_trpnL9L7-s9EKiM","$qmW_FthIQ5V2AObNLda7mtEZQkHaWV7_uhlSm6JcI3c"],"content":{"membership":"leave"},"depth":8,"hashes":{"sha256":"sGb84db/guiaHDC8tqd9YnXGn3h0/DHwOnEh8uDpFpc"},"origin_server_ts":1776178995326,"prev_events":["$qmW_FthIQ5V2AObNLda7mtEZQkHaWV7_uhlSm6JcI3c"],"room_id":"!0-kUVViXDbt5jK1ZLeyD:host.docker.internal:40461","sender":"@user-32-t23alice:hs1","signatures":{"hs1":{"ed25519:a_WVdX":"Rb4MyehfVuIAG8b6rU8yjCtFwUHKU2m508JhA94rUNp3+tgxBj6ZLlMghdw+dmYWHebtr1HamI2PY/w3/ouUAg"}},"state_key":"@user-32-t23alice:hs1","type":"m.room.member"}
##[endgroup]
```

### Pull Request Checklist

- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)

