### PR TITLE
Fix state not showing up fast enough with `TestDelayedEvents`

### DIFF
--- a/tests/msc4140/delayed_event_test.go
+++ b/tests/msc4140/delayed_event_test.go
@@ -371,6 +371,11 @@ func TestDelayedEvents(t *testing.T) {
 
 		numberOfDelayedEvents := 0
 
+		// Start a sync loop (initial sync)
+		since := user.MustSyncUntil(
+			t, client.SyncReq{},
+		)
+
 		// Send an initial delayed event that will be ready to send as soon as the server
 		// comes back up.
 		user.MustDo(
@@ -440,7 +445,9 @@ func TestDelayedEvents(t *testing.T) {
 		remainingDelayedEventCount := countDelayedEvents(t, delayedEventResponse)
 		// Sanity check that the room state was updated correctly with the delayed events
 		// that were sent.
-		user.MustDo(t, "GET", getPathForState(roomID, eventType, stateKey1))
+		since = user.MustSyncUntil(t, client.SyncReq{Since: since}, client.SyncStateHas(roomID, func(ev gjson.Result) bool {
+			return ev.Get("type").Str == eventType && ev.Get("state_key").Str == stateKey1
+		}))
 
 		// Wait until we see another delayed event being sent (ensure things resumed and are continuing).
 		time.Sleep(10 * time.Second)
@@ -452,7 +459,9 @@ func TestDelayedEvents(t *testing.T) {
 		// FIXME: Ideally, we'd check specifically for the last one that was sent but it
 		// will be a bit of a juggle and fiddly to get this right so for now we just check
 		// one.
-		user.MustDo(t, "GET", getPathForState(roomID, eventType, stateKey2))
+		since = user.MustSyncUntil(t, client.SyncReq{Since: since}, client.SyncStateHas(roomID, func(ev gjson.Result) bool {
+			return ev.Get("type").Str == eventType && ev.Get("state_key").Str == stateKey2
+		}))
 	})
 }
 


### PR DESCRIPTION
Fix state not showing up fast enough with `TestDelayedEvents`.

Follow-up to https://github.com/matrix-org/complement/pull/830

As experienced when running this test against the worker-based Synapse setup we use alongside the Synapse Pro Rust apps, https://github.com/element-hq/synapse-rust-apps/actions/runs/24910122124/job/72949760158?pr=360 (https://github.com/element-hq/synapse-rust-apps/pull/360)

```
❌ TestDelayedEvents/delayed_state_events_are_kept_on_server_restart (10.12s)
      delayed_event_test.go:425: StopServer hs1
      delayed_event_test.go:429: StartServer hs1
      delayed_event_test.go:443: CSAPI.MustDo GET http://127.0.0.1:32978/_matrix/client/v3/rooms/%21MbDncghrqxTzEmQhCP:hs1/state/com.example.test/1 returned non-2xx code: 404 Not Found - body: {"errcode":"M_NOT_FOUND","error":"Event not found."}
```

### Why does this happen?

Discussed in https://github.com/matrix-org/complement/pull/865#discussion_r3140459243

### Dev notes

MSC4140 Synapse implementation added in https://github.com/element-hq/synapse/pull/17326

### Pull Request Checklist

- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)

