### PR TITLE
Revert "Fix state not showing up fast enough with `TestDelayedEvents` (#865)"

### DIFF
--- a/tests/msc4140/delayed_event_test.go
+++ b/tests/msc4140/delayed_event_test.go
@@ -371,11 +371,6 @@ func TestDelayedEvents(t *testing.T) {
 
 		numberOfDelayedEvents := 0
 
-		// Start a sync loop (initial sync)
-		since := user.MustSyncUntil(
-			t, client.SyncReq{},
-		)
-
 		// Send an initial delayed event that will be ready to send as soon as the server
 		// comes back up.
 		user.MustDo(
@@ -445,9 +440,7 @@ func TestDelayedEvents(t *testing.T) {
 		remainingDelayedEventCount := countDelayedEvents(t, delayedEventResponse)
 		// Sanity check that the room state was updated correctly with the delayed events
 		// that were sent.
-		since = user.MustSyncUntil(t, client.SyncReq{Since: since}, client.SyncStateHas(roomID, func(ev gjson.Result) bool {
-			return ev.Get("type").Str == eventType && ev.Get("state_key").Str == stateKey1
-		}))
+		user.MustDo(t, "GET", getPathForState(roomID, eventType, stateKey1))
 
 		// Wait until we see another delayed event being sent (ensure things resumed and are continuing).
 		time.Sleep(10 * time.Second)
@@ -459,9 +452,7 @@ func TestDelayedEvents(t *testing.T) {
 		// FIXME: Ideally, we'd check specifically for the last one that was sent but it
 		// will be a bit of a juggle and fiddly to get this right so for now we just check
 		// one.
-		since = user.MustSyncUntil(t, client.SyncReq{Since: since}, client.SyncStateHas(roomID, func(ev gjson.Result) bool {
-			return ev.Get("type").Str == eventType && ev.Get("state_key").Str == stateKey2
-		}))
+		user.MustDo(t, "GET", getPathForState(roomID, eventType, stateKey2))
 	})
 }
 


### PR DESCRIPTION
Revert https://github.com/matrix-org/complement/pull/865 as I jumped the gun after I got approval.

The test doesn't actually pass yet which was a possible outcome since I said:

> I haven't actually checked whether this PR fixes the problem there (just theory)


### Dev notes

```
COMPLEMENT_DIR=../complement ./scripts-dev/complement.sh -run TestDelayedEvents/delayed_state_events_are_kept_on_server_restart
...
=== RUN   TestDelayedEvents
2026/04/28 10:41:12 Sharing [SERVER_NAME=hs1 SYNAPSE_LOG_TESTING=1 SYNAPSE_COMPLEMENT_USE_WORKERS= SYNAPSE_COMPLEMENT_DATABASE=sqlite] host environment variables with container
    client.go:860: [CSAPI] POST hs1/_matrix/client/v3/register => 200 OK (119.846655ms)
    client.go:860: [CSAPI] POST hs1/_matrix/client/v3/register => 200 OK (109.988701ms)
    client.go:860: [CSAPI] POST hs1/_matrix/client/v3/createRoom => 200 OK (399.343873ms)
    client.go:860: [CSAPI] POST hs1/_matrix/client/v3/join/!eFHFYeCzmVnzXjRzkc:hs1 => 200 OK (168.784729ms)
=== RUN   TestDelayedEvents/delayed_state_events_are_kept_on_server_restart
=== NAME  TestDelayedEvents
    client.go:860: [CSAPI] GET hs1/_matrix/client/v3/sync => 200 OK (68.962216ms)
    client.go:860: [CSAPI] PUT hs1/_matrix/client/v3/rooms/!eFHFYeCzmVnzXjRzkc:hs1/state/com.example.test/1 => 200 OK (10.306259ms)
    client.go:860: [CSAPI] PUT hs1/_matrix/client/v3/rooms/!eFHFYeCzmVnzXjRzkc:hs1/state/com.example.test/2 => 200 OK (10.009426ms)
    client.go:860: [CSAPI] PUT hs1/_matrix/client/v3/rooms/!eFHFYeCzmVnzXjRzkc:hs1/state/com.example.test/3 => 200 OK (10.216832ms)
    client.go:860: [CSAPI] PUT hs1/_matrix/client/v3/rooms/!eFHFYeCzmVnzXjRzkc:hs1/state/com.example.test/4 => 200 OK (9.972808ms)
    client.go:860: [CSAPI] PUT hs1/_matrix/client/v3/rooms/!eFHFYeCzmVnzXjRzkc:hs1/state/com.example.test/5 => 200 OK (9.828299ms)
    client.go:860: [CSAPI] GET hs1/_matrix/client/unstable/org.matrix.msc4140/delayed_events => 200 OK (1.037622ms)
=== NAME  TestDelayedEvents/delayed_state_events_are_kept_on_server_restart
    delayed_event_test.go:430: StopServer hs1
    delayed_event_test.go:434: StartServer hs1
=== NAME  TestDelayedEvents
    client.go:860: [CSAPI] GET hs1/_matrix/client/unstable/org.matrix.msc4140/delayed_events => 200 OK (4.170123ms)
    client.go:860: [CSAPI] GET hs1/_matrix/client/v3/sync => 200 OK (9.541304ms)
    client.go:860: [CSAPI] GET hs1/_matrix/client/v3/sync => 200 OK (1.004062489s)
    client.go:860: [CSAPI] GET hs1/_matrix/client/v3/sync => 200 OK (261.778698ms)
    client.go:860: [CSAPI] GET hs1/_matrix/client/v3/sync => 200 OK (1.003701897s)
    client.go:860: [CSAPI] GET hs1/_matrix/client/v3/sync => 200 OK (1.00386416s)
    client.go:860: [CSAPI] GET hs1/_matrix/client/v3/sync => 200 OK (1.00362875s)
    client.go:860: [CSAPI] GET hs1/_matrix/client/v3/sync => 200 OK (1.004212426s)
=== NAME  TestDelayedEvents/delayed_state_events_are_kept_on_server_restart
    delayed_event_test.go:448: @user-1:hs1 MustSyncUntil: timed out after 5.291597479s. Seen 7 /sync responses. Checkers:
        [t=9.62996ms] Response #1: SyncStateHas(!eFHFYeCzmVnzXjRzkc:hs1): check function did not pass while iterating over 0 elements: []
        [t=1.013801461s] Response #2: SyncStateHas(!eFHFYeCzmVnzXjRzkc:hs1): Key rooms.join.!eFHFYeCzmVnzXjRzkc:hs1.state.events does not exist
        [t=1.275687059s] Response #3: SyncStateHas(!eFHFYeCzmVnzXjRzkc:hs1): check function did not pass while iterating over 0 elements: []
        [t=2.279498379s] Response #4: SyncStateHas(!eFHFYeCzmVnzXjRzkc:hs1): Key rooms.join.!eFHFYeCzmVnzXjRzkc:hs1.state.events does not exist
        [t=3.283492931s] Response #5: SyncStateHas(!eFHFYeCzmVnzXjRzkc:hs1): Key rooms.join.!eFHFYeCzmVnzXjRzkc:hs1.state.events does not exist
        [t=4.287246344s] Response #6: SyncStateHas(!eFHFYeCzmVnzXjRzkc:hs1): Key rooms.join.!eFHFYeCzmVnzXjRzkc:hs1.state.events does not exist
        [t=5.291595926s] Response #7: SyncStateHas(!eFHFYeCzmVnzXjRzkc:hs1): Key rooms.join.!eFHFYeCzmVnzXjRzkc:hs1.state.events does not exist, 
        
=== NAME  TestDelayedEvents
    client.go:860: [CSAPI] GET hs1/_matrix/client/unstable/org.matrix.msc4140/delayed_events => 200 OK (1.128721ms)
    client.go:860: [CSAPI] POST hs1/_matrix/client/unstable/org.matrix.msc4140/delayed_events/syd_BUeEAMZqVUiMQVHcbrHb/cancel => 200 OK (10.199249ms)
    client.go:860: [CSAPI] POST hs1/_matrix/client/unstable/org.matrix.msc4140/delayed_events/syd_DygPoWaFlRLIKGqZGVtg/cancel => 200 OK (10.216842ms)
    client.go:860: [CSAPI] POST hs1/_matrix/client/unstable/org.matrix.msc4140/delayed_events/syd_EtLNMMaTpNdUJRKjxWqW/cancel => 200 OK (10.909402ms)
    client.go:860: [CSAPI] GET hs1/_matrix/client/unstable/org.matrix.msc4140/delayed_events => 200 OK (912.018µs)
...
--- FAIL: TestDelayedEvents (22.52s)
    --- FAIL: TestDelayedEvents/delayed_state_events_are_kept_on_server_restart (14.18s)
FAIL
FAIL    github.com/matrix-org/complement/tests/msc4140  23.589s
FAIL
```


### Pull Request Checklist

- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)

