### PR TITLE
Fix state not showing up fast enough with `TestDelayedEvents` (de-flake v2)

### DIFF
--- a/client/sync.go
+++ b/client/sync.go
@@ -215,10 +215,11 @@ func SyncTimelineHasEventID(roomID string, eventID string) SyncCheckOpt {
 	})
 }
 
-// Check that the state section for `roomID` has an event which passes the check function.
-// Note that the state section of a sync response only contains the change in state up to the start
-// of the timeline and will not contain the entire state of the room for incremental or
-// `lazy_load_members` syncs.
+// Check that the `state` section for `roomID` has an event which passes the check function.
+//
+// Note that the `state` section of a sync response only contains the change in state up
+// to the start of the `timeline` and will not contain the entire state of the room for
+// incremental or `lazy_load_members` syncs.
 func SyncStateHas(roomID string, check func(gjson.Result) bool) SyncCheckOpt {
 	return func(clientUserID string, topLevelSyncJSON gjson.Result) error {
 		err := checkArrayElements(

--- a/tests/msc4140/delayed_event_test.go
+++ b/tests/msc4140/delayed_event_test.go
@@ -445,7 +445,7 @@ func TestDelayedEvents(t *testing.T) {
 		remainingDelayedEventCount := countDelayedEvents(t, delayedEventResponse)
 		// Sanity check that the room state was updated correctly with the delayed events
 		// that were sent.
-		since = user.MustSyncUntil(t, client.SyncReq{Since: since}, client.SyncStateHas(roomID, func(ev gjson.Result) bool {
+		since = user.MustSyncUntil(t, client.SyncReq{Since: since}, client.SyncTimelineHas(roomID, func(ev gjson.Result) bool {
 			return ev.Get("type").Str == eventType && ev.Get("state_key").Str == stateKey1
 		}))
 
@@ -459,7 +459,7 @@ func TestDelayedEvents(t *testing.T) {
 		// FIXME: Ideally, we'd check specifically for the last one that was sent but it
 		// will be a bit of a juggle and fiddly to get this right so for now we just check
 		// one.
-		since = user.MustSyncUntil(t, client.SyncReq{Since: since}, client.SyncStateHas(roomID, func(ev gjson.Result) bool {
+		since = user.MustSyncUntil(t, client.SyncReq{Since: since}, client.SyncTimelineHas(roomID, func(ev gjson.Result) bool {
 			return ev.Get("type").Str == eventType && ev.Get("state_key").Str == stateKey2
 		}))
 	})

--- a/tests/msc4140/delayed_event_test.go
+++ b/tests/msc4140/delayed_event_test.go
@@ -371,6 +371,11 @@ func TestDelayedEvents(t *testing.T) {
 
 		numberOfDelayedEvents := 0
 
+		// Start a sync loop (initial sync)
+		since := user.MustSyncUntil(
+			t, client.SyncReq{},
+		)
+
 		// Send an initial delayed event that will be ready to send as soon as the server
 		// comes back up.
 		user.MustDo(
@@ -440,7 +445,9 @@ func TestDelayedEvents(t *testing.T) {
 		remainingDelayedEventCount := countDelayedEvents(t, delayedEventResponse)
 		// Sanity check that the room state was updated correctly with the delayed events
 		// that were sent.
-		user.MustDo(t, "GET", getPathForState(roomID, eventType, stateKey1))
+		since = user.MustSyncUntil(t, client.SyncReq{Since: since}, client.SyncStateHas(roomID, func(ev gjson.Result) bool {
+			return ev.Get("type").Str == eventType && ev.Get("state_key").Str == stateKey1
+		}))
 
 		// Wait until we see another delayed event being sent (ensure things resumed and are continuing).
 		time.Sleep(10 * time.Second)
@@ -452,7 +459,9 @@ func TestDelayedEvents(t *testing.T) {
 		// FIXME: Ideally, we'd check specifically for the last one that was sent but it
 		// will be a bit of a juggle and fiddly to get this right so for now we just check
 		// one.
-		user.MustDo(t, "GET", getPathForState(roomID, eventType, stateKey2))
+		since = user.MustSyncUntil(t, client.SyncReq{Since: since}, client.SyncStateHas(roomID, func(ev gjson.Result) bool {
+			return ev.Get("type").Str == eventType && ev.Get("state_key").Str == stateKey2
+		}))
 	})
 }
 

--- a/tests/msc4140/delayed_event_test.go
+++ b/tests/msc4140/delayed_event_test.go
@@ -192,7 +192,8 @@ func TestDelayedEvents(t *testing.T) {
 		// Wait one second which will cause the delayed state event to be sent
 		time.Sleep(1 * time.Second)
 
-		// Check for the state change from the delayed state event
+		// Check for the state change from the delayed state event (using `MustSyncUntil` to
+		// account for any processing or worker replication delays)
 		user.MustSyncUntil(t, client.SyncReq{Filter: NoTimelineSyncFilter}, client.SyncStateHas(roomID, func(ev gjson.Result) bool {
 			return ev.Get("type").Str == eventType && ev.Get("state_key").Str == stateKey
 		}))
@@ -256,6 +257,7 @@ func TestDelayedEvents(t *testing.T) {
 
 		stateKey := "to_never_send"
 
+		// Schedule a delayed event
 		setterKey := "setter"
 		setterExpected := "none"
 		res = user.MustDo(
@@ -269,22 +271,33 @@ func TestDelayedEvents(t *testing.T) {
 		)
 		delayID := client.GetJSONFieldStr(t, client.ParseJSON(t, res), "delay_id")
 
+		// Wait a bit but not long enough for the delayed state event to be sent
 		time.Sleep(1 * time.Second)
+		// We should still see the scheduled delayed event (hasn't been sent yet)
 		matchDelayedEvents(t, user, delayedEventsNumberEqual(1))
+
+		// Sanity check that the room state hasn't changed
 		res = user.Do(t, "GET", getPathForState(roomID, eventType, stateKey))
 		must.MatchResponse(t, res, match.HTTPResponse{
 			StatusCode: 404,
 		})
 
+		// Cancel the delayed event
 		unauthedClient.MustDo(
 			t,
 			"POST",
 			getPathForUpdateDelayedEvent(delayID, DelayedEventActionCancel),
 			client.WithJSONBody(t, map[string]interface{}{}),
 		)
+		// No more delayed events
 		matchDelayedEvents(t, user, delayedEventsNumberEqual(0))
 
+		// Sanity check that the previously scheduled delayed event doesn't end up being sent anyway
+		//
+		// Wait another second which would cause the previously scheduled delayed to be sent
+		// as we've waited a total of 2s now (> 1.5s delay)
 		time.Sleep(1 * time.Second)
+		// Sanity check that the room state hasn't changed
 		res = user.Do(t, "GET", getPathForState(roomID, eventType, stateKey))
 		must.MatchResponse(t, res, match.HTTPResponse{
 			StatusCode: 404,
@@ -298,6 +311,7 @@ func TestDelayedEvents(t *testing.T) {
 
 		stateKey := "to_send_on_request"
 
+		// Schedule a delayed event
 		setterKey := "setter"
 		setterExpected := "on_send"
 		res = user.MustDo(
@@ -311,26 +325,39 @@ func TestDelayedEvents(t *testing.T) {
 		)
 		delayID := client.GetJSONFieldStr(t, client.ParseJSON(t, res), "delay_id")
 
+		// Wait a bit but not long enough for the delayed state event to be sent
 		time.Sleep(1 * time.Second)
+		// We should still see the scheduled delayed event (hasn't been sent yet)
 		matchDelayedEvents(t, user, delayedEventsNumberEqual(1))
+
+		// Sanity check that the room state hasn't changed yet
 		res = user.Do(t, "GET", getPathForState(roomID, eventType, stateKey))
 		must.MatchResponse(t, res, match.HTTPResponse{
 			StatusCode: 404,
 		})
 
+		// Force the delayed event to be sent immediately
 		unauthedClient.MustDo(
 			t,
 			"POST",
 			getPathForUpdateDelayedEvent(delayID, DelayedEventActionSend),
 			client.WithJSONBody(t, map[string]interface{}{}),
 		)
-		matchDelayedEvents(t, user, delayedEventsNumberEqual(0))
-		res = user.Do(t, "GET", getPathForState(roomID, eventType, stateKey))
+
+		// Check for the state change from the delayed state event (using `MustSyncUntil` to
+		// account for any processing or worker replication delays)
+		user.MustSyncUntil(t, client.SyncReq{Filter: NoTimelineSyncFilter}, client.SyncStateHas(roomID, func(ev gjson.Result) bool {
+			return ev.Get("type").Str == eventType && ev.Get("state_key").Str == stateKey
+		}))
+		// Make sure the state looks as expected after
+		res = user.MustDo(t, "GET", getPathForState(roomID, eventType, stateKey))
 		must.MatchResponse(t, res, match.HTTPResponse{
 			JSON: []match.JSON{
 				match.JSONKeyEqual(setterKey, setterExpected),
 			},
 		})
+		// No more delayed events
+		matchDelayedEvents(t, user, delayedEventsNumberEqual(0))
 	})
 
 	t.Run("delayed state events can be restarted", func(t *testing.T) {
@@ -340,6 +367,7 @@ func TestDelayedEvents(t *testing.T) {
 
 		defer cleanupDelayedEvents(t, user)
 
+		// Schedule a delayed event
 		setterKey := "setter"
 		setterExpected := "on_timeout"
 		res = user.MustDo(
@@ -353,13 +381,18 @@ func TestDelayedEvents(t *testing.T) {
 		)
 		delayID := client.GetJSONFieldStr(t, client.ParseJSON(t, res), "delay_id")
 
+		// Wait a bit but not long enough for the delayed state event to be sent
 		time.Sleep(1 * time.Second)
+		// We should still see the scheduled delayed event (hasn't been sent yet)
 		matchDelayedEvents(t, user, delayedEventsNumberEqual(1))
+
+		// Sanity check that the room state hasn't changed yet
 		res = user.Do(t, "GET", getPathForState(roomID, eventType, stateKey))
 		must.MatchResponse(t, res, match.HTTPResponse{
 			StatusCode: 404,
 		})
 
+		// Restart the timer on the delayed event
 		unauthedClient.MustDo(
 			t,
 			"POST",
@@ -367,21 +400,37 @@ func TestDelayedEvents(t *testing.T) {
 			client.WithJSONBody(t, map[string]interface{}{}),
 		)
 
+		// Wait a bit but not long enough for the delayed state event to be sent
 		time.Sleep(1 * time.Second)
+		// We should still see the scheduled delayed event (hasn't been sent yet)
 		matchDelayedEvents(t, user, delayedEventsNumberEqual(1))
+
+		// Sanity check that the room state hasn't changed yet
 		res = user.Do(t, "GET", getPathForState(roomID, eventType, stateKey))
 		must.MatchResponse(t, res, match.HTTPResponse{
 			StatusCode: 404,
 		})
 
+		// Wait one second which will cause the delayed state event to be sent
 		time.Sleep(1 * time.Second)
-		matchDelayedEvents(t, user, delayedEventsNumberEqual(0))
+		
+		// Wait one second which will cause the delayed state event to be sent
+		time.Sleep(1 * time.Second)
+
+		// Check for the state change from the delayed state event (using `MustSyncUntil` to
+		// account for any processing or worker replication delays)
+		user.MustSyncUntil(t, client.SyncReq{Filter: NoTimelineSyncFilter}, client.SyncStateHas(roomID, func(ev gjson.Result) bool {
+			return ev.Get("type").Str == eventType && ev.Get("state_key").Str == stateKey
+		}))
+		// Make sure the state looks as expected after
 		res = user.MustDo(t, "GET", getPathForState(roomID, eventType, stateKey))
 		must.MatchResponse(t, res, match.HTTPResponse{
 			JSON: []match.JSON{
 				match.JSONKeyEqual(setterKey, setterExpected),
 			},
 		})
+		// No more delayed events
+		matchDelayedEvents(t, user, delayedEventsNumberEqual(0))
 	})
 
 	t.Run("delayed state events are kept on server restart", func(t *testing.T) {
@@ -463,7 +512,8 @@ func TestDelayedEvents(t *testing.T) {
 		// Capture whatever number of delayed events are remaining after the server restart.
 		remainingDelayedEventCount := countDelayedEvents(t, delayedEventResponse)
 		// Sanity check that the room state was updated correctly with the delayed events
-		// that were sent.
+		// that were sent. (using `MustSyncUntil` to account for any processing or worker
+		// replication delays)
 		user.MustSyncUntil(t, client.SyncReq{Filter: NoTimelineSyncFilter}, client.SyncStateHas(roomID, func(ev gjson.Result) bool {
 			return ev.Get("type").Str == eventType && ev.Get("state_key").Str == stateKey1
 		}))
@@ -474,6 +524,8 @@ func TestDelayedEvents(t *testing.T) {
 			delayedEventsNumberLessThan(remainingDelayedEventCount),
 		)
 		// Sanity check that the other delayed events also updated the room state correctly.
+		// (using `MustSyncUntil` to account for any processing or worker replication
+		// delays)
 		//
 		// FIXME: Ideally, we'd check specifically for the last one that was sent but it
 		// will be a bit of a juggle and fiddly to get this right so for now we just check
@@ -605,6 +657,8 @@ func matchDelayedEvents(t *testing.T, user *client.CSAPI, checks ...delayedEvent
 	)
 }
 
+// FIXME: Instead of using `cleanupDelayedEvents`, each test should just use their own
+// room
 func cleanupDelayedEvents(t *testing.T, user *client.CSAPI) {
 	t.Helper()
 	res := getDelayedEvents(t, user)

--- a/tests/msc4140/delayed_event_test.go
+++ b/tests/msc4140/delayed_event_test.go
@@ -72,6 +72,7 @@ func TestDelayedEvents(t *testing.T) {
 		})
 	})
 
+	// FIXME: Too much mixing of tests that should be more independent
 	t.Run("delayed message events are sent on timeout", func(t *testing.T) {
 		var res *http.Response
 		var countExpected uint64

--- a/tests/msc4140/delayed_event_test.go
+++ b/tests/msc4140/delayed_event_test.go
@@ -30,6 +30,16 @@ const (
 	DelayedEventActionSend    = "send"
 )
 
+// A filter for `/sync` that excludes timeline events.
+//
+// This is useful if you want to see `state` in the `/sync` response without the pesky
+// de-duplication with `timeline` that traditional `/sync` does.
+const NoTimelineSyncFilter = `{
+		"room": {
+			"timeline": { "limit": 0 }
+	}
+}`
+
 // TODO: Test pagination of `GET /_matrix/client/v1/delayed_events` once
 // it is implemented in a homeserver.
 
@@ -371,11 +381,6 @@ func TestDelayedEvents(t *testing.T) {
 
 		numberOfDelayedEvents := 0
 
-		// Start a sync loop (initial sync)
-		since := user.MustSyncUntil(
-			t, client.SyncReq{},
-		)
-
 		// Send an initial delayed event that will be ready to send as soon as the server
 		// comes back up.
 		user.MustDo(
@@ -445,7 +450,7 @@ func TestDelayedEvents(t *testing.T) {
 		remainingDelayedEventCount := countDelayedEvents(t, delayedEventResponse)
 		// Sanity check that the room state was updated correctly with the delayed events
 		// that were sent.
-		since = user.MustSyncUntil(t, client.SyncReq{Since: since}, client.SyncTimelineHas(roomID, func(ev gjson.Result) bool {
+		user.MustSyncUntil(t, client.SyncReq{Filter: NoTimelineSyncFilter}, client.SyncStateHas(roomID, func(ev gjson.Result) bool {
 			return ev.Get("type").Str == eventType && ev.Get("state_key").Str == stateKey1
 		}))
 
@@ -459,7 +464,7 @@ func TestDelayedEvents(t *testing.T) {
 		// FIXME: Ideally, we'd check specifically for the last one that was sent but it
 		// will be a bit of a juggle and fiddly to get this right so for now we just check
 		// one.
-		since = user.MustSyncUntil(t, client.SyncReq{Since: since}, client.SyncTimelineHas(roomID, func(ev gjson.Result) bool {
+		user.MustSyncUntil(t, client.SyncReq{Filter: NoTimelineSyncFilter}, client.SyncStateHas(roomID, func(ev gjson.Result) bool {
 			return ev.Get("type").Str == eventType && ev.Get("state_key").Str == stateKey2
 		}))
 	})

--- a/tests/msc4140/delayed_event_test.go
+++ b/tests/msc4140/delayed_event_test.go
@@ -149,6 +149,7 @@ func TestDelayedEvents(t *testing.T) {
 
 		stateKey := "to_send_on_timeout"
 
+		// Schedule a delayed event
 		setterKey := "setter"
 		setterExpected := "on_timeout"
 		user.MustDo(
@@ -161,8 +162,11 @@ func TestDelayedEvents(t *testing.T) {
 			getDelayQueryParam("900"),
 		)
 
+		// Ensure that a delayed event is now scheduled
 		matchDelayedEvents(t, user, delayedEventsNumberEqual(1))
-
+		// And includes the correct content
+		//
+		// FIXME: This assertion seems superfluous to this test and should be it's own test
 		res = getDelayedEvents(t, user)
 		must.MatchResponse(t, res, match.HTTPResponse{
 			JSON: []match.JSON{
@@ -178,19 +182,29 @@ func TestDelayedEvents(t *testing.T) {
 				}),
 			},
 		})
+
+		// Sanity check that the room state hasn't changed yet
 		res = user.Do(t, "GET", getPathForState(roomID, eventType, stateKey))
 		must.MatchResponse(t, res, match.HTTPResponse{
 			StatusCode: 404,
 		})
 
+		// Wait one second which will cause the delayed state event to be sent
 		time.Sleep(1 * time.Second)
-		matchDelayedEvents(t, user, delayedEventsNumberEqual(0))
+
+		// Check for the state change from the delayed state event
+		user.MustSyncUntil(t, client.SyncReq{Filter: NoTimelineSyncFilter}, client.SyncStateHas(roomID, func(ev gjson.Result) bool {
+			return ev.Get("type").Str == eventType && ev.Get("state_key").Str == stateKey
+		}))
+		// Make sure the state looks as expected after
 		res = user.MustDo(t, "GET", getPathForState(roomID, eventType, stateKey))
 		must.MatchResponse(t, res, match.HTTPResponse{
 			JSON: []match.JSON{
 				match.JSONKeyEqual(setterKey, setterExpected),
 			},
 		})
+		// No more delayed events
+		matchDelayedEvents(t, user, delayedEventsNumberEqual(0))
 	})
 
 	t.Run("cannot update a delayed event without an action", func(t *testing.T) {

--- a/tests/msc4140/delayed_event_test.go
+++ b/tests/msc4140/delayed_event_test.go
@@ -414,9 +414,6 @@ func TestDelayedEvents(t *testing.T) {
 
 		// Wait one second which will cause the delayed state event to be sent
 		time.Sleep(1 * time.Second)
-		
-		// Wait one second which will cause the delayed state event to be sent
-		time.Sleep(1 * time.Second)
 
 		// Check for the state change from the delayed state event (using `MustSyncUntil` to
 		// account for any processing or worker replication delays)


### PR DESCRIPTION
Fix state not showing up fast enough with `TestDelayedEvents` (de-flake tests)

Re-introducing the changes from https://github.com/matrix-org/complement/pull/865 which were reverted in https://github.com/matrix-org/complement/pull/867

Follow-up to https://github.com/matrix-org/complement/pull/830

As experienced when running this test against the worker-based Synapse setup we use alongside the Synapse Pro Rust apps, https://github.com/element-hq/synapse-rust-apps/actions/runs/24910122124/job/72949760158?pr=360 (https://github.com/element-hq/synapse-rust-apps/pull/360)

```
❌ TestDelayedEvents/delayed_state_events_are_kept_on_server_restart (10.12s)
      delayed_event_test.go:425: StopServer hs1
      delayed_event_test.go:429: StartServer hs1
      delayed_event_test.go:443: CSAPI.MustDo GET http://127.0.0.1:32978/_matrix/client/v3/rooms/%21MbDncghrqxTzEmQhCP:hs1/state/com.example.test/1 returned non-2xx code: 404 Not Found - body: {"errcode":"M_NOT_FOUND","error":"Event not found."}
```

Also updating the rest of the `TestDelayedEvents` tests to better account for state changes that might not show up immediately because processing/worker/replication delay

### Why does this flake happen?

Discussed in https://github.com/matrix-org/complement/pull/865#discussion_r3140459243

### Dev notes

MSC4140 Synapse implementation added in https://github.com/element-hq/synapse/pull/17326


Testing with Synapse:

```
COMPLEMENT_DIR=../complement ./scripts-dev/complement.sh -run TestDelayedEvents
```


### Pull Request Checklist

- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)

