### PR TITLE
`TestJumpToDateEndpoint`: Guard the parallel boundary subtests against millisecond collisions.

### DIFF
--- a/tests/room_timestamp_to_event_test.go
+++ b/tests/room_timestamp_to_event_test.go
@@ -131,6 +131,7 @@ func TestJumpToDateEndpoint(t *testing.T) {
 		t.Run("should not be able to query a private room you are not a member of", func(t *testing.T) {
 			t.Parallel()
 			timeBeforeRoomCreation := time.Now()
+			time.Sleep(tsBoundaryGuard)
 
 			// Alice will create the private room
 			roomID := alice.MustCreateRoom(t, map[string]interface{}{
@@ -159,6 +160,7 @@ func TestJumpToDateEndpoint(t *testing.T) {
 		t.Run("should not be able to query a public room you are not a member of", func(t *testing.T) {
 			t.Parallel()
 			timeBeforeRoomCreation := time.Now()
+			time.Sleep(tsBoundaryGuard)
 
 			// Alice will create the public room
 			roomID := alice.MustCreateRoom(t, map[string]interface{}{
@@ -205,6 +207,7 @@ func TestJumpToDateEndpoint(t *testing.T) {
 			t.Run("when looking backwards before the room was created, should be able to find event that was imported", func(t *testing.T) {
 				t.Parallel()
 				timeBeforeRoomCreation := time.Now()
+				time.Sleep(tsBoundaryGuard)
 				roomID, _, _ := createTestRoom(t, alice)
 
 				// Join from the application service bridge user so we can use it to send
@@ -349,15 +352,14 @@ type eventTime struct {
 	AfterTimestamp  time.Time
 }
 
-// tsBoundaryGuard is the pause inserted around each time.Now() sample in this
-// file's helpers and subtests so that no homeserver-stamped origin_server_ts
-// can collide with the sample at millisecond granularity. /timestamp_to_event
-// returns the boundary event inclusively (forward picks the earliest event
-// with ts >= query, backward picks the latest with ts <= query), so a shared
-// millisecond between sample and event lets the wrong event win the boundary.
-// time.Sleep pauses for at least its argument, and adding a whole millisecond
-// to a timestamp always carries it into the next millisecond bucket, so 1ms is
-// enough to separate the sample from every event stamped after the pause.
+// tsBoundaryGuard is a pause inserted around (before and after) where we create events
+// so that `time.Now()` samples and subsequent event `origin_server_ts` don't collide at
+// the same millisecond granularity. /timestamp_to_event returns the boundary event
+// inclusively (forward picks the earliest event with ts >= query, backward picks the
+// latest with ts <= query), so a shared millisecond between events means the wrong
+// event can be picked. Adding one whole millisecond to a timestamp always carries it
+// into the next millisecond bucket, so 1ms is enough to separate the sample from every
+// event stamped after the pause.
 const tsBoundaryGuard = 1 * time.Millisecond
 
 func createTestRoom(t *testing.T, c *client.CSAPI) (roomID string, eventA, eventB *eventTime) {
@@ -367,15 +369,8 @@ func createTestRoom(t *testing.T, c *client.CSAPI) (roomID string, eventA, event
 		"preset": "public_chat",
 	})
 
-	// MustCreateRoom returns once the homeserver has stamped the full
-	// createRoom state batch (m.room.create through m.room.guest_access);
-	// the trailing state event can share a millisecond with the time.Now()
-	// below. Pausing here pushes the sample past that boundary so a forward
-	// search anchored on timeBeforeEventA cannot land back on the createRoom
-	// state.
-	time.Sleep(tsBoundaryGuard)
-
 	timeBeforeEventA := time.Now()
+	time.Sleep(tsBoundaryGuard)
 	eventAID := c.SendEventSynced(t, roomID, b.Event{
 		Type: "m.room.message",
 		Content: map[string]interface{}{
@@ -383,14 +378,10 @@ func createTestRoom(t *testing.T, c *client.CSAPI) (roomID string, eventA, event
 			"body":    "Message A",
 		},
 	})
-	timeAfterEventA := time.Now()
 
-	// eventB.BeforeTimestamp has to sit in a strictly later millisecond than
-	// eventA, otherwise a forward search anchored there could land back on
-	// eventA at a shared boundary millisecond. Nothing exercises this yet, but
-	// keep the helper honest for callers that eventually will.
 	time.Sleep(tsBoundaryGuard)
 	timeBeforeEventB := time.Now()
+	time.Sleep(tsBoundaryGuard)
 	eventBID := c.SendEventSynced(t, roomID, b.Event{
 		Type: "m.room.message",
 		Content: map[string]interface{}{
@@ -398,9 +389,11 @@ func createTestRoom(t *testing.T, c *client.CSAPI) (roomID string, eventA, event
 			"body":    "Message B",
 		},
 	})
+
+	time.Sleep(tsBoundaryGuard)
 	timeAfterEventB := time.Now()
 
-	eventA = &eventTime{EventID: eventAID, BeforeTimestamp: timeBeforeEventA, AfterTimestamp: timeAfterEventA}
+	eventA = &eventTime{EventID: eventAID, BeforeTimestamp: timeBeforeEventA, AfterTimestamp: timeBeforeEventB}
 	eventB = &eventTime{EventID: eventBID, BeforeTimestamp: timeBeforeEventB, AfterTimestamp: timeAfterEventB}
 
 	return roomID, eventA, eventB

--- a/tests/room_timestamp_to_event_test.go
+++ b/tests/room_timestamp_to_event_test.go
@@ -56,6 +56,14 @@ func TestJumpToDateEndpoint(t *testing.T) {
 		t.Run("should find nothing before the earliest timestamp", func(t *testing.T) {
 			t.Parallel()
 			timeBeforeRoomCreation := time.Now()
+			// /timestamp_to_event is millisecond-granular by spec, and the next
+			// call (createTestRoom) writes an m.room.create whose
+			// origin_server_ts can land in the same millisecond as the sample
+			// above. A backward search at that millisecond inclusively returns
+			// the create event when the test wants 404. Pause long enough that
+			// every event the homeserver subsequently stamps is in a strictly
+			// later millisecond. See matrix-org/complement#868.
+			time.Sleep(tsBoundaryGuard)
 			roomID, _, _ := createTestRoom(t, alice)
 			mustCheckEventisReturnedForTime(t, alice, roomID, timeBeforeRoomCreation, "b", "")
 		})
@@ -331,12 +339,31 @@ type eventTime struct {
 	AfterTimestamp  time.Time
 }
 
+// tsBoundaryGuard is the pause inserted around each time.Now() sample in this
+// file's helpers and subtests so that no homeserver-stamped origin_server_ts
+// can collide with the sample at millisecond granularity. /timestamp_to_event
+// returns the boundary event inclusively (forward picks the earliest event
+// with ts >= query, backward picks the latest with ts <= query), so a shared
+// millisecond between sample and event lets the wrong event win the boundary.
+// 2ms is well above the per-millisecond clock resolution every supported
+// platform exposes and short enough that the cost is invisible compared to a
+// homeserver round-trip. See matrix-org/complement#868.
+const tsBoundaryGuard = 2 * time.Millisecond
+
 func createTestRoom(t *testing.T, c *client.CSAPI) (roomID string, eventA, eventB *eventTime) {
 	t.Helper()
 
 	roomID = c.MustCreateRoom(t, map[string]interface{}{
 		"preset": "public_chat",
 	})
+
+	// MustCreateRoom returns once the homeserver has stamped the full
+	// createRoom state batch (m.room.create through m.room.guest_access);
+	// the trailing state event can share a millisecond with the time.Now()
+	// below. Pausing here pushes the sample past that boundary so a forward
+	// search anchored on timeBeforeEventA cannot land back on the createRoom
+	// state. See matrix-org/complement#868.
+	time.Sleep(tsBoundaryGuard)
 
 	timeBeforeEventA := time.Now()
 	eventAID := c.SendEventSynced(t, roomID, b.Event{

--- a/tests/room_timestamp_to_event_test.go
+++ b/tests/room_timestamp_to_event_test.go
@@ -62,7 +62,7 @@ func TestJumpToDateEndpoint(t *testing.T) {
 			// above. A backward search at that millisecond inclusively returns
 			// the create event when the test wants 404. Pause long enough that
 			// every event the homeserver subsequently stamps is in a strictly
-			// later millisecond. See matrix-org/complement#868.
+			// later millisecond.
 			time.Sleep(tsBoundaryGuard)
 			roomID, _, _ := createTestRoom(t, alice)
 			mustCheckEventisReturnedForTime(t, alice, roomID, timeBeforeRoomCreation, "b", "")
@@ -83,6 +83,11 @@ func TestJumpToDateEndpoint(t *testing.T) {
 			as.MustJoinRoom(t, roomID, []spec.ServerName{
 				deployment.GetFullyQualifiedHomeserverName(t, "hs1"),
 			})
+
+			// Keep the join in an earlier millisecond than the messages below so
+			// it cannot win the boundary search; the topological tie-break is
+			// what this subtest actually exercises.
+			time.Sleep(tsBoundaryGuard)
 
 			// Send a couple messages with the same timestamp after the other test
 			// messages in the room.
@@ -105,6 +110,11 @@ func TestJumpToDateEndpoint(t *testing.T) {
 			as.MustJoinRoom(t, roomID, []spec.ServerName{
 				deployment.GetFullyQualifiedHomeserverName(t, "hs1"),
 			})
+
+			// Keep the join in an earlier millisecond than the messages below so
+			// it cannot win the boundary search; the topological tie-break is
+			// what this subtest actually exercises.
+			time.Sleep(tsBoundaryGuard)
 
 			// Send a couple messages with the same timestamp after the other test
 			// messages in the room.
@@ -345,10 +355,10 @@ type eventTime struct {
 // returns the boundary event inclusively (forward picks the earliest event
 // with ts >= query, backward picks the latest with ts <= query), so a shared
 // millisecond between sample and event lets the wrong event win the boundary.
-// 2ms is well above the per-millisecond clock resolution every supported
-// platform exposes and short enough that the cost is invisible compared to a
-// homeserver round-trip. See matrix-org/complement#868.
-const tsBoundaryGuard = 2 * time.Millisecond
+// time.Sleep pauses for at least its argument, and adding a whole millisecond
+// to a timestamp always carries it into the next millisecond bucket, so 1ms is
+// enough to separate the sample from every event stamped after the pause.
+const tsBoundaryGuard = 1 * time.Millisecond
 
 func createTestRoom(t *testing.T, c *client.CSAPI) (roomID string, eventA, eventB *eventTime) {
 	t.Helper()
@@ -362,7 +372,7 @@ func createTestRoom(t *testing.T, c *client.CSAPI) (roomID string, eventA, event
 	// the trailing state event can share a millisecond with the time.Now()
 	// below. Pausing here pushes the sample past that boundary so a forward
 	// search anchored on timeBeforeEventA cannot land back on the createRoom
-	// state. See matrix-org/complement#868.
+	// state.
 	time.Sleep(tsBoundaryGuard)
 
 	timeBeforeEventA := time.Now()
@@ -375,6 +385,12 @@ func createTestRoom(t *testing.T, c *client.CSAPI) (roomID string, eventA, event
 	})
 	timeAfterEventA := time.Now()
 
+	// eventB.BeforeTimestamp has to sit in a strictly later millisecond than
+	// eventA, otherwise a forward search anchored there could land back on
+	// eventA at a shared boundary millisecond. Nothing exercises this yet, but
+	// keep the helper honest for callers that eventually will.
+	time.Sleep(tsBoundaryGuard)
+	timeBeforeEventB := time.Now()
 	eventBID := c.SendEventSynced(t, roomID, b.Event{
 		Type: "m.room.message",
 		Content: map[string]interface{}{
@@ -385,7 +401,7 @@ func createTestRoom(t *testing.T, c *client.CSAPI) (roomID string, eventA, event
 	timeAfterEventB := time.Now()
 
 	eventA = &eventTime{EventID: eventAID, BeforeTimestamp: timeBeforeEventA, AfterTimestamp: timeAfterEventA}
-	eventB = &eventTime{EventID: eventBID, BeforeTimestamp: timeAfterEventA, AfterTimestamp: timeAfterEventB}
+	eventB = &eventTime{EventID: eventBID, BeforeTimestamp: timeBeforeEventB, AfterTimestamp: timeAfterEventB}
 
 	return roomID, eventA, eventB
 }

--- a/tests/room_timestamp_to_event_test.go
+++ b/tests/room_timestamp_to_event_test.go
@@ -56,13 +56,8 @@ func TestJumpToDateEndpoint(t *testing.T) {
 		t.Run("should find nothing before the earliest timestamp", func(t *testing.T) {
 			t.Parallel()
 			timeBeforeRoomCreation := time.Now()
-			// /timestamp_to_event is millisecond-granular by spec, and the next
-			// call (createTestRoom) writes an m.room.create whose
-			// origin_server_ts can land in the same millisecond as the sample
-			// above. A backward search at that millisecond inclusively returns
-			// the create event when the test wants 404. Pause long enough that
-			// every event the homeserver subsequently stamps is in a strictly
-			// later millisecond.
+			// Guard so createRoom cannot share this sample's millisecond; a
+			// backward search there would return m.room.create instead of nothing.
 			time.Sleep(tsBoundaryGuard)
 			roomID, _, _ := createTestRoom(t, alice)
 			mustCheckEventisReturnedForTime(t, alice, roomID, timeBeforeRoomCreation, "b", "")
@@ -84,9 +79,7 @@ func TestJumpToDateEndpoint(t *testing.T) {
 				deployment.GetFullyQualifiedHomeserverName(t, "hs1"),
 			})
 
-			// Keep the join in an earlier millisecond than the messages below so
-			// it cannot win the boundary search; the topological tie-break is
-			// what this subtest actually exercises.
+			// Guard so the join cannot share a millisecond with the messages below.
 			time.Sleep(tsBoundaryGuard)
 
 			// Send a couple messages with the same timestamp after the other test
@@ -111,9 +104,7 @@ func TestJumpToDateEndpoint(t *testing.T) {
 				deployment.GetFullyQualifiedHomeserverName(t, "hs1"),
 			})
 
-			// Keep the join in an earlier millisecond than the messages below so
-			// it cannot win the boundary search; the topological tie-break is
-			// what this subtest actually exercises.
+			// Guard so the join cannot share a millisecond with the messages below.
 			time.Sleep(tsBoundaryGuard)
 
 			// Send a couple messages with the same timestamp after the other test
@@ -379,6 +370,8 @@ func createTestRoom(t *testing.T, c *client.CSAPI) (roomID string, eventA, event
 		},
 	})
 
+	// timeBeforeEventB doubles as eventA's after-timestamp, so guard it on
+	// both sides to keep it between the two events.
 	time.Sleep(tsBoundaryGuard)
 	timeBeforeEventB := time.Now()
 	time.Sleep(tsBoundaryGuard)


### PR DESCRIPTION

Closes #868.

The two `parallel` boundary subtests `should_find_event_after_given_timestamp` and `should_find_nothing_before_the_earliest_timestamp` flake against any homeserver fast enough to handle a `createRoom` round-trip inside a single millisecond. The race is in the test, not the implementation: `/timestamp_to_event` is millisecond-granular by spec and resolves the boundary inclusively (forward picks the earliest event with `ts >= query`, backward picks the latest with `ts <= query`), so when a `time.Now()` sample collides with an `origin_server_ts` the homeserver just stamped, the inclusive match returns an event the subtest does not want.

### `should_find_event_after_given_timestamp`

`createTestRoom` reads `time.Now()` immediately after `MustCreateRoom` returns. The trailing state event of the `public_chat` preset's createRoom batch (typically `m.room.guest_access`, after `create`, `member`/join, `power_levels`, `join_rules`, `history_visibility`) lands in the same millisecond as that sample on a fast deploy. The forward search anchored on `timeBeforeEventA` then iterates events with `ts >= sample` from the earliest, hits the trailing state event before `Message A`, and the assertion fails with the wrong `event_id`.

### `should_find_nothing_before_the_earliest_timestamp`

The subtest samples `timeBeforeRoomCreation := time.Now()` and immediately calls `createTestRoom`. The `m.room.create` event the homeserver writes in response is stamped at the same millisecond. The backward search at that boundary inclusively returns the create event when the test wants 404.

### Solution

The race direction is different for the two subtests, so the placement of the guard differs:

- For the forward race in `createTestRoom`, the offending event has already been stamped before `time.Now()` is called. The sleep goes **before** the sample (between `MustCreateRoom` returning and `timeBeforeEventA := time.Now()`), advancing the sample past the trailing state event's millisecond.
- For the backward race in the failing subtest, the offending event is stamped after `time.Now()`. The sleep goes **after** the sample (between `timeBeforeRoomCreation := time.Now()` and `createTestRoom`), pushing `m.room.create` into a strictly later millisecond.

A 2 ms pause is long enough to step past the 1 ms clock resolution exposed on every supported platform and short enough to be invisible against the normal homeserver round-trip. The constant `tsBoundaryGuard` and a paragraph above it document the invariant so neither sleep gets removed as cosmetic later.

The wire contract is unchanged: `/timestamp_to_event` continues to be millisecond-granular and continues to resolve the boundary inclusively. Only the test pacing changes.

### Empirical evidence

A local soak against tuwunel (`bench` build, `complement_count=N`, `complement_parallel=1`, single docker invocation per batch, fresh `OldDeploy` per iteration):

| Subtest | Unpatched (N=100) | Patched (N=100) |
|---|---|---|
| `should_find_event_after_given_timestamp` | 23 fail / 77 pass | 0 fail / 100 pass |
| `should_find_nothing_before_the_earliest_timestamp` | 66 fail / 34 pass | 0 fail / 100 pass |

89 flakes vs 0 across the 200 paired trials. The unpatched tester image is the prior `tuwunel-changes` HEAD (`9e8d447`); the patched tester image is the same Complement plus this commit. The testee binary, the homeserver deployment shape (hs1 + hs2 + AS bridge), and the test invocation flags are identical between batches.

The same flake fired three times in matrix-construct/tuwunel CI in the days before we routed the two subtests onto a `complement_skip` allowlist:

- [run `25346770228`, job `74331724982`](https://github.com/matrix-construct/tuwunel/actions/runs/25346770228/job/74331724982) (2026-05-04): both subtests failed.
- [run `25363319978`, job `74376393945`](https://github.com/matrix-construct/tuwunel/actions/runs/25363319978/job/74376393945) (2026-05-05): `should_find_event_after_given_timestamp` failed.
- [run `25367139913`, job `74452002935`](https://github.com/matrix-construct/tuwunel/actions/runs/25367139913/job/74452002935) (2026-05-05): both subtests failed.

The patch only adjusts `tests/room_timestamp_to_event_test.go`. The `should_not_be_able_to_query_a_*_room_you_are_not_a_member_of` subtests sample the same `timeBeforeRoomCreation` pattern but assert HTTP 403, which the homeserver returns regardless of which event a backward search would surface, so the boundary does not matter there. The `parallel/federation/when_looking_backwards_before_the_room_was_created,_should_be_able_to_find_event_that_was_imported` subtest has the same pattern but its dominant failure mode is federation backfill, not the boundary; the guard is harmless if added later but is out of scope here.

The matching guard is backported to the matrix-construct fork at [`matrix-construct/complement@28df927`](https://github.com/matrix-construct/complement/commit/28df927bb293d917bc36f2e030f30771ef366d0c) on its `tuwunel-changes` branch and is wired into matrix-construct/tuwunel CI (`complement_ref` in `docker/Dockerfile.complement` is bumped to that hash, and the corresponding `complement_skip` entries are dropped) so the patched path is exercised against tuwunel ahead of merge here.

### Pull Request Checklist

- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
