### PR TITLE
Log `userID` when using `syncMembershipIn` to better differentiate checks

### DIFF
--- a/client/sync.go
+++ b/client/sync.go
@@ -347,7 +347,7 @@ func syncMembershipIn(userID, roomID, membership string, checks ...func(gjson.Re
 			} else if membership == "knock" {
 				roomTypeKey = "knock"
 			} else {
-				return fmt.Errorf("syncMembershipIn(%s, %s): unknown membership: %s", roomID, membership, membership)
+				return fmt.Errorf("syncMembershipIn(%s, %s, %s): unknown membership: %s", userID, roomID, membership, membership)
 			}
 		}
 
@@ -363,7 +363,7 @@ func syncMembershipIn(userID, roomID, membership string, checks ...func(gjson.Re
 			} else if membership == "knock" {
 				stateKey = "knock_state"
 			} else {
-				return fmt.Errorf("syncMembershipIn(%s, %s): unknown membership: %s", roomID, membership, membership)
+				return fmt.Errorf("syncMembershipIn(%s, %s, %s): unknown membership: %s", userID, roomID, membership, membership)
 			}
 		}
 
@@ -399,7 +399,7 @@ func syncMembershipIn(userID, roomID, membership string, checks ...func(gjson.Re
 			}
 		}
 
-		return fmt.Errorf("syncMembershipIn(%s, %s): %s & %s - %s", roomID, membership, firstErr, secondErr, topLevelSyncJSON)
+		return fmt.Errorf("syncMembershipIn(%s, %s, %s): %s & %s - %s", userID, roomID, membership, firstErr, secondErr, topLevelSyncJSON)
 	}
 }
 


### PR DESCRIPTION
Log `userID` when using `syncMembershipIn` to better differentiate checks

Spawning from staring at some logs and wanting to know which user this pertains to without having to dive into the test source:

```
      federation_rooms_invite_test.go:151: @user-58-alice:hs1 MustSyncUntil: timed out after 5.441786693s. Seen 6 /sync responses. Checkers:
          [t=391.995078ms] Response #1: syncMembershipIn(!nQhJEXkKJaajxcXaif:hs1, leave): check function did not pass while iterating ...
```

### Pull Request Checklist

- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)

