### PR TITLE
Run the cleanup routines even if the main goroutine panics

### DIFF
--- a/test_main.go
+++ b/test_main.go
@@ -78,6 +78,8 @@ func TestMain(m *testing.M, namespace string, customOpts ...opt) {
 	}
 
 	// Run the cleanup functions even on panic.
+	// Note that deferred functions aren't run on `os.Exit`, so we need to put the `defer` calls
+	// inside a new `func()`.
 	runAndCleanup := func() int {
 		defer testPackage.Cleanup()
 		if opts.cleanup != nil {

--- a/test_main.go
+++ b/test_main.go
@@ -76,12 +76,18 @@ func TestMain(m *testing.M, namespace string, customOpts ...opt) {
 		fmt.Printf("Error: %s", err)
 		os.Exit(1)
 	}
-	exitCode := m.Run()
-	if opts.cleanup != nil {
-		opts.cleanup(testPackage.Config)
+
+	// Run the cleanup functions even on panic.
+	runAndCleanup := func() int {
+		defer testPackage.Cleanup()
+		if opts.cleanup != nil {
+			defer opts.cleanup(testPackage.Config)
+		}
+
+		return m.Run()
 	}
-	testPackage.Cleanup()
-	os.Exit(exitCode)
+
+	os.Exit(runAndCleanup())
 }
 
 // Deploy will deploy the given blueprint or terminate the test.


### PR DESCRIPTION
We should stop any running containers on panic, and things like complement-crypto expect their cleanup handlers to be run.

There is a comment in complement-crypto to this effect (https://github.com/matrix-org/complement-crypto/blob/6ba55b6fb878dd44872edc44d9632241d253a8cc/internal/cc/instance.go#L42), and that expectation seems to have been broken by the [transition to `WithCleanup`](https://github.com/matrix-org/complement-crypto/commit/df785ea9e53ef2c2037f74511d79982520e09dbc#diff-0a2a73f63f0707d0366654971055ac58350fa92558376fe46e93406052d86464).