### PR TITLE
Support Room version 12 as default for a homeserver being tested

### DIFF
--- a/tests/csapi/apidoc_room_alias_test.go
+++ b/tests/csapi/apidoc_room_alias_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
 	"github.com/matrix-org/complement/should"
+	"github.com/matrix-org/gomatrixserverlib"
 )
 
 func setRoomAliasResp(t *testing.T, c *client.CSAPI, roomID, roomAlias string) *http.Response {
@@ -192,6 +193,8 @@ func TestRoomDeleteAlias(t *testing.T) {
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
+	defaultRoomVersion := alice.GetDefaultRoomVersion(t)
+
 	t.Run("Parallel", func(t *testing.T) {
 		// sytest: Alias creators can delete alias with no ops
 		t.Run("Alias creators can delete alias with no ops", func(t *testing.T) {
@@ -352,14 +355,21 @@ func TestRoomDeleteAlias(t *testing.T) {
 			alice.SendEventSynced(t, roomID, b.Event{
 				Type:     "m.room.power_levels",
 				StateKey: b.Ptr(""),
-				Content: map[string]interface{}{
-					"users": map[string]int64{
-						alice.UserID: 100,
-					},
-					"events": map[string]int64{
-						"m.room.aliases": 50,
-					},
-				},
+				Content: func() map[string]interface{} {
+					content := map[string]interface{}{
+						"events": map[string]int64{
+							"m.room.aliases": 50,
+						},
+						"users": map[string]int64{
+							alice.UserID: 100,
+						},
+					}
+					// Room v12+ prohibits the room creator in the `users` object
+					if gomatrixserverlib.MustGetRoomVersion(defaultRoomVersion).PrivilegedCreators() {
+						delete(content["users"].(map[string]int64), alice.UserID)
+					}
+					return content
+				}(),
 			})
 
 			res := setRoomAliasResp(t, bob, roomID, randomAlias)
@@ -428,12 +438,18 @@ func TestRoomDeleteAlias(t *testing.T) {
 			alice.SendEventSynced(t, roomID, b.Event{
 				Type:     "m.room.power_levels",
 				StateKey: b.Ptr(""),
-				Content: map[string]interface{}{
-					"users": map[string]int64{
-						alice.UserID: 100,
-						bob.UserID:   100,
-					},
-				},
+				Content: func() map[string]interface{} {
+					content := map[string]interface{}{
+						"users": map[string]int64{
+							alice.UserID: 100,
+							bob.UserID:   100,
+						},
+					}
+					if gomatrixserverlib.MustGetRoomVersion(defaultRoomVersion).PrivilegedCreators() {
+						delete(content["users"].(map[string]int64), alice.UserID)
+					}
+					return content
+				}(),
 			})
 
 			res := setRoomAliasResp(t, alice, roomID, randomAlias)

--- a/tests/csapi/apidoc_room_members_test.go
+++ b/tests/csapi/apidoc_room_members_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
+	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/gomatrixserverlib/spec"
 )
 
@@ -84,6 +85,7 @@ func TestRoomMembers(t *testing.T) {
 		// sytest: Test that we can be reinvited to a room we created
 		t.Run("Test that we can be reinvited to a room we created", func(t *testing.T) {
 			t.Parallel()
+			defaultRoomVersion := alice.GetDefaultRoomVersion(t)
 			roomID := alice.MustCreateRoom(t, map[string]interface{}{
 				"preset": "private_chat",
 			})
@@ -101,13 +103,19 @@ func TestRoomMembers(t *testing.T) {
 			alice.SendEventSynced(t, roomID, b.Event{
 				Type:     "m.room.power_levels",
 				StateKey: &stateKey,
-				Content: map[string]interface{}{
-					"invite": 100,
-					"users": map[string]interface{}{
-						alice.UserID: 100,
-						bob.UserID:   100,
-					},
-				},
+				Content: func() map[string]interface{} {
+					content := map[string]interface{}{
+						"invite": 100,
+						"users": map[string]int64{
+							bob.UserID:   100,
+							alice.UserID: 100,
+						},
+					}
+					if gomatrixserverlib.MustGetRoomVersion(defaultRoomVersion).PrivilegedCreators() {
+						delete(content["users"].(map[string]int64), alice.UserID)
+					}
+					return content
+				}(),
 			})
 
 			alice.MustLeaveRoom(t, roomID)

--- a/tests/csapi/power_levels_test.go
+++ b/tests/csapi/power_levels_test.go
@@ -80,6 +80,8 @@ func TestPowerLevels(t *testing.T) {
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
 
+	defaultRoomVersion := alice.GetDefaultRoomVersion(t)
+
 	roomID := alice.MustCreateRoom(t, map[string]interface{}{})
 
 	// sytest: GET /rooms/:room_id/state/m.room.power_levels can fetch levels
@@ -90,7 +92,11 @@ func TestPowerLevels(t *testing.T) {
 		// However, for this test, we control the test environment,
 		//  and we will assume the server is sane and give us powerlevels as numbers,
 		//  and if it doesn't, that's an offense worthy of a frown.
-		content := alice.MustGetStateEventContent(t, roomID, "m.room.power_levels", "")
+		// note 2: before v12 the `users` object had to explicitly define the room creator, if they
+		//  should have some power level other than the room's default. Starting with v12, this user
+		//  is to be excluded from the `users` object, as they have an infinite power level that is
+		//  not representable in JSON
+		content := alice.MustGetStateEventContent(t, roomID, spec.MRoomPowerLevels, "")
 		must.MatchGJSON(t, content,
 			match.JSONKeyTypeEqual("ban", gjson.Number),
 			match.JSONKeyTypeEqual("kick", gjson.Number),
@@ -116,13 +122,18 @@ func TestPowerLevels(t *testing.T) {
 			}),
 
 			func(body gjson.Result) error {
-				userDefault := int(body.Get("users_default").Num)
-				thisUser := int(body.Get("users." + client.GjsonEscape(alice.UserID)).Num)
-
-				if thisUser > userDefault {
+				// This key should be missing for room v12+
+				if gomatrixserverlib.MustGetRoomVersion(defaultRoomVersion).PrivilegedCreators() {
+					match.JSONKeyMissing("users." + client.GjsonEscape(alice.UserID))
 					return nil
 				} else {
-					return fmt.Errorf("expected room creator (%d) to have a higher-than-default powerlevel (which is %d)", thisUser, userDefault)
+					userDefault := int(body.Get("users_default").Num)
+					thisUser := int(body.Get("users." + client.GjsonEscape(alice.UserID)).Num)
+					if thisUser > userDefault {
+						return nil
+					} else {
+						return fmt.Errorf("expected room creator (%d) to have a higher-than-default powerlevel (which is %d)", thisUser, userDefault)
+					}
 				}
 			},
 		)
@@ -139,8 +150,13 @@ func TestPowerLevels(t *testing.T) {
 			},
 		}
 
+		// Rooms versioned 12+ do not allow having the room creator in the 'users' object, so just remove it
+		if gomatrixserverlib.MustGetRoomVersion(defaultRoomVersion).PrivilegedCreators() {
+			delete(PLContent["users"].(map[string]interface{}), alice.UserID)
+		}
+
 		eventId := alice.SendEventSynced(t, roomID, b.Event{
-			Type:     "m.room.power_levels",
+			Type:     spec.MRoomPowerLevels,
 			StateKey: b.Ptr(""),
 			Content:  PLContent,
 		})
@@ -162,37 +178,70 @@ func TestPowerLevels(t *testing.T) {
 	t.Run("PUT power_levels should not explode if the old power levels were empty", func(t *testing.T) {
 		// Absence of an "events" key
 		alice.SendEventSynced(t, roomID, b.Event{
-			Type:     "m.room.power_levels",
+			Type:     spec.MRoomPowerLevels,
 			StateKey: b.Ptr(""),
-			Content: map[string]interface{}{
-				"users": map[string]interface{}{
-					alice.UserID: 100,
-				},
-			},
+			Content: func() map[string]interface{} {
+				PLContent := map[string]interface{}{
+					"users": map[string]int64{
+						alice.UserID: 100,
+					},
+				}
+				// Rooms versioned 12+ do not allow having the room creator in the 'users' object, so just remove the
+				// single user so the empty `users` object is present
+				if gomatrixserverlib.MustGetRoomVersion(defaultRoomVersion).PrivilegedCreators() {
+					delete(PLContent["users"].(map[string]int64), alice.UserID)
+				}
+				return PLContent
+			}(),
 		})
 
 		// Absence of a "users" key
 		alice.SendEventSynced(t, roomID, b.Event{
-			Type:     "m.room.power_levels",
+			Type:     spec.MRoomPowerLevels,
 			StateKey: b.Ptr(""),
 			Content:  map[string]interface{}{},
 		})
 
-		// This should give a 403 (not a 500)
-		res := alice.Do(
-			t,
-			"PUT",
-			[]string{"_matrix", "client", "v3", "rooms", roomID, "state", "m.room.power_levels"},
-			client.WithJSONBody(t, map[string]interface{}{
-				"users": map[string]string{},
-			}),
-		)
-		must.MatchResponse(t, res, match.HTTPResponse{
-			StatusCode: 403,
-		})
+		// This part of the test should check that sending a power_levels event fails. As then the previous
+		// power_levels event should not have changed. Depending on the room version, this can be done in one
+		//  of two different ways:
+		if gomatrixserverlib.MustGetRoomVersion(defaultRoomVersion).PrivilegedCreators() {
+			// For rooms with privileged creators(MSC4289), try and send an event with the room creator in the
+			// `users` object, which should be prohibited with a 400 error code. An empty `users` object appears
+			// to be allowed, hence the difference from the below condition for other room versions.
+			res := alice.Do(
+				t,
+				"PUT",
+				[]string{"_matrix", "client", "v3", "rooms", roomID, "state", spec.MRoomPowerLevels},
+				client.WithJSONBody(t, map[string]interface{}{
+					"users": map[string]int64{
+						alice.UserID: 100,
+					},
+				}),
+			)
+			must.MatchResponse(t, res, match.HTTPResponse{
+				StatusCode: 400,
+			})
+
+		} else {
+			// Prior to rooms using privileged creators, an empty `users` object would be prohibited and should
+			// give a 403 (not a 500)
+			res := alice.Do(
+				t,
+				"PUT",
+				[]string{"_matrix", "client", "v3", "rooms", roomID, "state", spec.MRoomPowerLevels},
+				client.WithJSONBody(t, map[string]interface{}{
+					"users": map[string]int64{},
+				}),
+			)
+			must.MatchResponse(t, res, match.HTTPResponse{
+				StatusCode: 403,
+			})
+
+		}
 
 		// Test if the old state still exists
-		content := alice.MustGetStateEventContent(t, roomID, "m.room.power_levels", "")
+		content := alice.MustGetStateEventContent(t, roomID, spec.MRoomPowerLevels, "")
 		must.MatchGJSON(t, content, match.JSONKeyMissing("users"))
 	})
 }

--- a/tests/csapi/power_levels_test.go
+++ b/tests/csapi/power_levels_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
+	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/spec"
 )
 
 // This test ensures that an authorised (PL 100) user is able to modify the users_default value
@@ -22,30 +24,53 @@ func TestDemotingUsersViaUsersDefault(t *testing.T) {
 	defer deployment.Destroy(t)
 
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+
+	defaultRoomVersion := alice.GetDefaultRoomVersion(t)
 
 	roomID := alice.MustCreateRoom(t, map[string]interface{}{
 		"preset": "public_chat",
-		"power_level_content_override": map[string]interface{}{
-			"users_default": 100, // the default is 0
-			"users": map[string]interface{}{
-				alice.UserID: 100,
-			},
-			"events":        map[string]int64{},
-			"notifications": map[string]int64{},
-		},
+		"power_level_content_override": func() map[string]interface{} {
+			power_level_content := map[string]interface{}{
+				"users_default": 100, // the default is 0
+				"users": map[string]int64{
+					alice.UserID: 100,
+					bob.UserID:   100,
+				},
+				"events":        map[string]int64{},
+				"notifications": map[string]int64{},
+			}
+			// Remove the room creator if this is a v12+ room
+			if gomatrixserverlib.MustGetRoomVersion(defaultRoomVersion).PrivilegedCreators() {
+				delete(power_level_content["users"].(map[string]int64), alice.UserID)
+			}
+			return power_level_content
+		}(),
 	})
 
-	alice.SendEventSynced(t, roomID, b.Event{
-		Type:     "m.room.power_levels",
+	bob.MustJoinRoom(t, roomID, []spec.ServerName{
+		deployment.GetFullyQualifiedHomeserverName(t, "hs1"),
+	})
+
+	bob.SendEventSynced(t, roomID, b.Event{
+		Type:     spec.MRoomPowerLevels,
 		StateKey: b.Ptr(""),
-		Content: map[string]interface{}{
-			"users_default": 40, // we change the default to 40. We should be able to do this.
-			"users": map[string]interface{}{
-				alice.UserID: 100,
-			},
-			"events":        map[string]int64{},
-			"notifications": map[string]int64{},
-		},
+		Content: func() map[string]interface{} {
+			content := map[string]interface{}{
+				"users_default": 40, // we change the default to 40. We should be able to do this.
+				"users": map[string]int64{
+					alice.UserID: 100,
+					bob.UserID:   100,
+				},
+				"events":        map[string]int64{},
+				"notifications": map[string]int64{},
+			}
+			// Remove the room creator if this is a v12+ room
+			if gomatrixserverlib.MustGetRoomVersion(defaultRoomVersion).PrivilegedCreators() {
+				delete(content["users"].(map[string]int64), alice.UserID)
+			}
+			return content
+		}(),
 	})
 }
 

--- a/tests/csapi/power_levels_test.go
+++ b/tests/csapi/power_levels_test.go
@@ -124,7 +124,7 @@ func TestPowerLevels(t *testing.T) {
 			func(body gjson.Result) error {
 				// This key should be missing for room v12+
 				if gomatrixserverlib.MustGetRoomVersion(defaultRoomVersion).PrivilegedCreators() {
-					match.JSONKeyMissing("users." + client.GjsonEscape(alice.UserID))
+					must.MatchGJSON(t, body, match.JSONKeyMissing("users." + client.GjsonEscape(alice.UserID)))
 					return nil
 				} else {
 					userDefault := int(body.Get("users_default").Num)

--- a/tests/federation_room_event_auth_test.go
+++ b/tests/federation_room_event_auth_test.go
@@ -110,6 +110,7 @@ func TestInboundFederationRejectsEventsWithRejectedAuthEvents(t *testing.T) {
 
 	// have Alice create a room, and then join it
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
+	defaultRoomVersion := alice.GetDefaultRoomVersion(t)
 	testRoomID := alice.MustCreateRoom(t, map[string]interface{}{
 		"preset": "public_chat",
 	})
@@ -145,12 +146,20 @@ func TestInboundFederationRejectsEventsWithRejectedAuthEvents(t *testing.T) {
 		StateKey: &charlie,
 		Sender:   charlie,
 		Content:  map[string]interface{}{"membership": "join", "test": 1},
-		AuthEvents: []string{
-			room.CurrentState("m.room.create", "").EventID(),
-			room.CurrentState("m.room.join_rules", "").EventID(),
-			rejectedEvent.EventID(),
-			charlieMembershipEvent.EventID(),
-		},
+		AuthEvents: func() []string {
+			content := []string{
+				room.CurrentState("m.room.create", "").EventID(),
+				room.CurrentState("m.room.join_rules", "").EventID(),
+				rejectedEvent.EventID(),
+				charlieMembershipEvent.EventID(),
+			}
+			if gomatrixserverlib.MustGetRoomVersion(defaultRoomVersion).DomainlessRoomIDs() {
+				// Room v12+ (MSC4291) does not allow the create event in the auth_events key. This outlier
+				// is supposed to be invalid, but not for that reason
+				content = content[1:]
+			}
+			return content
+		}(),
 	})
 	// add it to room.Timeline so that HandleEventRequests() can find it, but
 	// don't use room.AddEvent(), because we don't want it to be a forward extremity.
@@ -159,13 +168,19 @@ func TestInboundFederationRejectsEventsWithRejectedAuthEvents(t *testing.T) {
 
 	// create a regular event which refers to the outlier event in its auth events,
 	// so that the outlier gets pulled in.
-	sentEventAuthEvents := []gomatrixserverlib.PDU{
-		room.CurrentState("m.room.create", ""),
-		room.CurrentState("m.room.join_rules", ""),
-		room.CurrentState("m.room.power_levels", ""),
-		charlieMembershipEvent,
-		outlierEvent,
-	}
+	sentEventAuthEvents := func() []gomatrixserverlib.PDU {
+		content := []gomatrixserverlib.PDU{
+			room.CurrentState("m.room.create", ""),
+			room.CurrentState("m.room.join_rules", ""),
+			room.CurrentState("m.room.power_levels", ""),
+			charlieMembershipEvent,
+			outlierEvent,
+		}
+		if gomatrixserverlib.MustGetRoomVersion(defaultRoomVersion).DomainlessRoomIDs() {
+			content = content[1:]
+		}
+		return content
+	}()
 	sentEvent1 := srv.MustCreateEvent(t, room, federation.Event{
 		Type:       "m.room.message",
 		Sender:     charlie,

--- a/tests/federation_room_event_auth_test.go
+++ b/tests/federation_room_event_auth_test.go
@@ -110,7 +110,7 @@ func TestInboundFederationRejectsEventsWithRejectedAuthEvents(t *testing.T) {
 
 	// have Alice create a room, and then join it
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
-	defaultRoomVersion := alice.GetDefaultRoomVersion(t)
+
 	testRoomID := alice.MustCreateRoom(t, map[string]interface{}{
 		"preset": "public_chat",
 	})
@@ -153,7 +153,7 @@ func TestInboundFederationRejectsEventsWithRejectedAuthEvents(t *testing.T) {
 				rejectedEvent.EventID(),
 				charlieMembershipEvent.EventID(),
 			}
-			if gomatrixserverlib.MustGetRoomVersion(defaultRoomVersion).DomainlessRoomIDs() {
+			if gomatrixserverlib.MustGetRoomVersion(room.Version).DomainlessRoomIDs() {
 				// Room v12+ (MSC4291) does not allow the create event in the auth_events key. This outlier
 				// is supposed to be invalid, but not for that reason
 				content = content[1:]
@@ -176,7 +176,7 @@ func TestInboundFederationRejectsEventsWithRejectedAuthEvents(t *testing.T) {
 			charlieMembershipEvent,
 			outlierEvent,
 		}
-		if gomatrixserverlib.MustGetRoomVersion(defaultRoomVersion).DomainlessRoomIDs() {
+		if gomatrixserverlib.MustGetRoomVersion(room.Version).DomainlessRoomIDs() {
 			content = content[1:]
 		}
 		return content

--- a/tests/msc3902/federation_room_join_partial_state_test.go
+++ b/tests/msc3902/federation_room_join_partial_state_test.go
@@ -1683,6 +1683,7 @@ func TestPartialStateJoin(t *testing.T) {
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
 			LocalpartSuffix: "t16alice",
 		})
+		defaultRoomVersion := alice.GetDefaultRoomVersion(t)
 		syncToken := getSyncToken(t, alice)
 		server := createTestServer(t, deployment)
 		cancel := server.Listen()
@@ -1700,7 +1701,11 @@ func TestPartialStateJoin(t *testing.T) {
 		// update the users map in the PL event
 		for _, ev := range initialRoomEvents {
 			if ev.Type == "m.room.power_levels" {
-				ev.Content["users"] = map[string]int64{charlie: 100, derek: 50}
+				if gomatrixserverlib.MustGetRoomVersion(defaultRoomVersion).PrivilegedCreators() {
+					ev.Content["users"] = map[string]int64{derek: 50}
+				} else {
+					ev.Content["users"] = map[string]int64{charlie: 100, derek: 50}
+				}
 			}
 		}
 		serverRoom := server.MustMakeRoom(t, roomVer, initialRoomEvents)
@@ -1725,11 +1730,17 @@ func TestPartialStateJoin(t *testing.T) {
 			Content: map[string]interface{}{
 				"body": "bad state event",
 			},
-			AuthEvents: serverRoom.EventIDsOrReferences([]gomatrixserverlib.PDU{
-				serverRoom.CurrentState("m.room.create", ""),
-				serverRoom.CurrentState("m.room.power_levels", ""),
-				derekJoinEvent,
-			}),
+			AuthEvents: serverRoom.EventIDsOrReferences(func() []gomatrixserverlib.PDU {
+				content := []gomatrixserverlib.PDU{
+					serverRoom.CurrentState("m.room.create", ""),
+					serverRoom.CurrentState("m.room.power_levels", ""),
+					derekJoinEvent,
+				}
+				if gomatrixserverlib.MustGetRoomVersion(defaultRoomVersion).DomainlessRoomIDs() {
+					content = content[1:]
+				}
+				return content
+			}()),
 		})
 		// add to the timeline, but not the state (so that when testReceiveEventDuringPartialStateJoin checks the state,
 		// it doesn't expect to see this)
@@ -1763,6 +1774,7 @@ func TestPartialStateJoin(t *testing.T) {
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
 			LocalpartSuffix: "t17alice",
 		})
+		defaultRoomVersion := alice.GetDefaultRoomVersion(t)
 		syncToken := getSyncToken(t, alice)
 		server := createTestServer(t, deployment)
 		cancel := server.Listen()
@@ -1781,7 +1793,13 @@ func TestPartialStateJoin(t *testing.T) {
 		// update the users map in the PL event
 		for _, ev := range initialRoomEvents {
 			if ev.Type == "m.room.power_levels" {
-				ev.Content["users"] = map[string]int64{charlie: 100, derek: 100, elsie: 50}
+				if gomatrixserverlib.MustGetRoomVersion(defaultRoomVersion).PrivilegedCreators() {
+					ev.Content["users"] = map[string]int64{derek: 100, elsie: 50}
+
+				} else {
+					ev.Content["users"] = map[string]int64{charlie: 100, derek: 100, elsie: 50}
+
+				}
 			}
 		}
 		serverRoom := server.MustMakeRoom(t, roomVer, initialRoomEvents)
@@ -1808,12 +1826,18 @@ func TestPartialStateJoin(t *testing.T) {
 			StateKey: &elsie,
 			Sender:   derek,
 			Content:  map[string]interface{}{"membership": "leave"},
-			AuthEvents: serverRoom.EventIDsOrReferences([]gomatrixserverlib.PDU{
-				serverRoom.CurrentState("m.room.create", ""),
-				serverRoom.CurrentState("m.room.power_levels", ""),
-				derekJoinEvent,
-				elsieJoinEvent,
-			}),
+			AuthEvents: serverRoom.EventIDsOrReferences(func() []gomatrixserverlib.PDU {
+				content := []gomatrixserverlib.PDU{
+					serverRoom.CurrentState("m.room.create", ""),
+					serverRoom.CurrentState("m.room.power_levels", ""),
+					derekJoinEvent,
+					elsieJoinEvent,
+				}
+				if gomatrixserverlib.MustGetRoomVersion(defaultRoomVersion).DomainlessRoomIDs() {
+					content = content[1:]
+				}
+				return content
+			}()),
 		})
 		// add to the timeline, but not the state (so that when testReceiveEventDuringPartialStateJoin checks the state,
 		// it doesn't expect to see this)
@@ -1828,11 +1852,17 @@ func TestPartialStateJoin(t *testing.T) {
 			StateKey: b.Ptr(""),
 			Sender:   elsie,
 			Content:  map[string]interface{}{"body": "rejected state"},
-			AuthEvents: serverRoom.EventIDsOrReferences([]gomatrixserverlib.PDU{
-				serverRoom.CurrentState("m.room.create", ""),
-				serverRoom.CurrentState("m.room.power_levels", ""),
-				elsieJoinEvent,
-			}),
+			AuthEvents: serverRoom.EventIDsOrReferences(func() []gomatrixserverlib.PDU {
+				content := []gomatrixserverlib.PDU{
+					serverRoom.CurrentState("m.room.create", ""),
+					serverRoom.CurrentState("m.room.power_levels", ""),
+					elsieJoinEvent,
+				}
+				if gomatrixserverlib.MustGetRoomVersion(defaultRoomVersion).DomainlessRoomIDs() {
+					content = content[1:]
+				}
+				return content
+			}()),
 		})
 		serverRoom.AddEvent(rejectedStateEvent)
 		t.Logf("elsie created state event %s", rejectedStateEvent.EventID())
@@ -2437,6 +2467,7 @@ func TestPartialStateJoin(t *testing.T) {
 		) (syncToken string, server2Room *federation.ServerRoom, psjResult partialStateJoinResult) {
 			derek := server1.UserID("derek")
 			elsie := server2.UserID("elsie")
+			roomVersion := room.Version
 
 			// The room starts with @charlie:server1 and @derek:server1 in it.
 			// @derek:server1 becomes an admin.
@@ -2483,11 +2514,17 @@ func TestPartialStateJoin(t *testing.T) {
 				StateKey: b.Ptr(elsie),
 				Sender:   derek,
 				Content:  map[string]interface{}{"membership": "leave"},
-				AuthEvents: room.EventIDsOrReferences([]gomatrixserverlib.PDU{
-					room.CurrentState("m.room.create", ""),
-					room.CurrentState("m.room.power_levels", ""),
-					derekJoinEvent,
-				}),
+				AuthEvents: room.EventIDsOrReferences(func() []gomatrixserverlib.PDU {
+					content := []gomatrixserverlib.PDU{
+						room.CurrentState("m.room.create", ""),
+						room.CurrentState("m.room.power_levels", ""),
+						derekJoinEvent,
+					}
+					if gomatrixserverlib.MustGetRoomVersion(roomVersion).DomainlessRoomIDs() {
+						content = content[1:]
+					}
+					return content
+				}()),
 			})
 			room.Timeline = append(room.Timeline, badKickEvent)
 			room.Depth = badKickEvent.Depth()
@@ -3288,11 +3325,17 @@ func TestPartialStateJoin(t *testing.T) {
 				StateKey: b.Ptr(derek),
 				Sender:   fred,
 				Content:  map[string]interface{}{"membership": "ban"},
-				AuthEvents: room.EventIDsOrReferences([]gomatrixserverlib.PDU{
-					room.CurrentState("m.room.create", ""),
-					room.CurrentState("m.room.power_levels", ""),
-					fredJoinEvent,
-				}),
+				AuthEvents: room.EventIDsOrReferences(func() []gomatrixserverlib.PDU {
+					content := []gomatrixserverlib.PDU{
+						room.CurrentState("m.room.create", ""),
+						room.CurrentState("m.room.power_levels", ""),
+						fredJoinEvent,
+					}
+					if gomatrixserverlib.MustGetRoomVersion(room.Version).DomainlessRoomIDs() {
+						content = content[1:]
+					}
+					return content
+				}()),
 			})
 			room.Timeline = append(room.Timeline, badKickEvent)
 			room.Depth = badKickEvent.Depth()
@@ -3931,7 +3974,8 @@ func TestPartialStateJoin(t *testing.T) {
 			cancel := server.Listen()
 			defer cancel()
 
-			serverRoom := createTestRoom(t, server, alice.GetDefaultRoomVersion(t))
+			defaultRoomVersion := alice.GetDefaultRoomVersion(t)
+			serverRoom := createTestRoom(t, server, defaultRoomVersion)
 			t.Log("Alice partial-joins her room")
 			psjResult := beginPartialStateJoin(t, server, serverRoom, alice)
 			// Alice is not joined to the room at the end of the test, so we do not
@@ -3950,12 +3994,18 @@ func TestPartialStateJoin(t *testing.T) {
 				StateKey: b.Ptr(alice.UserID),
 				Sender:   server.UserID("charlie"),
 				Content:  map[string]interface{}{"membership": "leave"},
-				AuthEvents: serverRoom.EventIDsOrReferences([]gomatrixserverlib.PDU{
-					serverRoom.CurrentState("m.room.create", ""),
-					serverRoom.CurrentState("m.room.power_levels", ""),
-					serverRoom.CurrentState("m.room.member", alice.UserID),
-					serverRoom.CurrentState("m.room.member", server.UserID("charlie")),
-				}),
+				AuthEvents: serverRoom.EventIDsOrReferences(func() []gomatrixserverlib.PDU {
+					content := []gomatrixserverlib.PDU{
+						serverRoom.CurrentState("m.room.create", ""),
+						serverRoom.CurrentState("m.room.power_levels", ""),
+						serverRoom.CurrentState("m.room.member", alice.UserID),
+						serverRoom.CurrentState("m.room.member", server.UserID("charlie")),
+					}
+					if gomatrixserverlib.MustGetRoomVersion(defaultRoomVersion).DomainlessRoomIDs() {
+						content = content[1:]
+					}
+					return content
+				}()),
 			})
 			serverRoom.AddEvent(kickEvent)
 			server.MustSendTransaction(t, deployment, deployment.GetFullyQualifiedHomeserverName(t, "hs1"), []json.RawMessage{kickEvent.JSON()}, nil)
@@ -3985,7 +4035,8 @@ func TestPartialStateJoin(t *testing.T) {
 			cancel := server.Listen()
 			defer cancel()
 
-			serverRoom := createTestRoom(t, server, alice.GetDefaultRoomVersion(t))
+			defaultRoomVersion := alice.GetDefaultRoomVersion(t)
+			serverRoom := createTestRoom(t, server, defaultRoomVersion)
 			t.Log("Alice partial-joins her room")
 			psjResult := beginPartialStateJoin(t, server, serverRoom, alice)
 			// Alice is not joined to the room at the end of the test, so we do not
@@ -4004,12 +4055,18 @@ func TestPartialStateJoin(t *testing.T) {
 				StateKey: b.Ptr(alice.UserID),
 				Sender:   server.UserID("charlie"),
 				Content:  map[string]interface{}{"membership": "ban"},
-				AuthEvents: serverRoom.EventIDsOrReferences([]gomatrixserverlib.PDU{
-					serverRoom.CurrentState("m.room.create", ""),
-					serverRoom.CurrentState("m.room.power_levels", ""),
-					serverRoom.CurrentState("m.room.member", alice.UserID),
-					serverRoom.CurrentState("m.room.member", server.UserID("charlie")),
-				}),
+				AuthEvents: serverRoom.EventIDsOrReferences(func() []gomatrixserverlib.PDU {
+					content := []gomatrixserverlib.PDU{
+						serverRoom.CurrentState("m.room.create", ""),
+						serverRoom.CurrentState("m.room.power_levels", ""),
+						serverRoom.CurrentState("m.room.member", alice.UserID),
+						serverRoom.CurrentState("m.room.member", server.UserID("charlie")),
+					}
+					if gomatrixserverlib.MustGetRoomVersion(defaultRoomVersion).DomainlessRoomIDs() {
+						content = content[1:]
+					}
+					return content
+				}()),
 			})
 			serverRoom.AddEvent(banEvent)
 			server.MustSendTransaction(t, deployment, deployment.GetFullyQualifiedHomeserverName(t, "hs1"), []json.RawMessage{banEvent.JSON()}, nil)

--- a/tests/msc3902/federation_room_join_partial_state_test.go
+++ b/tests/msc3902/federation_room_join_partial_state_test.go
@@ -1683,7 +1683,6 @@ func TestPartialStateJoin(t *testing.T) {
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
 			LocalpartSuffix: "t16alice",
 		})
-		defaultRoomVersion := alice.GetDefaultRoomVersion(t)
 		syncToken := getSyncToken(t, alice)
 		server := createTestServer(t, deployment)
 		cancel := server.Listen()
@@ -1701,7 +1700,7 @@ func TestPartialStateJoin(t *testing.T) {
 		// update the users map in the PL event
 		for _, ev := range initialRoomEvents {
 			if ev.Type == "m.room.power_levels" {
-				if gomatrixserverlib.MustGetRoomVersion(defaultRoomVersion).PrivilegedCreators() {
+				if gomatrixserverlib.MustGetRoomVersion(roomVer).PrivilegedCreators() {
 					ev.Content["users"] = map[string]int64{derek: 50}
 				} else {
 					ev.Content["users"] = map[string]int64{charlie: 100, derek: 50}
@@ -1736,7 +1735,7 @@ func TestPartialStateJoin(t *testing.T) {
 					serverRoom.CurrentState("m.room.power_levels", ""),
 					derekJoinEvent,
 				}
-				if gomatrixserverlib.MustGetRoomVersion(defaultRoomVersion).DomainlessRoomIDs() {
+				if gomatrixserverlib.MustGetRoomVersion(roomVer).DomainlessRoomIDs() {
 					content = content[1:]
 				}
 				return content
@@ -1774,7 +1773,6 @@ func TestPartialStateJoin(t *testing.T) {
 		alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{
 			LocalpartSuffix: "t17alice",
 		})
-		defaultRoomVersion := alice.GetDefaultRoomVersion(t)
 		syncToken := getSyncToken(t, alice)
 		server := createTestServer(t, deployment)
 		cancel := server.Listen()
@@ -1793,7 +1791,7 @@ func TestPartialStateJoin(t *testing.T) {
 		// update the users map in the PL event
 		for _, ev := range initialRoomEvents {
 			if ev.Type == "m.room.power_levels" {
-				if gomatrixserverlib.MustGetRoomVersion(defaultRoomVersion).PrivilegedCreators() {
+				if gomatrixserverlib.MustGetRoomVersion(roomVer).PrivilegedCreators() {
 					ev.Content["users"] = map[string]int64{derek: 100, elsie: 50}
 
 				} else {
@@ -1833,7 +1831,7 @@ func TestPartialStateJoin(t *testing.T) {
 					derekJoinEvent,
 					elsieJoinEvent,
 				}
-				if gomatrixserverlib.MustGetRoomVersion(defaultRoomVersion).DomainlessRoomIDs() {
+				if gomatrixserverlib.MustGetRoomVersion(roomVer).DomainlessRoomIDs() {
 					content = content[1:]
 				}
 				return content
@@ -1858,7 +1856,7 @@ func TestPartialStateJoin(t *testing.T) {
 					serverRoom.CurrentState("m.room.power_levels", ""),
 					elsieJoinEvent,
 				}
-				if gomatrixserverlib.MustGetRoomVersion(defaultRoomVersion).DomainlessRoomIDs() {
+				if gomatrixserverlib.MustGetRoomVersion(roomVer).DomainlessRoomIDs() {
 					content = content[1:]
 				}
 				return content


### PR DESCRIPTION
Largely, this is just "on-the-fly" adjustment of power levels to not contain the room creator, and removing the `m.room.create` event from `auth_events` using a splice. The former was easy to base on the `RoomVersion` having the `PrivilegedCreators` property(for [MSC4289](https://github.com/matrix-org/matrix-spec-proposals/pull/4289)), the latter I chose to go with the existing property `DomainlessRoomIDs` as [MSC4291](https://github.com/matrix-org/matrix-spec-proposals/pull/4291) suggests it is where this requirement for no `m.room.create` event in `auth_events` comes from.

For the regression test `TestDemotingUsersViaUsersDefault`, I opted to change the basis of the test to a different user, to work around the room's creator having an infinite power level.

To fix `TestOutboundFederationIgnoresMissingEventWithBadJSONForRoomVersion6`, this
Depends on:
* https://github.com/matrix-org/gomatrixserverlib/pull/467

### Pull Request Checklist

- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)

Signed-off-by: `Jason Little <j.little@famedly.com>`