### PR TITLE
Fix grammar typo in `serverNames` arg docstring

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -203,7 +203,7 @@ func (c *CSAPI) UpgradeRoom(t ct.TestLike, roomID string, newVersion string) *ht
 //
 // Args:
 //   - `serverNames`: The list of servers to attempt to join the room through.
-//     These should be a resolvable addresses within the deployment network.
+//     These should be a resolvable address within the deployment network.
 func (c *CSAPI) MustJoinRoom(t ct.TestLike, roomIDOrAlias string, serverNames []spec.ServerName) string {
 	t.Helper()
 	res := c.JoinRoom(t, roomIDOrAlias, serverNames)
@@ -221,7 +221,7 @@ func (c *CSAPI) MustJoinRoom(t ct.TestLike, roomIDOrAlias string, serverNames []
 //
 // Args:
 //   - `serverNames`: The list of servers to attempt to join the room through.
-//     These should be a resolvable addresses within the deployment network.
+//     These should be a resolvable address within the deployment network.
 func (c *CSAPI) JoinRoom(t ct.TestLike, roomIDOrAlias string, serverNames []spec.ServerName) *http.Response {
 	t.Helper()
 	// construct URL query parameters

--- a/federation/server.go
+++ b/federation/server.go
@@ -241,7 +241,7 @@ func (s *Server) FederationClient(deployment FederationDeployment) fclient.Feder
 // for any sent PDUs. Times out after 10 seconds.
 //
 // Args:
-//   - `destination`: This should be a resolvable addresses within the deployment network.
+//   - `destination`: This should be a resolvable address within the deployment network.
 func (s *Server) MustSendTransaction(t ct.TestLike, deployment FederationDeployment, destination spec.ServerName, pdus []json.RawMessage, edus []gomatrixserverlib.EDU) {
 	t.Helper()
 	fedClient := s.FederationClient(deployment)
@@ -361,7 +361,7 @@ func (s *Server) MustCreateEvent(t ct.TestLike, room *ServerRoom, ev Event) goma
 // It returns the resultant room.
 //
 // Args:
-//   - `remoteServer`: This should be a resolvable addresses within the deployment network.
+//   - `remoteServer`: This should be a resolvable address within the deployment network.
 func (s *Server) MustJoinRoom(t ct.TestLike, deployment FederationDeployment, remoteServer spec.ServerName, roomID string, userID string, opts ...JoinRoomOpt) *ServerRoom {
 	t.Helper()
 	var jr joinRoom
@@ -446,7 +446,7 @@ func (s *Server) MustJoinRoom(t ct.TestLike, deployment FederationDeployment, re
 // Leaves a room. If this is rejecting an invite then a make_leave request is made first, before send_leave.
 //
 // Args:
-//   - `remoteServer`: This should be a resolvable addresses within the deployment network.
+//   - `remoteServer`: This should be a resolvable address within the deployment network.
 func (s *Server) MustLeaveRoom(t ct.TestLike, deployment FederationDeployment, remoteServer spec.ServerName, roomID string, userID string) {
 	t.Helper()
 	origin := spec.ServerName(s.serverName)

--- a/tests/knocking_test.go
+++ b/tests/knocking_test.go
@@ -303,7 +303,7 @@ func knockingBetweenTwoUsersTest(
 //
 // Args:
 //   - `serverNames`: The list of servers to attempt to knock on the room through.
-//     These should be a resolvable addresses within the deplyment network.
+//     These should be a resolvable address within the deployment network.
 func mustKnockOnRoomSynced(t *testing.T, c *client.CSAPI, roomID, reason string, serverNames []spec.ServerName) {
 	knockOnRoomWithStatus(t, c, roomID, reason, serverNames, 200)
 
@@ -317,7 +317,7 @@ func mustKnockOnRoomSynced(t *testing.T, c *client.CSAPI, roomID, reason string,
 //
 // Args:
 //   - `serverNames`: The list of servers to attempt to knock on the room through.
-//     These should be a resolvable addresses within the deployment network.
+//     These should be a resolvable address within the deployment network.
 func knockOnRoomWithStatus(t *testing.T, c *client.CSAPI, roomID, reason string, serverNames []spec.ServerName, expectedStatus int) {
 	b := []byte("{}")
 	var err error


### PR DESCRIPTION
Fix grammar typo in `serverNames` arg docstring

As spotted by @anoadragon453, https://github.com/matrix-org/complement/pull/796#discussion_r3318905933


### Pull Request Checklist

- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)

