### PR TITLE
Perform UIA correctly when registering users on a deployment

### DIFF
--- a/client/auth.go
+++ b/client/auth.go
@@ -118,14 +118,14 @@ func (c *CSAPI) RegisterUser(t ct.TestLike, localpart, password string) (userID,
 		ct.Fatalf(t, "unable to read response body: %v", err)
 	}
 	session := GetJSONFieldStr(t, body, "session")
-	if session == "" {
-		ct.Fatalf(t, "uia challenge did not include a session")
-	}
 
 	// Now actually register the user
 	reqBody["auth"] = map[string]any{
 		"session": session,
 		"type":    "m.login.dummy",
+	}
+	if session == "" {
+		delete(reqBody["auth"].(map[string]any), "session")
 	}
 	res = c.MustDo(t, "POST", []string{"_matrix", "client", "v3", "register"}, WithJSONBody(t, reqBody))
 	body, err = io.ReadAll(res.Body)

--- a/client/auth.go
+++ b/client/auth.go
@@ -99,19 +99,36 @@ func (c *CSAPI) ConsumeRefreshToken(t ct.TestLike, refreshToken string) (newAcce
 }
 
 // RegisterUser will register the user with given parameters and
-// return user ID, access token and device ID. It fails the test on network error.
+// return user ID, access token and device ID. It fails the test on network error,
+// or if registration fails for another reason (e.g. server has non-dummy requirements).
 func (c *CSAPI) RegisterUser(t ct.TestLike, localpart, password string) (userID, accessToken, deviceID string) {
 	t.Helper()
-	reqBody := map[string]interface{}{
-		"auth": map[string]string{
-			"type": "m.login.dummy",
-		},
+	reqBody := map[string]any{
 		"username": localpart,
 		"password": password,
 	}
-	res := c.MustDo(t, "POST", []string{"_matrix", "client", "v3", "register"}, WithJSONBody(t, reqBody))
+	// First request is expected to receive a UIA challenge
+	res := c.Do(t, "POST", []string{"_matrix", "client", "v3", "register"}, WithJSONBody(t, reqBody))
+	if res.StatusCode != 401 {
+		ct.Fatalf(t, "Expected 401 Unauthorized, got %d", res.StatusCode)
+	}
 
 	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		ct.Fatalf(t, "unable to read response body: %v", err)
+	}
+	session := GetJSONFieldStr(t, body, "session")
+	if session == "" {
+		ct.Fatalf(t, "uia challenge did not include a session")
+	}
+
+	// Now actually register the user
+	reqBody["auth"] = map[string]any{
+		"session": session,
+		"type":    "m.login.dummy",
+	}
+	res = c.MustDo(t, "POST", []string{"_matrix", "client", "v3", "register"}, WithJSONBody(t, reqBody))
+	body, err = io.ReadAll(res.Body)
 	if err != nil {
 		ct.Fatalf(t, "unable to read response body: %v", err)
 	}

--- a/tests/csapi/apidoc_register_test.go
+++ b/tests/csapi/apidoc_register_test.go
@@ -344,9 +344,9 @@ func startUIASession(t *testing.T, c *client.CSAPI, user, pass string, extra map
 		t.Fatal(err)
 	}
 	session := client.GetJSONFieldStr(t, body, "session")
-	if session == "" {
-		t.Fatal("expected non-empty `session` in uia challenge")
-	}
 	reqBody["auth"] = map[string]string{"session": session, "type": "m.login.dummy"}
+	if session == "" {
+		delete(reqBody["auth"].(map[string]any), "session")
+	}
 	return reqBody, session
 }

--- a/tests/csapi/apidoc_register_test.go
+++ b/tests/csapi/apidoc_register_test.go
@@ -6,7 +6,9 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
+	"maps"
 	"net/http"
 	"net/url"
 	"testing"
@@ -63,14 +65,10 @@ func TestRegistration(t *testing.T) {
 		// sytest: POST /register can create a user
 		t.Run("POST /register can create a user", func(t *testing.T) {
 			t.Parallel()
-			res := unauthedClient.Do(t, "POST", []string{"_matrix", "client", "v3", "register"}, client.WithRawBody(json.RawMessage(`{
-				"auth": {
-					"type": "m.login.dummy"
-				},
-				"username": "post-can-create-a-user",
-				"password": "sUp3rs3kr1t"
-			}`)))
+			reqBody, _ := startUIASession(t, unauthedClient, "post-can-create-a-user", "sUp3rs3kr1t", nil)
+			res := unauthedClient.Do(t, "POST", []string{"_matrix", "client", "v3", "register"}, client.WithJSONBody(t, reqBody))
 			must.MatchResponse(t, res, match.HTTPResponse{
+				StatusCode: 200,
 				JSON: []match.JSON{
 					match.JSONKeyTypeEqual("access_token", gjson.String),
 					match.JSONKeyTypeEqual("user_id", gjson.String),
@@ -80,14 +78,10 @@ func TestRegistration(t *testing.T) {
 		// sytest: POST /register downcases capitals in usernames
 		t.Run("POST /register downcases capitals in usernames", func(t *testing.T) {
 			t.Parallel()
-			res := unauthedClient.Do(t, "POST", []string{"_matrix", "client", "v3", "register"}, client.WithRawBody(json.RawMessage(`{
-				"auth": {
-					"type": "m.login.dummy"
-				},
-				"username": "user-UPPER",
-				"password": "sUp3rs3kr1t"
-			}`)))
+			reqBody, _ := startUIASession(t, unauthedClient, "user-UPPER", "sUp3rs3kr1t", nil)
+			res := unauthedClient.Do(t, "POST", []string{"_matrix", "client", "v3", "register"}, client.WithJSONBody(t, reqBody))
 			must.MatchResponse(t, res, match.HTTPResponse{
+				StatusCode: 200,
 				JSON: []match.JSON{
 					match.JSONKeyTypeEqual("access_token", gjson.String),
 					match.JSONKeyEqual("user_id", "@user-upper:hs1"),
@@ -98,15 +92,10 @@ func TestRegistration(t *testing.T) {
 		t.Run("POST /register returns the same device_id as that in the request", func(t *testing.T) {
 			t.Parallel()
 			deviceID := "my_device_id"
-			res := unauthedClient.Do(t, "POST", []string{"_matrix", "client", "v3", "register"}, client.WithRawBody(json.RawMessage(`{
-				"auth": {
-					"type": "m.login.dummy"
-				},
-				"username": "user-device",
-				"password": "sUp3rs3kr1t",
-				"device_id": "`+deviceID+`"
-			}`)))
+			reqBody, _ := startUIASession(t, unauthedClient, "user-device", deviceID, map[string]any{"device_id": deviceID})
+			res := unauthedClient.Do(t, "POST", []string{"_matrix", "client", "v3", "register"}, client.WithJSONBody(t, reqBody))
 			must.MatchResponse(t, res, match.HTTPResponse{
+				StatusCode: 200,
 				JSON: []match.JSON{
 					match.JSONKeyTypeEqual("access_token", gjson.String),
 					match.JSONKeyEqual("device_id", deviceID),
@@ -134,14 +123,10 @@ func TestRegistration(t *testing.T) {
 				`'`,
 			}
 			for _, ch := range specialChars {
-				res := unauthedClient.Do(t, "POST", []string{"_matrix", "client", "v3", "register"},
-					client.WithJSONBody(t, map[string]interface{}{
-						"auth": map[string]string{
-							"type": "m.login.dummy",
-						},
-						"username": "user-" + ch + "-reject-please",
-						"password": "sUp3rs3kr1t",
-					}))
+				// CONCERN: Should servers be expected to validate parameters before starting a UIA session?
+				// This test will flake if they do so, since 401 will be returned instead of 400.
+				reqBody, _ := startUIASession(t, unauthedClient, "user-"+ch+"-reject-please", "sUp3rs3kr1t", nil)
+				res := unauthedClient.Do(t, "POST", []string{"_matrix", "client", "v3", "register"}, client.WithJSONBody(t, reqBody))
 				must.MatchResponse(t, res, match.HTTPResponse{
 					StatusCode: 400,
 					JSON: []match.JSON{
@@ -152,28 +137,21 @@ func TestRegistration(t *testing.T) {
 		})
 		t.Run("POST /register rejects if user already exists", func(t *testing.T) {
 			t.Parallel()
-			res := unauthedClient.Do(t, "POST", []string{"_matrix", "client", "v3", "register"}, client.WithRawBody(json.RawMessage(`{
-				"auth": {
-					"type": "m.login.dummy"
-				},
-				"username": "post-can-create-a-user-once",
-				"password": "sUp3rs3kr1t"
-			}`)))
+			reqBody, _ := startUIASession(t, unauthedClient, "post-can-create-a-user-once", "sUp3rs3kr1t", nil)
+			res := unauthedClient.Do(t, "POST", []string{"_matrix", "client", "v3", "register"}, client.WithJSONBody(t, reqBody))
 			must.MatchResponse(t, res, match.HTTPResponse{
 				JSON: []match.JSON{
 					match.JSONKeyTypeEqual("access_token", gjson.String),
 					match.JSONKeyTypeEqual("user_id", gjson.String),
 				},
 			})
-			res = unauthedClient.Do(t, "POST", []string{"_matrix", "client", "v3", "register"}, client.WithRawBody(json.RawMessage(`{
-				"auth": {
-					"type": "m.login.dummy"
-				},
-				"username": "post-can-create-a-user-once",
-				"password": "anotherSuperSecret"
-			}`)))
+			reqBody, _ = startUIASession(t, unauthedClient, "post-can-create-a-user-once", "sUp3rs3kr1t", nil)
+			res = unauthedClient.Do(t, "POST", []string{"_matrix", "client", "v3", "register"}, client.WithJSONBody(t, reqBody))
 			must.MatchResponse(t, res, match.HTTPResponse{
 				StatusCode: 400,
+				JSON: []match.JSON{
+					match.JSONKeyEqual("errcode", "M_USER_IN_USE"),
+				},
 			})
 		})
 		// sytest: POST /register allows registration of usernames with '$chr'
@@ -345,4 +323,30 @@ func registerSharedSecret(t *testing.T, c *client.CSAPI, user, pass string, isAd
 	}
 	resp = c.Do(t, "POST", []string{"_synapse", "admin", "v1", "register"}, client.WithJSONBody(t, reqBody))
 	return resp
+}
+
+// startUIASession starts a UIA session and returns the updated request body,
+// and associated session token, failing the test if the response is not a UIA challenge.
+func startUIASession(t *testing.T, c *client.CSAPI, user, pass string, extra map[string]any) (map[string]any, string) {
+	reqBody := map[string]any{
+		"username": user,
+		"password": pass,
+	}
+	if extra != nil {
+		maps.Copy(extra, reqBody)
+	}
+	res := c.Do(t, "POST", []string{"_matrix", "client", "v3", "register"}, client.WithJSONBody(t, reqBody))
+	if res.StatusCode != 401 {
+		t.Fatalf("expected status code 401 (UIA challenge), got %d", res.StatusCode)
+	}
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	session := client.GetJSONFieldStr(t, body, "session")
+	if session == "" {
+		t.Fatal("expected non-empty `session` in uia challenge")
+	}
+	reqBody["auth"] = map[string]string{"session": session, "type": "m.login.dummy"}
+	return reqBody, session
 }

--- a/tests/csapi/apidoc_register_test.go
+++ b/tests/csapi/apidoc_register_test.go
@@ -123,10 +123,13 @@ func TestRegistration(t *testing.T) {
 				`'`,
 			}
 			for _, ch := range specialChars {
-				// CONCERN: Should servers be expected to validate parameters before starting a UIA session?
-				// This test will flake if they do so, since 401 will be returned instead of 400.
-				reqBody, _ := startUIASession(t, unauthedClient, "user-"+ch+"-reject-please", "sUp3rs3kr1t", nil)
+				reqBody := map[string]any{
+					"username": "user-" + ch + "-reject-please",
+					"password": "sUp3rs3kr1t",
+				}
 				res := unauthedClient.Do(t, "POST", []string{"_matrix", "client", "v3", "register"}, client.WithJSONBody(t, reqBody))
+				// N.B. servers are expected to validate request bodies before handling UIA,
+				// so 400 is expected here, not 401.
 				must.MatchResponse(t, res, match.HTTPResponse{
 					StatusCode: 400,
 					JSON: []match.JSON{
@@ -145,7 +148,8 @@ func TestRegistration(t *testing.T) {
 					match.JSONKeyTypeEqual("user_id", gjson.String),
 				},
 			})
-			reqBody, _ = startUIASession(t, unauthedClient, "post-can-create-a-user-once", "sUp3rs3kr1t", nil)
+			// Since servers validate the request body before handling auth, this returns 400
+			delete(reqBody, "auth")
 			res = unauthedClient.Do(t, "POST", []string{"_matrix", "client", "v3", "register"}, client.WithJSONBody(t, reqBody))
 			must.MatchResponse(t, res, match.HTTPResponse{
 				StatusCode: 400,
@@ -350,7 +354,7 @@ func startUIASession(t *testing.T, c *client.CSAPI, user, pass string, extra map
 		"password": pass,
 	}
 	if extra != nil {
-		maps.Copy(extra, reqBody)
+		maps.Copy(reqBody, extra)
 	}
 	res := c.Do(t, "POST", []string{"_matrix", "client", "v3", "register"}, client.WithJSONBody(t, reqBody))
 	if res.StatusCode != 401 {

--- a/tests/csapi/apidoc_register_test.go
+++ b/tests/csapi/apidoc_register_test.go
@@ -286,6 +286,23 @@ func TestRegistration(t *testing.T) {
 				},
 			})
 		})
+		// Test that subsequent calls to /_matrix/client/v3/register after receiving a UIA
+		// challenge fail if the session is not provided.
+		t.Run("Registration without a session fails", func(t *testing.T) {
+			t.Parallel()
+			reqBody, session := startUIASession(t, unauthedClient, "auth-requires-session", "sUp3rs3kr1t", nil)
+			if session == "" {
+				t.Skip("Homeserver does not require a session for UIA")
+			}
+			delete(reqBody["auth"].(map[string]any), "session")
+			// Re-send the same request without the session.
+			// Since session is required if it is provided by the homeserver, this should
+			// return an error
+			res := unauthedClient.Do(t, "POST", []string{"_matrix", "client", "v3", "register"}, client.WithJSONBody(t, reqBody))
+			must.MatchResponse(t, res, match.HTTPResponse{
+				StatusCode: 401,
+			})
+		})
 	})
 }
 
@@ -344,7 +361,7 @@ func startUIASession(t *testing.T, c *client.CSAPI, user, pass string, extra map
 		t.Fatal(err)
 	}
 	session := client.GetJSONFieldStr(t, body, "session")
-	reqBody["auth"] = map[string]string{"session": session, "type": "m.login.dummy"}
+	reqBody["auth"] = map[string]any{"session": session, "type": "m.login.dummy"}
 	if session == "" {
 		delete(reqBody["auth"].(map[string]any), "session")
 	}

--- a/tests/csapi/apidoc_register_test.go
+++ b/tests/csapi/apidoc_register_test.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/matrix-org/complement/runtime"
 	"github.com/tidwall/gjson"
 
 	"github.com/matrix-org/complement"
@@ -293,6 +294,8 @@ func TestRegistration(t *testing.T) {
 		// Test that subsequent calls to /_matrix/client/v3/register after receiving a UIA
 		// challenge fail if the session is not provided.
 		t.Run("Registration without a session fails", func(t *testing.T) {
+			// Many implementations historically did not enforce this requirement strictly
+			runtime.SkipIf(t, runtime.Synapse, runtime.Dendrite, runtime.Conduit)
 			t.Parallel()
 			reqBody, session := startUIASession(t, unauthedClient, "auth-requires-session", "sUp3rs3kr1t", nil)
 			if session == "" {

--- a/tests/csapi/apidoc_register_test.go
+++ b/tests/csapi/apidoc_register_test.go
@@ -149,8 +149,8 @@ func TestRegistration(t *testing.T) {
 					match.JSONKeyTypeEqual("user_id", gjson.String),
 				},
 			})
-			// Since servers validate the request body before handling auth, this returns 400
-			delete(reqBody, "auth")
+			_, session := startUIASession(t, unauthedClient, "post-can-create-a-user-once", "sUp3rs3kr1t", nil)
+			reqBody["auth"].(map[string]any)["session"] = session
 			res = unauthedClient.Do(t, "POST", []string{"_matrix", "client", "v3", "register"}, client.WithJSONBody(t, reqBody))
 			must.MatchResponse(t, res, match.HTTPResponse{
 				StatusCode: 400,

--- a/tests/csapi/apidoc_register_test.go
+++ b/tests/csapi/apidoc_register_test.go
@@ -140,6 +140,10 @@ func TestRegistration(t *testing.T) {
 			}
 		})
 		t.Run("POST /register rejects if user already exists", func(t *testing.T) {
+			// Dendrite: auth is validated before input, meaning the second register request needs to start a fresh
+			// auth session. This conflicts with Synapse, which forbids a second session being started, as it
+			// validates the input before auth. Skip on Dendrite for now.
+			runtime.SkipIf(t, runtime.Dendrite)
 			t.Parallel()
 			reqBody, _ := startUIASession(t, unauthedClient, "post-can-create-a-user-once", "sUp3rs3kr1t", nil)
 			res := unauthedClient.Do(t, "POST", []string{"_matrix", "client", "v3", "register"}, client.WithJSONBody(t, reqBody))
@@ -149,8 +153,7 @@ func TestRegistration(t *testing.T) {
 					match.JSONKeyTypeEqual("user_id", gjson.String),
 				},
 			})
-			_, session := startUIASession(t, unauthedClient, "post-can-create-a-user-once", "sUp3rs3kr1t", nil)
-			reqBody["auth"].(map[string]any)["session"] = session
+			delete(reqBody, "auth")
 			res = unauthedClient.Do(t, "POST", []string{"_matrix", "client", "v3", "register"}, client.WithJSONBody(t, reqBody))
 			must.MatchResponse(t, res, match.HTTPResponse{
 				StatusCode: 400,


### PR DESCRIPTION
Fixes #893 by:

* Correctly initiating and completing a UIA session when calling `CSApi.RegisterUser`
* Using a helper function to initiate UIA and then complete it during `TestRegistration`
* Adding a test to `TestRegistration` that ensures homeservers [enforce the requirement for the `session` auth field](https://spec.matrix.org/v1.19/client-server-api/#overview:~:text=It%20must%20also%20contain%20a%20session%20key%20with%20the%20value%20of%20the%20session%20key%20given%20by%20the%20homeserver%2C%20if%20one%20was%20given), but only when a `session` is given at all

This PR does not fix the fact that Complement *assumes* the target homeserver returns at least one flow whose only stage is `m.login.dummy`, but this is seen as a non-issue given there isn't really a reasonable way to dynamically pass the challenge.

### Pull Request Checklist

- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)

