### PR TITLE
Add Venator homeserver blacklist build tag

### DIFF
--- a/runtime/hs.go
+++ b/runtime/hs.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"slices"
 
 	"github.com/docker/docker/client"
 	"github.com/matrix-org/complement/ct"
@@ -12,6 +13,7 @@ const (
 	Synapse   = "synapse"
 	Conduit   = "conduit"
 	Conduwuit = "conduwuit"
+	Venator   = "venator"
 )
 
 var Homeserver string
@@ -49,4 +51,20 @@ func SkipIf(t ct.TestLike, hses ...string) {
 			t.Name(), hses,
 		)
 	}
+}
+
+// SkipUnless is the inverse of SkipIf: if the homeserver being tested is not present in the provided set, the test is skipped.
+// This also means running without a blacklist tag will always skip.
+func SkipUnless(t ct.TestLike, hses ...string) {
+	t.Helper()
+	if slices.Contains(hses, Homeserver) {
+		return
+	}
+	if Homeserver == "" {
+		t.Logf(
+			"WARNING: %s called runtime.SkipUnless(%v) but Complement doesn't know which HS is running as it was run without a *_blacklist tag: not executing test.",
+			t.Name(), hses,
+		)
+	}
+	t.Skipf("test only runs on specific homeservers: %v", hses)
 }

--- a/runtime/hs_venator.go
+++ b/runtime/hs_venator.go
@@ -1,0 +1,7 @@
+//go:build venator_blacklist
+
+package runtime
+
+func init() {
+	Homeserver = Venator
+}

--- a/tests/csapi/account_change_password_pushers_test.go
+++ b/tests/csapi/account_change_password_pushers_test.go
@@ -1,5 +1,7 @@
-//go:build !dendrite_blacklist
-// +build !dendrite_blacklist
+//go:build !dendrite_blacklist && !venator_blacklist
+// +build !dendrite_blacklist,!venator_blacklist
+
+// Venator: https://github.com/matrix-org/complement/issues/897
 
 package csapi_tests
 

--- a/tests/csapi/account_change_password_test.go
+++ b/tests/csapi/account_change_password_test.go
@@ -9,11 +9,16 @@ import (
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
+	"github.com/matrix-org/complement/runtime"
 
 	"github.com/tidwall/gjson"
 )
 
 func TestChangePassword(t *testing.T) {
+	// Venator: https://github.com/matrix-org/complement/issues/897
+	// Omitting the entire file via build tag breaks other test files due to the definition of createSession
+	runtime.SkipIf(t, runtime.Venator)
+
 	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 	password1 := "superuser"

--- a/tests/csapi/account_deactivate_test.go
+++ b/tests/csapi/account_deactivate_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/matrix-org/complement/runtime"
 	"github.com/tidwall/gjson"
 
 	"github.com/matrix-org/complement"
@@ -73,6 +74,8 @@ func TestDeactivateAccount(t *testing.T) {
 
 	// sytest: Can't deactivate account with wrong password
 	t.Run("Can't deactivate account with wrong password", func(t *testing.T) {
+		// Venator: https://github.com/matrix-org/complement/issues/898
+		runtime.SkipIf(t, runtime.Venator)
 		res := deactivateAccount(t, authedClient, "wrong_password")
 		must.MatchResponse(t, res, match.HTTPResponse{
 			StatusCode: 401,
@@ -83,6 +86,8 @@ func TestDeactivateAccount(t *testing.T) {
 	})
 	// sytest: Can deactivate account
 	t.Run("Can deactivate account", func(t *testing.T) {
+		// Venator: https://github.com/matrix-org/complement/issues/898
+		runtime.SkipIf(t, runtime.Venator)
 
 		res := deactivateAccount(t, authedClient, password)
 		must.MatchResponse(t, res, match.HTTPResponse{
@@ -91,6 +96,8 @@ func TestDeactivateAccount(t *testing.T) {
 	})
 	// sytest: After deactivating account, can't log in with password
 	t.Run("After deactivating account, can't log in with password", func(t *testing.T) {
+		// Venator: https://github.com/matrix-org/complement/issues/898
+		runtime.SkipIf(t, runtime.Venator)
 
 		reqBody := client.WithJSONBody(t, map[string]interface{}{
 			"identifier": map[string]interface{}{

--- a/tests/csapi/apidoc_content_test.go
+++ b/tests/csapi/apidoc_content_test.go
@@ -14,6 +14,8 @@ import (
 func TestContent(t *testing.T) {
 	// Synapse no longer allows downloads over the unauthenticated media endpoints by default
 	runtime.SkipIf(t, runtime.Synapse)
+	// Venator is too young for any media to be available over the unauthenticated API, and always returns M_NOT_FOUND
+	runtime.SkipIf(t, runtime.Venator)
 
 	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)

--- a/tests/csapi/apidoc_device_management_test.go
+++ b/tests/csapi/apidoc_device_management_test.go
@@ -3,6 +3,7 @@ package csapi_tests
 import (
 	"testing"
 
+	"github.com/matrix-org/complement/runtime"
 	"github.com/tidwall/gjson"
 
 	"github.com/matrix-org/complement"
@@ -126,6 +127,8 @@ func TestDeviceManagement(t *testing.T) {
 
 	// sytest: DELETE /device/{deviceId}
 	t.Run("DELETE /device/{deviceId}", func(t *testing.T) {
+		// Venator: https://github.com/matrix-org/complement/issues/899
+		runtime.SkipIf(t, runtime.Venator)
 		newDeviceID, session2 := createSession(t, deployment, authedClient.UserID, "superuser")
 		session2.MustSync(t, client.SyncReq{})
 
@@ -196,6 +199,8 @@ func TestDeviceManagement(t *testing.T) {
 	})
 	// sytest: DELETE /device/{deviceId} requires UI auth user to match device owner
 	t.Run("DELETE /device/{deviceId} requires UI auth user to match device owner", func(t *testing.T) {
+		// Venator: https://github.com/matrix-org/complement/issues/899
+		runtime.SkipIf(t, runtime.Venator)
 		bob := deployment.Register(t, "hs1", helpers.RegistrationOpts{
 			LocalpartSuffix: "bob",
 			Password:        "bobspassword",

--- a/tests/csapi/apidoc_presence_test.go
+++ b/tests/csapi/apidoc_presence_test.go
@@ -1,7 +1,8 @@
-//go:build !dendrite_blacklist
-// +build !dendrite_blacklist
+//go:build !dendrite_blacklist && !venator_blacklist
+// +build !dendrite_blacklist,!venator_blacklist
 
 // Rationale for being included in Dendrite's blacklist: https://github.com/matrix-org/complement/pull/104#discussion_r617646624
+// Venator: Does not implement presence
 
 package csapi_tests
 

--- a/tests/csapi/apidoc_register_test.go
+++ b/tests/csapi/apidoc_register_test.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/matrix-org/complement/runtime"
 	"github.com/tidwall/gjson"
 
 	"github.com/matrix-org/complement"
@@ -62,6 +63,8 @@ func TestRegistration(t *testing.T) {
 		})
 		// sytest: POST /register can create a user
 		t.Run("POST /register can create a user", func(t *testing.T) {
+			// Venator: https://github.com/matrix-org/complement/issues/893
+			runtime.SkipIf(t, runtime.Venator)
 			t.Parallel()
 			res := unauthedClient.Do(t, "POST", []string{"_matrix", "client", "v3", "register"}, client.WithRawBody(json.RawMessage(`{
 				"auth": {
@@ -79,6 +82,8 @@ func TestRegistration(t *testing.T) {
 		})
 		// sytest: POST /register downcases capitals in usernames
 		t.Run("POST /register downcases capitals in usernames", func(t *testing.T) {
+			// Venator: https://github.com/matrix-org/complement/issues/893
+			runtime.SkipIf(t, runtime.Venator)
 			t.Parallel()
 			res := unauthedClient.Do(t, "POST", []string{"_matrix", "client", "v3", "register"}, client.WithRawBody(json.RawMessage(`{
 				"auth": {
@@ -96,6 +101,8 @@ func TestRegistration(t *testing.T) {
 		})
 		// sytest: POST /register returns the same device_id as that in the request
 		t.Run("POST /register returns the same device_id as that in the request", func(t *testing.T) {
+			// Venator: https://github.com/matrix-org/complement/issues/893
+			runtime.SkipIf(t, runtime.Venator)
 			t.Parallel()
 			deviceID := "my_device_id"
 			res := unauthedClient.Do(t, "POST", []string{"_matrix", "client", "v3", "register"}, client.WithRawBody(json.RawMessage(`{
@@ -115,6 +122,8 @@ func TestRegistration(t *testing.T) {
 		})
 		// sytest: POST /register rejects registration of usernames with '$q'
 		t.Run("POST /register rejects usernames with special characters", func(t *testing.T) {
+			// Venator: https://github.com/matrix-org/complement/issues/893
+			runtime.SkipIf(t, runtime.Venator)
 			t.Parallel()
 			specialChars := []string{
 				`!`,
@@ -151,6 +160,8 @@ func TestRegistration(t *testing.T) {
 			}
 		})
 		t.Run("POST /register rejects if user already exists", func(t *testing.T) {
+			// Venator: https://github.com/matrix-org/complement/issues/893
+			runtime.SkipIf(t, runtime.Venator)
 			t.Parallel()
 			res := unauthedClient.Do(t, "POST", []string{"_matrix", "client", "v3", "register"}, client.WithRawBody(json.RawMessage(`{
 				"auth": {
@@ -178,6 +189,8 @@ func TestRegistration(t *testing.T) {
 		})
 		// sytest: POST /register allows registration of usernames with '$chr'
 		t.Run("POST /register allows registration of usernames with ", func(t *testing.T) {
+			// Venator: https://github.com/matrix-org/complement/issues/893
+			runtime.SkipIf(t, runtime.Venator)
 			testChars := []rune("q3._=-/")
 			for x := range testChars {
 				localpart := fmt.Sprintf("chrtestuser%s", string(testChars[x]))

--- a/tests/csapi/apidoc_room_alias_test.go
+++ b/tests/csapi/apidoc_room_alias_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/matrix-org/complement/runtime"
 	"github.com/tidwall/gjson"
 
 	"github.com/matrix-org/complement"
@@ -276,6 +277,8 @@ func TestRoomDeleteAlias(t *testing.T) {
 
 		// sytest: Can delete canonical alias
 		t.Run("Can delete canonical alias", func(t *testing.T) {
+			// Venator: https://github.com/matrix-org/complement/issues/900
+			runtime.SkipIf(t, runtime.Venator)
 			t.Parallel()
 
 			roomID := alice.MustCreateRoom(t, map[string]interface{}{})
@@ -383,6 +386,8 @@ func TestRoomDeleteAlias(t *testing.T) {
 
 		// sytest: Users can't delete other's aliases
 		t.Run("Users can't delete other's aliases", func(t *testing.T) {
+			// Venator: https://github.com/matrix-org/complement/issues/900
+			runtime.SkipIf(t, runtime.Venator)
 			t.Parallel()
 
 			roomID := alice.MustCreateRoom(t, map[string]interface{}{})
@@ -416,6 +421,9 @@ func TestRoomDeleteAlias(t *testing.T) {
 
 		// sytest: Users with sufficient power-level can delete other's aliases
 		t.Run("Users with sufficient power-level can delete other's aliases", func(t *testing.T) {
+			// Venator: https://github.com/matrix-org/complement/issues/900
+			// This technically passes, but not because of the behaviour this test is testing for.
+			runtime.SkipIf(t, runtime.Venator)
 			t.Parallel()
 
 			roomID := alice.MustCreateRoom(t, map[string]interface{}{})

--- a/tests/csapi/apidoc_room_create_test.go
+++ b/tests/csapi/apidoc_room_create_test.go
@@ -158,6 +158,8 @@ func TestRoomCreate(t *testing.T) {
 		})
 		// sytest: POST /createRoom creates a room with the given version
 		t.Run("POST /createRoom creates a room with the given version", func(t *testing.T) {
+			// Venator: does not support room v2 (>=v10 only)
+			runtime.SkipIf(t, runtime.Venator)
 			t.Parallel()
 			roomID := alice.MustCreateRoom(t, map[string]interface{}{
 				"room_version": "2",

--- a/tests/csapi/apidoc_room_forget_test.go
+++ b/tests/csapi/apidoc_room_forget_test.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/matrix-org/complement/runtime"
 	"github.com/tidwall/gjson"
 
 	"github.com/matrix-org/complement"
@@ -39,6 +40,8 @@ func TestRoomForget(t *testing.T) {
 		})
 		// sytest: Forgotten room messages cannot be paginated
 		t.Run("Forgotten room messages cannot be paginated", func(t *testing.T) {
+			// Venator: does not implement manual room forgetting (is always done automatically on leave)
+			runtime.SkipIf(t, runtime.Venator)
 			t.Parallel()
 			roomID := alice.MustCreateRoom(t, map[string]interface{}{"preset": "public_chat"})
 			bob.MustJoinRoom(t, roomID, []spec.ServerName{})
@@ -61,6 +64,8 @@ func TestRoomForget(t *testing.T) {
 		})
 		// sytest: Forgetting room does not show up in v2 /sync
 		t.Run("Forgetting room does not show up in v2 initial /sync", func(t *testing.T) {
+			// Venator: does not implement manual room forgetting (is always done automatically on leave)
+			runtime.SkipIf(t, runtime.Venator)
 			t.Parallel()
 			roomID := alice.MustCreateRoom(t, map[string]interface{}{"preset": "public_chat"})
 			bob.MustJoinRoom(t, roomID, []spec.ServerName{})
@@ -102,6 +107,8 @@ func TestRoomForget(t *testing.T) {
 			}
 		})
 		t.Run("Leave for forgotten room shows up in v2 incremental /sync", func(t *testing.T) {
+			// Venator: does not implement manual room forgetting (is always done automatically on leave)
+			runtime.SkipIf(t, runtime.Venator)
 			// Note that this test runs counter to the wording of the spec. At the time of writing,
 			// the spec says that forgotten rooms should not show up in any /sync responses, but
 			// that would make it impossible for other devices to determine that a room has been
@@ -144,6 +151,8 @@ func TestRoomForget(t *testing.T) {
 		})
 		// sytest: Can forget room you've been kicked from
 		t.Run("Can forget room you've been kicked from", func(t *testing.T) {
+			// Venator: does not implement manual room forgetting (is always done automatically on leave)
+			runtime.SkipIf(t, runtime.Venator)
 			t.Parallel()
 			roomID := alice.MustCreateRoom(t, map[string]interface{}{"preset": "public_chat"})
 			bob.MustJoinRoom(t, roomID, []spec.ServerName{})
@@ -176,6 +185,8 @@ func TestRoomForget(t *testing.T) {
 
 		// sytest: Can re-join room if re-invited
 		t.Run("Can re-join room if re-invited", func(t *testing.T) {
+			// Venator: does not implement manual room forgetting (is always done automatically on leave)
+			runtime.SkipIf(t, runtime.Venator)
 			t.Parallel()
 			roomID := alice.MustCreateRoom(t, map[string]interface{}{"preset": "private_chat"})
 			// Invite Bob
@@ -248,6 +259,8 @@ func TestRoomForget(t *testing.T) {
 		})
 
 		t.Run("Can forget room we weren't an actual member", func(t *testing.T) {
+			// Venator: does not implement manual room forgetting (is always done automatically on leave)
+			runtime.SkipIf(t, runtime.Venator)
 			t.Parallel()
 			roomID := alice.MustCreateRoom(t, map[string]interface{}{"preset": "private_chat"})
 			alice.MustInviteRoom(t, roomID, bob.UserID)

--- a/tests/csapi/apidoc_room_forget_test.go
+++ b/tests/csapi/apidoc_room_forget_test.go
@@ -20,6 +20,8 @@ import (
 
 // These tests ensure that forgetting about rooms works as intended
 func TestRoomForget(t *testing.T) {
+	// Venator: does not implement manual room forgetting (is always done automatically on leave)
+	runtime.SkipIf(t, runtime.Venator)
 	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
@@ -40,8 +42,6 @@ func TestRoomForget(t *testing.T) {
 		})
 		// sytest: Forgotten room messages cannot be paginated
 		t.Run("Forgotten room messages cannot be paginated", func(t *testing.T) {
-			// Venator: does not implement manual room forgetting (is always done automatically on leave)
-			runtime.SkipIf(t, runtime.Venator)
 			t.Parallel()
 			roomID := alice.MustCreateRoom(t, map[string]interface{}{"preset": "public_chat"})
 			bob.MustJoinRoom(t, roomID, []spec.ServerName{})
@@ -64,8 +64,6 @@ func TestRoomForget(t *testing.T) {
 		})
 		// sytest: Forgetting room does not show up in v2 /sync
 		t.Run("Forgetting room does not show up in v2 initial /sync", func(t *testing.T) {
-			// Venator: does not implement manual room forgetting (is always done automatically on leave)
-			runtime.SkipIf(t, runtime.Venator)
 			t.Parallel()
 			roomID := alice.MustCreateRoom(t, map[string]interface{}{"preset": "public_chat"})
 			bob.MustJoinRoom(t, roomID, []spec.ServerName{})
@@ -107,8 +105,6 @@ func TestRoomForget(t *testing.T) {
 			}
 		})
 		t.Run("Leave for forgotten room shows up in v2 incremental /sync", func(t *testing.T) {
-			// Venator: does not implement manual room forgetting (is always done automatically on leave)
-			runtime.SkipIf(t, runtime.Venator)
 			// Note that this test runs counter to the wording of the spec. At the time of writing,
 			// the spec says that forgotten rooms should not show up in any /sync responses, but
 			// that would make it impossible for other devices to determine that a room has been
@@ -151,8 +147,6 @@ func TestRoomForget(t *testing.T) {
 		})
 		// sytest: Can forget room you've been kicked from
 		t.Run("Can forget room you've been kicked from", func(t *testing.T) {
-			// Venator: does not implement manual room forgetting (is always done automatically on leave)
-			runtime.SkipIf(t, runtime.Venator)
 			t.Parallel()
 			roomID := alice.MustCreateRoom(t, map[string]interface{}{"preset": "public_chat"})
 			bob.MustJoinRoom(t, roomID, []spec.ServerName{})
@@ -185,8 +179,6 @@ func TestRoomForget(t *testing.T) {
 
 		// sytest: Can re-join room if re-invited
 		t.Run("Can re-join room if re-invited", func(t *testing.T) {
-			// Venator: does not implement manual room forgetting (is always done automatically on leave)
-			runtime.SkipIf(t, runtime.Venator)
 			t.Parallel()
 			roomID := alice.MustCreateRoom(t, map[string]interface{}{"preset": "private_chat"})
 			// Invite Bob
@@ -259,8 +251,6 @@ func TestRoomForget(t *testing.T) {
 		})
 
 		t.Run("Can forget room we weren't an actual member", func(t *testing.T) {
-			// Venator: does not implement manual room forgetting (is always done automatically on leave)
-			runtime.SkipIf(t, runtime.Venator)
 			t.Parallel()
 			roomID := alice.MustCreateRoom(t, map[string]interface{}{"preset": "private_chat"})
 			alice.MustInviteRoom(t, roomID, bob.UserID)

--- a/tests/csapi/apidoc_room_state_test.go
+++ b/tests/csapi/apidoc_room_state_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/matrix-org/complement/runtime"
 	"github.com/tidwall/gjson"
 
 	"github.com/matrix-org/complement"
@@ -329,6 +330,8 @@ func TestRoomState(t *testing.T) {
 			})
 		})
 		t.Run("GET /rooms/:room_id/joined_members is forbidden after leaving room", func(t *testing.T) {
+			// Venator: does not implement API version r0
+			runtime.SkipIf(t, runtime.Venator)
 			t.Parallel()
 			roomID := authedClient.MustCreateRoom(t, map[string]interface{}{})
 			authedClient.MustLeaveRoom(t, roomID)

--- a/tests/csapi/apidoc_room_state_test.go
+++ b/tests/csapi/apidoc_room_state_test.go
@@ -60,6 +60,8 @@ func TestRoomState(t *testing.T) {
 		})
 		// sytest: GET /rooms/:room_id/state/m.room.power_levels fetches powerlevels
 		t.Run("GET /rooms/:room_id/state/m.room.power_levels fetches powerlevels", func(t *testing.T) {
+			// Venator doesn't marshal default values so the presence check fails despite being valid.
+			runtime.SkipIf(t, runtime.Venator)
 			t.Parallel()
 
 			roomID := authedClient.MustCreateRoom(t, map[string]interface{}{

--- a/tests/csapi/device_lists_test.go
+++ b/tests/csapi/device_lists_test.go
@@ -449,16 +449,34 @@ func TestDeviceListUpdates(t *testing.T) {
 	defer deployment.Destroy(t)
 
 	t.Run("when local user joins a room", func(t *testing.T) { testOtherUserJoin(t, deployment, "hs1", "hs1") })
-	t.Run("when remote user joins a room", func(t *testing.T) { testOtherUserJoin(t, deployment, "hs1", "hs2") })
+	t.Run("when remote user joins a room", func(t *testing.T) {
+		// Venator: does not yet implement federation
+		runtime.SkipIf(t, runtime.Venator)
+		testOtherUserJoin(t, deployment, "hs1", "hs2")
+	})
 	t.Run("when joining a room with a local user", func(t *testing.T) { testJoin(t, deployment, "hs1", "hs1") })
-	t.Run("when joining a room with a remote user", func(t *testing.T) { testJoin(t, deployment, "hs1", "hs2") })
+	t.Run("when joining a room with a remote user", func(t *testing.T) {
+		// Venator: does not yet implement federation
+		runtime.SkipIf(t, runtime.Venator)
+		testJoin(t, deployment, "hs1", "hs2")
+	})
 	t.Run("when local user leaves a room", func(t *testing.T) { testOtherUserLeave(t, deployment, "hs1", "hs1") })
-	t.Run("when remote user leaves a room", func(t *testing.T) { testOtherUserLeave(t, deployment, "hs1", "hs2") })
+	t.Run("when remote user leaves a room", func(t *testing.T) {
+		// Venator: does not yet implement federation
+		runtime.SkipIf(t, runtime.Venator)
+		testOtherUserLeave(t, deployment, "hs1", "hs2")
+	})
 	t.Run("when leaving a room with a local user", func(t *testing.T) { testLeave(t, deployment, "hs1", "hs1") })
 	t.Run("when leaving a room with a remote user", func(t *testing.T) {
 		runtime.SkipIf(t, runtime.Synapse) // FIXME: https://github.com/matrix-org/synapse/issues/13650
+		// Venator: does not yet implement federation
+		runtime.SkipIf(t, runtime.Venator)
 		testLeave(t, deployment, "hs1", "hs2")
 	})
 	t.Run("when local user rejoins a room", func(t *testing.T) { testOtherUserRejoin(t, deployment, "hs1", "hs1") })
-	t.Run("when remote user rejoins a room", func(t *testing.T) { testOtherUserRejoin(t, deployment, "hs1", "hs2") })
+	t.Run("when remote user rejoins a room", func(t *testing.T) {
+		// Venator: does not yet implement federation
+		runtime.SkipIf(t, runtime.Venator)
+		testOtherUserRejoin(t, deployment, "hs1", "hs2")
+	})
 }

--- a/tests/csapi/invalid_test.go
+++ b/tests/csapi/invalid_test.go
@@ -1,3 +1,7 @@
+//go:build !venator_blacklist
+
+// Venator: does not support room version 6 (>=v10 only)
+
 package csapi_tests
 
 import (

--- a/tests/csapi/keychanges_test.go
+++ b/tests/csapi/keychanges_test.go
@@ -1,3 +1,7 @@
+//go:build !venator_blacklist
+
+// Venator: does not implement r0 API, which part of this test depends on
+
 package csapi_tests
 
 import (

--- a/tests/csapi/media_async_uploads_test.go
+++ b/tests/csapi/media_async_uploads_test.go
@@ -31,6 +31,9 @@ func TestAsyncUpload(t *testing.T) {
 	})
 
 	t.Run("Not yet uploaded", func(t *testing.T) {
+		// Venator is too young for any media to be available over the unauthenticated API,
+		// and always returns M_NOT_FOUND
+		runtime.SkipIf(t, runtime.Venator)
 		mxcURI := alice.CreateMedia(t)
 		parts := strings.Split(mxcURI, "/")
 		mediaID := parts[len(parts)-1]

--- a/tests/csapi/media_misc_test.go
+++ b/tests/csapi/media_misc_test.go
@@ -63,6 +63,8 @@ func TestRoomImageRoundtrip(t *testing.T) {
 
 // sytest: Can read configuration endpoint
 func TestMediaConfig(t *testing.T) {
+	// Venator: does not permit the use of the legacy media API (always returns M_NOT_FOUND)
+	runtime.SkipIf(t, runtime.Venator)
 	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 

--- a/tests/csapi/power_levels_test.go
+++ b/tests/csapi/power_levels_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/matrix-org/complement/runtime"
 	"github.com/tidwall/gjson"
 
 	"github.com/matrix-org/complement"
@@ -59,6 +60,10 @@ func TestPowerLevels(t *testing.T) {
 
 	// sytest: GET /rooms/:room_id/state/m.room.power_levels can fetch levels
 	t.Run("GET /rooms/:room_id/state/m.room.power_levels can fetch levels", func(t *testing.T) {
+		// Venator skips marshalling default values, which means all of these checks fail:
+		// > MatchJSONBytes key 'ban' missing with input = {}
+		// This is a feature :D
+		runtime.SkipIf(t, runtime.Venator)
 		// Test if the old state still exists
 		// note: before v10 we technically cannot assume that powerlevel integers are json numbers,
 		//  as they can be both strings and numbers.

--- a/tests/csapi/room_leave_test.go
+++ b/tests/csapi/room_leave_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/matrix-org/complement/runtime"
 	"github.com/tidwall/gjson"
 
 	"github.com/matrix-org/complement"
@@ -127,6 +128,8 @@ func TestLeftRoomFixture(t *testing.T) {
 
 	// sytest: Can get rooms/{roomId}/state for a departed room (SPEC-216)
 	t.Run("Can get rooms/{roomId}/state for a departed room", func(t *testing.T) {
+		// Venator: rooms are automatically forgotten on leave, so this functionality conflicts
+		runtime.SkipIf(t, runtime.Venator)
 		// Bob gets the old state
 		content := bob.MustGetStateEventContent(t, roomID, madeUpStateKey, "")
 		must.MatchGJSON(t, content, match.JSONKeyEqual("body", beforeMadeUpState))
@@ -138,6 +141,8 @@ func TestLeftRoomFixture(t *testing.T) {
 
 	// sytest: Can get rooms/{roomId}/members for a departed room (SPEC-216)
 	t.Run("Can get rooms/{roomId}/members for a departed room", func(t *testing.T) {
+		// Venator: rooms are automatically forgotten on leave, so this functionality conflicts
+		runtime.SkipIf(t, runtime.Venator)
 		resp := bob.MustDo(
 			t,
 			"GET",
@@ -163,6 +168,8 @@ func TestLeftRoomFixture(t *testing.T) {
 
 	// sytest: Can get rooms/{roomId}/messages for a departed room (SPEC-216)
 	t.Run("Can get rooms/{roomId}/messages for a departed room", func(t *testing.T) {
+		// Venator: rooms are automatically forgotten on leave, so this functionality conflicts
+		runtime.SkipIf(t, runtime.Venator)
 		resp := bob.MustDo(t, "GET", []string{"_matrix", "client", "v3", "rooms", roomID, "messages"}, client.WithQueries(url.Values{
 			"dir":   []string{"b"},
 			"limit": []string{"3"},
@@ -188,6 +195,8 @@ func TestLeftRoomFixture(t *testing.T) {
 
 	// sytest: Can get 'm.room.name' state for a departed room (SPEC-216)
 	t.Run("Can get 'm.room.name' state for a departed room", func(t *testing.T) {
+		// Venator: rooms are automatically forgotten on leave, so this functionality conflicts
+		runtime.SkipIf(t, runtime.Venator)
 		// Bob gets the old name
 		content := bob.MustGetStateEventContent(t, roomID, "m.room.name", "")
 		must.MatchGJSON(t, content, match.JSONKeyEqual("name", beforeRoomName))
@@ -199,6 +208,8 @@ func TestLeftRoomFixture(t *testing.T) {
 
 	// sytest: Getting messages going forward is limited for a departed room (SPEC-216)
 	t.Run("Getting messages going forward is limited for a departed room", func(t *testing.T) {
+		// Venator: rooms are automatically forgotten on leave, so this functionality conflicts
+		runtime.SkipIf(t, runtime.Venator)
 		// TODO: try this with the most recent since token too
 		resp := bob.MustDo(t, "GET", []string{"_matrix", "client", "v3", "rooms", roomID, "messages"}, client.WithQueries(url.Values{
 			"dir":   []string{"f"},

--- a/tests/csapi/room_messages_test.go
+++ b/tests/csapi/room_messages_test.go
@@ -242,6 +242,8 @@ type MessagesTestCase struct {
 }
 
 func TestMessagesOverFederation(t *testing.T) {
+	// Venator: does not yet implement federation
+	runtime.SkipIf(t, runtime.Venator)
 	deployment := complement.Deploy(t, 2)
 	defer deployment.Destroy(t)
 

--- a/tests/csapi/room_upgrade_test.go
+++ b/tests/csapi/room_upgrade_test.go
@@ -21,6 +21,9 @@ import (
 // perhaps that just needs a clarification/MSC to document the state of things. Synapse
 // and Dendrite do this for example.
 func TestPushRuleRoomUpgrade(t *testing.T) {
+	// Venator: does not implement this functionality (needs spec change).
+	// Venator: additionally does not implement federation (which several tests depend on).
+	runtime.SkipIf(t, runtime.Venator)
 	deployment := complement.Deploy(t, 2)
 	defer deployment.Destroy(t)
 

--- a/tests/csapi/rooms_members_local_test.go
+++ b/tests/csapi/rooms_members_local_test.go
@@ -52,6 +52,8 @@ func TestMembersLocal(t *testing.T) {
 		// Split into initial and incremental sync cases in Complement.
 		t.Run("Existing members see new members' presence (in initial sync)", func(t *testing.T) {
 			runtime.SkipIf(t, runtime.Dendrite) // FIXME: https://github.com/matrix-org/matrix-spec/issues/1374
+			// Venator: does not implement presence
+			runtime.SkipIf(t, runtime.Venator)
 			t.Parallel()
 			// First we sync to make sure bob to have joined the room...
 			alice.MustSyncUntil(t, client.SyncReq{}, client.SyncJoinedTo(bob.UserID, roomID))
@@ -65,6 +67,8 @@ func TestMembersLocal(t *testing.T) {
 		// sytest: Existing members see new members' presence
 		// Split into initial and incremental sync cases in Complement.
 		t.Run("Existing members see new members' presence (in incremental sync)", func(t *testing.T) {
+			// Venator: does not implement presence
+			runtime.SkipIf(t, runtime.Venator)
 			t.Parallel()
 			alice.MustSyncUntil(t, client.SyncReq{Since: incrementalSyncTokenBeforeBobJoinsRoom},
 				client.SyncJoinedTo(bob.UserID, roomID),

--- a/tests/csapi/rooms_state_test.go
+++ b/tests/csapi/rooms_state_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/matrix-org/complement/runtime"
 	"github.com/tidwall/gjson"
 
 	"github.com/matrix-org/complement"
@@ -89,6 +90,8 @@ func TestRoomCreationReportsEventsToMyself(t *testing.T) {
 
 		// sytest: Setting state twice is idempotent
 		t.Run("Setting state twice is idempotent", func(t *testing.T) {
+			// Venator: https://github.com/matrix-org/complement/issues/901
+			runtime.SkipIf(t, runtime.Venator)
 			t.Parallel()
 
 			stateEvent := b.Event{
@@ -109,6 +112,9 @@ func TestRoomCreationReportsEventsToMyself(t *testing.T) {
 
 		// sytest: Joining room twice is idempotent
 		t.Run("Joining room twice is idempotent", func(t *testing.T) {
+			// Venator: https://github.com/matrix-org/complement/issues/901
+			// Test passes illegitimately
+			runtime.SkipIf(t, runtime.Venator)
 			t.Parallel()
 
 			roomID := bob.MustCreateRoom(t, map[string]interface{}{

--- a/tests/csapi/sync_archive_test.go
+++ b/tests/csapi/sync_archive_test.go
@@ -1,8 +1,9 @@
 package csapi_tests
 
 import (
-	"github.com/tidwall/gjson"
 	"testing"
+
+	"github.com/tidwall/gjson"
 
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/b"
@@ -49,6 +50,8 @@ func TestSyncLeaveSection(t *testing.T) {
 
 	// sytest: Left rooms appear in the leave section of sync
 	t.Run("Left rooms appear in the leave section of sync", func(t *testing.T) {
+		// Venator: rooms are automatically forgotten on leave, which results in conflicting behaviour
+		runtime.SkipIf(t, runtime.Venator)
 		// SyncLeftFrom does "active" probing of rooms.leave if userID == clientUserID
 		alice.MustSyncUntil(t, client.SyncReq{
 			Filter: includeLeaveFilter,
@@ -57,6 +60,8 @@ func TestSyncLeaveSection(t *testing.T) {
 
 	// sytest: Left rooms appear in the leave section of full state sync
 	t.Run("Left rooms appear in the leave section of full state sync", func(t *testing.T) {
+		// Venator: rooms are automatically forgotten on leave, which results in conflicting behaviour
+		runtime.SkipIf(t, runtime.Venator)
 		alice.MustSyncUntil(t, client.SyncReq{
 			Since:     fullStateSince,
 			Filter:    includeLeaveFilter,
@@ -75,6 +80,8 @@ func TestSyncLeaveSection(t *testing.T) {
 // sytest: Newly left rooms appear in the leave section of gapped sync
 func TestGappedSyncLeaveSection(t *testing.T) {
 	runtime.SkipIf(t, runtime.Dendrite) // FIXME: https://github.com/matrix-org/dendrite/issues/1323
+	// Venator: rooms are automatically forgotten on leave, which results in conflicting behaviour
+	runtime.SkipIf(t, runtime.Venator)
 
 	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
@@ -117,6 +124,8 @@ func TestGappedSyncLeaveSection(t *testing.T) {
 // ... plus later additions
 func TestArchivedRoomsHistory(t *testing.T) {
 	runtime.SkipIf(t, runtime.Dendrite) // FIXME: https://github.com/matrix-org/dendrite/issues/1323
+	// Venator: rooms are automatically forgotten on leave, which results in conflicting behaviour
+	runtime.SkipIf(t, runtime.Venator)
 
 	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)

--- a/tests/csapi/sync_test.go
+++ b/tests/csapi/sync_test.go
@@ -210,6 +210,8 @@ func TestSync(t *testing.T) {
 		// sytest: Newly joined room includes presence in incremental sync
 		t.Run("Newly joined room includes presence in incremental sync", func(t *testing.T) {
 			runtime.SkipIf(t, runtime.Dendrite) // FIXME: https://github.com/matrix-org/dendrite/issues/1324
+			// Venator: does not implement presence
+			runtime.SkipIf(t, runtime.Venator)
 			roomID := alice.MustCreateRoom(t, map[string]interface{}{"preset": "public_chat"})
 			alice.MustSyncUntil(t, client.SyncReq{}, client.SyncJoinedTo(alice.UserID, roomID))
 			_, nextBatch := bob.MustSync(t, client.SyncReq{})
@@ -230,6 +232,8 @@ func TestSync(t *testing.T) {
 		// sytest: Get presence for newly joined members in incremental sync
 		t.Run("Get presence for newly joined members in incremental sync", func(t *testing.T) {
 			runtime.SkipIf(t, runtime.Dendrite) // FIXME: https://github.com/matrix-org/dendrite/issues/1324
+			// Venator: does not implement presence
+			runtime.SkipIf(t, runtime.Venator)
 			roomID := alice.MustCreateRoom(t, map[string]interface{}{"preset": "public_chat"})
 			nextBatch := alice.MustSyncUntil(t, client.SyncReq{}, client.SyncJoinedTo(alice.UserID, roomID))
 			sendMessages(t, alice, roomID, "dummy message", 1)
@@ -276,6 +280,8 @@ func TestSync(t *testing.T) {
 			// in the order we send them, but in practice it seems to get close
 			// enough.
 
+			// Venator: does not yet implement federation, so this test cannot function (see third paragraph of above)
+			runtime.SkipIf(t, runtime.Venator)
 			t.Parallel()
 
 			// alice creates two rooms, which charlie (on our test server) joins
@@ -450,6 +456,8 @@ func TestSync(t *testing.T) {
 // events, with the `limited` flag set.
 func TestSyncTimelineGap(t *testing.T) {
 	runtime.SkipIf(t, runtime.Dendrite)
+	// Venator: does not yet implement federation (so this test cannot function)
+	runtime.SkipIf(t, runtime.Venator)
 	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
@@ -626,6 +634,8 @@ func TestSyncTimelineGap(t *testing.T) {
 
 // Test presence from people in 2 different rooms in incremental sync
 func TestPresenceSyncDifferentRooms(t *testing.T) {
+	// Venator: does not implement presence
+	runtime.SkipIf(t, runtime.Venator)
 	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 

--- a/tests/csapi/txnid_test.go
+++ b/tests/csapi/txnid_test.go
@@ -214,8 +214,8 @@ func TestTxnIdempotency(t *testing.T) {
 // TestTxnIdWithRefreshToken tests that when a client refreshes its access token,
 // it still gets back a transaction ID in the sync response and idempotency is respected.
 func TestTxnIdWithRefreshToken(t *testing.T) {
-	// Dendrite and Conduit don't support refresh tokens yet.
-	runtime.SkipIf(t, runtime.Dendrite, runtime.Conduit)
+	// Dendrite, Conduit, and Venator don't support refresh tokens yet.
+	runtime.SkipIf(t, runtime.Dendrite, runtime.Conduit, runtime.Venator)
 
 	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)

--- a/tests/csapi/url_preview_test.go
+++ b/tests/csapi/url_preview_test.go
@@ -41,6 +41,8 @@ var oGraphHtml = fmt.Sprintf(`
 // sytest: Test URL preview
 func TestUrlPreview(t *testing.T) {
 	runtime.SkipIf(t, runtime.Dendrite) // FIXME: https://github.com/matrix-org/dendrite/issues/621
+	// Venator: does not allow the use of the unauthenticated media API (always returns M_NOT_FOUND)
+	runtime.SkipIf(t, runtime.Venator)
 
 	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)

--- a/tests/direct_messaging_test.go
+++ b/tests/direct_messaging_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
+	"github.com/matrix-org/complement/runtime"
 	"github.com/matrix-org/gomatrixserverlib/fclient"
 
 	"github.com/matrix-org/gomatrixserverlib"
@@ -102,6 +103,8 @@ func TestIsDirectFlagLocal(t *testing.T) {
 // Test that the `is_direct` flag on m.room.member invites propagate to the target user. Users
 // are on different homeservers.
 func TestIsDirectFlagFederation(t *testing.T) {
+	// Venator: does not yet implement federation
+	runtime.SkipIf(t, runtime.Venator)
 	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 

--- a/tests/federation_acl_test.go
+++ b/tests/federation_acl_test.go
@@ -1,3 +1,7 @@
+//go:build !venator_blacklist
+
+// Venator: does not yet implement federation. ACLs are implemented, but not in a way that can be exposed to these tests
+
 package tests
 
 import (

--- a/tests/federation_device_list_update_test.go
+++ b/tests/federation_device_list_update_test.go
@@ -1,3 +1,7 @@
+//go:build !venator_blacklist
+
+// Venator: does not yet implement federation
+
 package tests
 
 import (

--- a/tests/federation_event_auth_test.go
+++ b/tests/federation_event_auth_test.go
@@ -1,3 +1,7 @@
+//go:build !venator_blacklist
+
+// Venator: does not yet implement federation
+
 package tests
 
 import (

--- a/tests/federation_media_content_test.go
+++ b/tests/federation_media_content_test.go
@@ -1,11 +1,16 @@
+//go:build !venator_blacklist
+
+// Venator: does not yet implement federation
+
 package tests
 
 import (
 	"bytes"
+	"testing"
+
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/internal/data"
-	"testing"
 )
 
 func TestContentMediaV1(t *testing.T) {

--- a/tests/federation_presence_test.go
+++ b/tests/federation_presence_test.go
@@ -1,3 +1,7 @@
+//go:build !venator_blacklist
+
+// Venator: does not yet implement federation, nor presence
+
 package tests
 
 import (

--- a/tests/federation_query_profile_test.go
+++ b/tests/federation_query_profile_test.go
@@ -1,3 +1,7 @@
+//go:build !venator_blacklist
+
+// Venator: does not yet implement federation
+
 package tests
 
 import (

--- a/tests/federation_redaction_test.go
+++ b/tests/federation_redaction_test.go
@@ -1,3 +1,7 @@
+//go:build !venator_blacklist
+
+// Venator: does not yet implement federation
+
 package tests
 
 import (

--- a/tests/federation_room_alias_test.go
+++ b/tests/federation_room_alias_test.go
@@ -8,10 +8,13 @@ import (
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
+	"github.com/matrix-org/complement/runtime"
 )
 
 // sytest: Remote room alias queries can handle Unicode
 func TestRemoteAliasRequestsUnderstandUnicode(t *testing.T) {
+	// Venator: does not yet implement federation
+	runtime.SkipIf(t, runtime.Venator)
 	deployment := complement.Deploy(t, 2)
 	defer deployment.Destroy(t)
 

--- a/tests/federation_room_ban_test.go
+++ b/tests/federation_room_ban_test.go
@@ -1,3 +1,7 @@
+//go:build !venator_blacklist
+
+// Venator: does not yet implement federation
+
 package tests
 
 import (

--- a/tests/federation_room_event_auth_test.go
+++ b/tests/federation_room_event_auth_test.go
@@ -1,6 +1,8 @@
 // These tests currently fail on Dendrite, due to Dendrite bugs.
-//go:build !dendrite_blacklist
-// +build !dendrite_blacklist
+//go:build !dendrite_blacklist && !venator_blacklist
+// +build !dendrite_blacklist,!venator_blacklist
+
+// Venator: does not yet implement federation
 
 package tests
 

--- a/tests/federation_room_get_missing_events_test.go
+++ b/tests/federation_room_get_missing_events_test.go
@@ -1,3 +1,7 @@
+//go:build !venator_blacklist
+
+// Venator: does not yet implement federation
+
 package tests
 
 import (

--- a/tests/federation_room_invite_test.go
+++ b/tests/federation_room_invite_test.go
@@ -1,3 +1,7 @@
+//go:build !venator_blacklist
+
+// Venator: does not yet implement federation
+
 package tests
 
 import (

--- a/tests/federation_room_join_test.go
+++ b/tests/federation_room_join_test.go
@@ -39,6 +39,10 @@ import (
 // m.room.create event would pick that up. We also can't tear down the Complement
 // server because otherwise signing key lookups will fail.
 func TestJoinViaRoomIDAndServerName(t *testing.T) {
+	// Venator: does not yet implement federation. The entire file cannot be ignored as
+	// testValidationForSendMembershipEndpoint is referenced elsewhere, which causes compile errors if elided by build
+	// constraints.
+	runtime.SkipIf(t, runtime.Venator)
 	deployment := complement.Deploy(t, 2)
 	defer deployment.Destroy(t)
 
@@ -89,6 +93,10 @@ func TestJoinViaRoomIDAndServerName(t *testing.T) {
 // This tests that joining a room with multiple ?server_name=s works correctly.
 // The join should succeed even if the first server is not in the room.
 func TestJoinFederatedRoomFailOver(t *testing.T) {
+	// Venator: does not yet implement federation. The entire file cannot be ignored as
+	// testValidationForSendMembershipEndpoint is referenced elsewhere, which causes compile errors if elided by build
+	// constraints.
+	runtime.SkipIf(t, runtime.Venator)
 	deployment := complement.Deploy(t, 2)
 	defer deployment.Destroy(t)
 
@@ -132,6 +140,10 @@ func TestJoinFederatedRoomFailOver(t *testing.T) {
 // the properties listed above, then asking HS1 to join them and make sure that
 // they 200 OK.
 func TestJoinFederatedRoomWithUnverifiableEvents(t *testing.T) {
+	// Venator: does not yet implement federation. The entire file cannot be ignored as
+	// testValidationForSendMembershipEndpoint is referenced elsewhere, which causes compile errors if elided by build
+	// constraints.
+	runtime.SkipIf(t, runtime.Venator)
 	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
@@ -298,6 +310,10 @@ func TestJoinFederatedRoomWithUnverifiableEvents(t *testing.T) {
 
 // This test checks that users cannot circumvent the auth checks via send_join.
 func TestBannedUserCannotSendJoin(t *testing.T) {
+	// Venator: does not yet implement federation. The entire file cannot be ignored as
+	// testValidationForSendMembershipEndpoint is referenced elsewhere, which causes compile errors if elided by build
+	// constraints.
+	runtime.SkipIf(t, runtime.Venator)
 	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
@@ -365,21 +381,37 @@ func TestBannedUserCannotSendJoin(t *testing.T) {
 
 // This test checks that we cannot submit anything via /v1/send_join except a join.
 func TestCannotSendNonJoinViaSendJoinV1(t *testing.T) {
+	// Venator: does not yet implement federation. The entire file cannot be ignored as
+	// testValidationForSendMembershipEndpoint is referenced elsewhere, which causes compile errors if elided by build
+	// constraints.
+	runtime.SkipIf(t, runtime.Venator)
 	testValidationForSendMembershipEndpoint(t, "/_matrix/federation/v1/send_join", "join", nil)
 }
 
 // This test checks that we cannot submit anything via /v2/send_join except a join.
 func TestCannotSendNonJoinViaSendJoinV2(t *testing.T) {
+	// Venator: does not yet implement federation. The entire file cannot be ignored as
+	// testValidationForSendMembershipEndpoint is referenced elsewhere, which causes compile errors if elided by build
+	// constraints.
+	runtime.SkipIf(t, runtime.Venator)
 	testValidationForSendMembershipEndpoint(t, "/_matrix/federation/v2/send_join", "join", nil)
 }
 
 // This test checks that we cannot submit anything via /v1/send_leave except a leave.
 func TestCannotSendNonLeaveViaSendLeaveV1(t *testing.T) {
+	// Venator: does not yet implement federation. The entire file cannot be ignored as
+	// testValidationForSendMembershipEndpoint is referenced elsewhere, which causes compile errors if elided by build
+	// constraints.
+	runtime.SkipIf(t, runtime.Venator)
 	testValidationForSendMembershipEndpoint(t, "/_matrix/federation/v1/send_leave", "leave", nil)
 }
 
 // This test checks that we cannot submit anything via /v2/send_leave except a leave.
 func TestCannotSendNonLeaveViaSendLeaveV2(t *testing.T) {
+	// Venator: does not yet implement federation. The entire file cannot be ignored as
+	// testValidationForSendMembershipEndpoint is referenced elsewhere, which causes compile errors if elided by build
+	// constraints.
+	runtime.SkipIf(t, runtime.Venator)
 	testValidationForSendMembershipEndpoint(t, "/_matrix/federation/v2/send_leave", "leave", nil)
 }
 
@@ -494,6 +526,10 @@ func testValidationForSendMembershipEndpoint(t *testing.T, baseApiPath, expected
 //
 // Will be skipped if the server returns a full-state response.
 func TestSendJoinPartialStateResponse(t *testing.T) {
+	// Venator: does not yet implement federation. The entire file cannot be ignored as
+	// testValidationForSendMembershipEndpoint is referenced elsewhere, which causes compile errors if elided by build
+	// constraints.
+	runtime.SkipIf(t, runtime.Venator)
 	// start with a homeserver with two users
 	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
@@ -580,6 +616,10 @@ func typeAndStateKeyForEvent(result gjson.Result) string {
 }
 
 func TestJoinFederatedRoomFromApplicationServiceBridgeUser(t *testing.T) {
+	// Venator: does not yet implement federation. The entire file cannot be ignored as
+	// testValidationForSendMembershipEndpoint is referenced elsewhere, which causes compile errors if elided by build
+	// constraints.
+	runtime.SkipIf(t, runtime.Venator)
 	// Dendrite doesn't read AS registration files from Complement yet
 	runtime.SkipIf(t, runtime.Dendrite) // FIXME: https://github.com/matrix-org/complement/issues/514
 

--- a/tests/federation_room_send_test.go
+++ b/tests/federation_room_send_test.go
@@ -1,3 +1,7 @@
+//go:build !venator_blacklist
+
+// Venator: does not yet implement federation
+
 package tests
 
 import (

--- a/tests/federation_room_typing_test.go
+++ b/tests/federation_room_typing_test.go
@@ -1,3 +1,7 @@
+//go:build !venator_blacklist
+
+// Venator: does not yet implement federation
+
 package tests
 
 import (

--- a/tests/federation_rooms_invite_test.go
+++ b/tests/federation_rooms_invite_test.go
@@ -1,6 +1,8 @@
 // These tests currently fail on Dendrite, due to Dendrite bugs.
-//go:build !dendrite_blacklist
-// +build !dendrite_blacklist
+//go:build !dendrite_blacklist && !venator_blacklist
+// +build !dendrite_blacklist,!venator_blacklist
+
+// Venator: does not yet implement federation
 
 package tests
 

--- a/tests/federation_sync_test.go
+++ b/tests/federation_sync_test.go
@@ -1,3 +1,7 @@
+//go:build !venator_blacklist
+
+// Venator: does not yet implement federation
+
 package tests
 
 import (

--- a/tests/federation_to_device_test.go
+++ b/tests/federation_to_device_test.go
@@ -1,3 +1,7 @@
+//go:build !venator_blacklist
+
+// Venator: does not yet implement federation
+
 package tests
 
 import (

--- a/tests/federation_unreject_rejected_test.go
+++ b/tests/federation_unreject_rejected_test.go
@@ -1,3 +1,7 @@
+//go:build !venator_blacklist
+
+// Venator: does not yet implement federation
+
 package tests
 
 import (

--- a/tests/federation_upload_keys_test.go
+++ b/tests/federation_upload_keys_test.go
@@ -1,3 +1,7 @@
+//go:build !venator_blacklist
+
+// Venator: does not yet implement federation
+
 package tests
 
 import (

--- a/tests/knock_restricted_test.go
+++ b/tests/knock_restricted_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/helpers"
+	"github.com/matrix-org/complement/runtime"
 )
 
 var (
@@ -32,6 +33,8 @@ func TestKnockRoomsInPublicRoomsDirectoryInMSC3787Room(t *testing.T) {
 
 // See TestCannotSendKnockViaSendKnock
 func TestCannotSendKnockViaSendKnockInMSC3787Room(t *testing.T) {
+	// Venator: does not yet implement federation.
+	runtime.SkipIf(t, runtime.Venator)
 	testValidationForSendMembershipEndpoint(t, "/_matrix/federation/v1/send_knock", "knock",
 		map[string]interface{}{
 			"preset":       "public_chat",
@@ -57,6 +60,8 @@ func TestRestrictedRoomsLocalJoinInMSC3787Room(t *testing.T) {
 
 // See TestRestrictedRoomsRemoteJoin
 func TestRestrictedRoomsRemoteJoinInMSC3787Room(t *testing.T) {
+	// Venator: does not yet implement federation.
+	runtime.SkipIf(t, runtime.Venator)
 	deployment := complement.Deploy(t, 2)
 	defer deployment.Destroy(t)
 

--- a/tests/knock_restricted_test.go
+++ b/tests/knock_restricted_test.go
@@ -77,6 +77,8 @@ func TestRestrictedRoomsRemoteJoinInMSC3787Room(t *testing.T) {
 
 // See TestRestrictedRoomsRemoteJoinLocalUser
 func TestRestrictedRoomsRemoteJoinLocalUserInMSC3787Room(t *testing.T) {
+	// Venator: does not yet implement federation
+	runtime.SkipIf(t, runtime.Venator)
 	doTestRestrictedRoomsRemoteJoinLocalUser(t, roomVersion, joinRule)
 }
 

--- a/tests/knocking_test.go
+++ b/tests/knocking_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/matrix-org/complement"
+	"github.com/matrix-org/complement/runtime"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/gomatrixserverlib/spec"
 	"github.com/tidwall/gjson"
@@ -40,6 +41,8 @@ func TestKnocking(t *testing.T) {
 }
 
 func doTestKnocking(t *testing.T, roomVersion string, joinRule string) {
+	// Venator: does not yet implement federation.
+	runtime.SkipIf(t, runtime.Venator)
 	deployment := complement.Deploy(t, 2)
 	defer deployment.Destroy(t)
 

--- a/tests/knocking_test.go
+++ b/tests/knocking_test.go
@@ -364,6 +364,8 @@ func knockOnRoomWithStatus(t *testing.T, c *client.CSAPI, roomID, reason string,
 // representing a knock room. For sanity-checking, this test will also create a public room and ensure it has a
 // 'join_rule' representing a publicly-joinable room.
 func TestKnockRoomsInPublicRoomsDirectory(t *testing.T) {
+	// Venator: does not support room v7 (>=v10 only)
+	runtime.SkipIf(t, runtime.Venator)
 	// v7 is required for knocking
 	doTestKnockRoomsInPublicRoomsDirectory(t, "7", "knock")
 }
@@ -454,6 +456,8 @@ func publishAndCheckRoomJoinRule(t *testing.T, c *client.CSAPI, roomID, expected
 
 // TestCannotSendNonKnockViaSendKnock checks that we cannot submit anything via /send_knock except a knock
 func TestCannotSendNonKnockViaSendKnock(t *testing.T) {
+	// Venator: does not yet implement federation, nor room v7 (>=v10 only)
+	runtime.SkipIf(t, runtime.Venator)
 	testValidationForSendMembershipEndpoint(t, "/_matrix/federation/v1/send_knock", "knock",
 		map[string]interface{}{
 			"preset":       "public_chat",

--- a/tests/media_filename_test.go
+++ b/tests/media_filename_test.go
@@ -43,6 +43,9 @@ func TestMediaFilenames(t *testing.T) {
 				t.Run(fmt.Sprintf("Can download file '%s'", filename), func(t *testing.T) {
 					// Synapse no longer allows downloads over the unauthenticated media endpoints by default
 					runtime.SkipIf(t, runtime.Synapse)
+					// Venator is too young for any media to be available over the unauthenticated API,
+					// and always returns M_NOT_FOUND
+					runtime.SkipIf(t, runtime.Venator)
 					t.Parallel()
 
 					mxcUri := alice.UploadContent(t, data.MatrixPng, filename, "image/png")
@@ -73,6 +76,9 @@ func TestMediaFilenames(t *testing.T) {
 			t.Run("Can download specifying a different ASCII file name", func(t *testing.T) {
 				// Synapse no longer allows downloads over the unauthenticated media endpoints by default
 				runtime.SkipIf(t, runtime.Synapse)
+				// Venator is too young for any media to be available over the unauthenticated API,
+				// and always returns M_NOT_FOUND
+				runtime.SkipIf(t, runtime.Venator)
 				t.Parallel()
 
 				mxcUri := alice.UploadContent(t, data.MatrixPng, asciiFileName, "image/png")
@@ -113,6 +119,9 @@ func TestMediaFilenames(t *testing.T) {
 			t.Run("Can download specifying a different Unicode file name", func(t *testing.T) {
 				// Synapse no longer allows downloads over the unauthenticated media endpoints by default
 				runtime.SkipIf(t, runtime.Synapse)
+				// Venator is too young for any media to be available over the unauthenticated API,
+				// and always returns M_NOT_FOUND
+				runtime.SkipIf(t, runtime.Venator)
 				t.Parallel()
 
 				mxcUri := alice.UploadContent(t, data.MatrixPng, unicodeFileName, "image/png")
@@ -144,6 +153,9 @@ func TestMediaFilenames(t *testing.T) {
 			t.Run("Can download with Unicode file name locally", func(t *testing.T) {
 				// Synapse no longer allows downloads over the unauthenticated media endpoints by default
 				runtime.SkipIf(t, runtime.Synapse)
+				// Venator is too young for any media to be available over the unauthenticated API,
+				// and always returns M_NOT_FOUND
+				runtime.SkipIf(t, runtime.Venator)
 				t.Parallel()
 
 				mxcUri := alice.UploadContent(t, data.MatrixPng, unicodeFileName, "image/png")
@@ -171,6 +183,9 @@ func TestMediaFilenames(t *testing.T) {
 			t.Run("Can download with Unicode file name over federation", func(t *testing.T) {
 				// Synapse no longer allows downloads over the unauthenticated media endpoints by default
 				runtime.SkipIf(t, runtime.Synapse)
+				// Venator is too young for any media to be available over the unauthenticated API,
+				// and always returns M_NOT_FOUND. It also doesn't implement federation yet.
+				runtime.SkipIf(t, runtime.Venator)
 				t.Parallel()
 
 				mxcUri := alice.UploadContent(t, data.MatrixPng, unicodeFileName, "image/png")
@@ -183,6 +198,8 @@ func TestMediaFilenames(t *testing.T) {
 			})
 
 			t.Run("Can download with Unicode file name over federation via _matrix/client/v1/media/download", func(t *testing.T) {
+				// Venator: doesn't implement federation yet.
+				runtime.SkipIf(t, runtime.Venator)
 				t.Parallel()
 
 				mxcUri := alice.UploadContent(t, data.MatrixPng, unicodeFileName, "image/png")
@@ -195,13 +212,11 @@ func TestMediaFilenames(t *testing.T) {
 			})
 
 			t.Run("Will serve safe media types as inline", func(t *testing.T) {
-				if runtime.Homeserver != runtime.Conduwuit {
-					// We need to check that this security behaviour is being correctly run in
-					// conduwuit, but since this is not part of the Matrix spec we do not assume
-					// other homeservers are doing so.
-					// Skip Synapse because it no longer allows downloads over the unauthenticated media endpoints by default
-					t.Skip("Skipping test of Content-Disposition header requirements on non-conduwuit homeserver")
-				}
+				// We need to check that this security behaviour is being correctly run in
+				// conduwuit, but since this is not part of the Matrix spec we do not assume
+				// other homeservers are doing so.
+				// Skip Synapse because it no longer allows downloads over the unauthenticated media endpoints by default
+				runtime.SkipUnless(t, runtime.Conduwuit)
 				t.Parallel()
 
 				mxcUri := alice.UploadContent(t, data.MatrixPng, "", "image/png")
@@ -214,12 +229,10 @@ func TestMediaFilenames(t *testing.T) {
 			})
 
 			t.Run("Will serve safe media types as inline via _matrix/client/v1/media/download", func(t *testing.T) {
-				if runtime.Homeserver != runtime.Synapse && runtime.Homeserver != runtime.Conduwuit {
-					// We need to check that this security behaviour is being correctly run in
-					// Synapse or conduwuit, but since this is not part of the Matrix spec we do not assume
-					// other homeservers are doing so.
-					t.Skip("Skipping test of Content-Disposition header requirements on non-Synapse and non-conduwuit homeserver")
-				}
+				// We need to check that this security behaviour is being correctly run in
+				// Synapse or conduwuit, but since this is not part of the Matrix spec we do not assume
+				// other homeservers are doing so.
+				runtime.SkipUnless(t, runtime.Synapse, runtime.Conduwuit)
 				t.Parallel()
 
 				mxcUri := alice.UploadContent(t, data.MatrixPng, "", "image/png")
@@ -232,13 +245,11 @@ func TestMediaFilenames(t *testing.T) {
 			})
 
 			t.Run("Will serve safe media types with parameters as inline", func(t *testing.T) {
-				if runtime.Homeserver != runtime.Conduwuit {
-					// We need to check that this security behaviour is being correctly run in
-					// conduwuit, but since this is not part of the Matrix spec we do not assume
-					// other homeservers are doing so.
-					// Skip Synapse because it no longer allows downloads over the unauthenticated media endpoints by default
-					t.Skip("Skipping test of Content-Disposition header requirements on non-conduwuit homeserver")
-				}
+				// We need to check that this security behaviour is being correctly run in
+				// conduwuit, but since this is not part of the Matrix spec we do not assume
+				// other homeservers are doing so.
+				// Skip Synapse because it no longer allows downloads over the unauthenticated media endpoints by default
+				runtime.SkipUnless(t, runtime.Conduwuit)
 				t.Parallel()
 
 				// Add parameters and upper-case, which should be parsed as text/plain.
@@ -252,12 +263,10 @@ func TestMediaFilenames(t *testing.T) {
 			})
 
 			t.Run("Will serve safe media types with parameters as inline via _matrix/client/v1/media/download", func(t *testing.T) {
-				if runtime.Homeserver != runtime.Synapse && runtime.Homeserver != runtime.Conduwuit {
-					// We need to check that this security behaviour is being correctly run in
-					// Synapse or conduwuit, but since this is not part of the Matrix spec we do not assume
-					// other homeservers are doing so.
-					t.Skip("Skipping test of Content-Disposition header requirements on non-Synapse and non-conduwuit homeserver")
-				}
+				// We need to check that this security behaviour is being correctly run in
+				// Synapse or conduwuit, but since this is not part of the Matrix spec we do not assume
+				// other homeservers are doing so.
+				runtime.SkipUnless(t, runtime.Synapse, runtime.Conduwuit)
 				t.Parallel()
 
 				// Add parameters and upper-case, which should be parsed as text/plain.
@@ -271,13 +280,11 @@ func TestMediaFilenames(t *testing.T) {
 			})
 
 			t.Run("Will serve unsafe media types as attachments", func(t *testing.T) {
-				if runtime.Homeserver != runtime.Conduwuit {
-					// We need to check that this security behaviour is being correctly run in
-					// conduwuit, but since this is not part of the Matrix spec we do not assume
-					// other homeservers are doing so.
-					// Skip Synapse because it no longer allows downloads over the unauthenticated media endpoints by default
-					t.Skip("Skipping test of Content-Disposition header requirements on non-conduwuit homeserver")
-				}
+				// We need to check that this security behaviour is being correctly run in
+				// conduwuit, but since this is not part of the Matrix spec we do not assume
+				// other homeservers are doing so.
+				// Skip Synapse because it no longer allows downloads over the unauthenticated media endpoints by default
+				runtime.SkipUnless(t, runtime.Conduwuit)
 				t.Parallel()
 
 				mxcUri := alice.UploadContent(t, data.MatrixSvg, "", "image/svg")
@@ -290,12 +297,10 @@ func TestMediaFilenames(t *testing.T) {
 			})
 
 			t.Run("Will serve unsafe media types as attachments via _matrix/client/v1/media/download", func(t *testing.T) {
-				if runtime.Homeserver != runtime.Synapse && runtime.Homeserver != runtime.Conduwuit {
-					// We need to check that this security behaviour is being correctly run in
-					// Synapse or conduwuit, but since this is not part of the Matrix spec we do not assume
-					// other homeservers are doing so.
-					t.Skip("Skipping test of Content-Disposition header requirements on non-Synapse and non-conduwuit homeserver")
-				}
+				// We need to check that this security behaviour is being correctly run in
+				// Synapse or conduwuit, but since this is not part of the Matrix spec we do not assume
+				// other homeservers are doing so.
+				runtime.SkipUnless(t, runtime.Synapse, runtime.Conduwuit)
 				t.Parallel()
 
 				mxcUri := alice.UploadContent(t, data.MatrixSvg, "", "image/svg")

--- a/tests/media_nofilename_test.go
+++ b/tests/media_nofilename_test.go
@@ -17,6 +17,8 @@ import (
 func TestMediaWithoutFileName(t *testing.T) {
 	// Synapse no longer allows downloads over the unauthenticated media endpoints by default
 	runtime.SkipIf(t, runtime.Synapse)
+	// Venator is too young for any media to be available over the unauthenticated API, and always returns M_NOT_FOUND
+	runtime.SkipIf(t, runtime.Venator)
 
 	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
@@ -103,6 +105,8 @@ func TestMediaWithoutFileName(t *testing.T) {
 
 // same test as above, but for the new _matrix/client/v1/media endpoint
 func TestMediaWithoutFileNameCSMediaV1(t *testing.T) {
+	// Venator: does not yet implement federation
+	runtime.SkipIf(t, runtime.Venator)
 	deployment := complement.Deploy(t, 2)
 	defer deployment.Destroy(t)
 

--- a/tests/media_thumbnail_test.go
+++ b/tests/media_thumbnail_test.go
@@ -39,6 +39,9 @@ func TestLocalPngThumbnail(t *testing.T) {
 	t.Run("test /_matrix/media/v3 endpoint", func(t *testing.T) {
 		// Synapse no longer allows downloads over the unauthenticated media endpoints by default
 		runtime.SkipIf(t, runtime.Synapse)
+		// Venator is too young for any media to be available over the unauthenticated API,
+		// and always returns M_NOT_FOUND
+		runtime.SkipIf(t, runtime.Venator)
 		fetchAndValidateThumbnail(t, alice, uri, false)
 	})
 
@@ -51,6 +54,8 @@ func TestLocalPngThumbnail(t *testing.T) {
 
 // sytest: Remote media can be thumbnailed
 func TestRemotePngThumbnail(t *testing.T) {
+	// Venator: does not yet implement federation
+	runtime.SkipIf(t, runtime.Venator)
 	deployment := complement.Deploy(t, 2)
 	defer deployment.Destroy(t)
 
@@ -84,6 +89,8 @@ func TestRemotePngThumbnail(t *testing.T) {
 
 func TestFederationThumbnail(t *testing.T) {
 	runtime.SkipIf(t, runtime.Dendrite)
+	// Venator: does not yet implement federation
+	runtime.SkipIf(t, runtime.Venator)
 
 	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)

--- a/tests/restricted_room_hierarchy_test.go
+++ b/tests/restricted_room_hierarchy_test.go
@@ -5,6 +5,7 @@ package tests
 import (
 	"testing"
 
+	"github.com/matrix-org/complement/runtime"
 	"github.com/tidwall/gjson"
 
 	"github.com/matrix-org/complement"
@@ -121,6 +122,8 @@ func TestRestrictedRoomsSpacesSummaryLocal(t *testing.T) {
 // different homeservers, and one might not have the proper information needed to
 // decide if a user is in a room.
 func TestRestrictedRoomsSpacesSummaryFederation(t *testing.T) {
+	// Venator: does not yet implement federation
+	runtime.SkipIf(t, runtime.Venator)
 	deployment := complement.Deploy(t, 2)
 	defer deployment.Destroy(t)
 

--- a/tests/restricted_rooms_test.go
+++ b/tests/restricted_rooms_test.go
@@ -331,6 +331,8 @@ func TestRestrictedRoomsRemoteJoinFailOver(t *testing.T) {
 
 func doTestRestrictedRoomsRemoteJoinFailOver(t *testing.T, roomVersion string, joinRule string) {
 	runtime.SkipIf(t, runtime.Dendrite) // FIXME: https://github.com/matrix-org/dendrite/issues/2801
+	// Venator: does not yet implement federation.
+	runtime.SkipIf(t, runtime.Venator)
 
 	deployment := complement.Deploy(t, 3)
 	defer deployment.Destroy(t)
@@ -469,6 +471,8 @@ func TestRestrictedRoomsLocalJoinNoCreatorsUsesPowerLevelsV11(t *testing.T) {
 }
 
 func doTestRestrictedRoomsLocalJoinNoCreatorsUsesPowerLevels(t *testing.T, roomVersion string, joinRule string) {
+	// Venator: does not yet implement federation.
+	runtime.SkipIf(t, runtime.Venator)
 	deployment := complement.Deploy(t, 2)
 	defer deployment.Destroy(t)
 	// Create the room

--- a/tests/restricted_rooms_test.go
+++ b/tests/restricted_rooms_test.go
@@ -187,6 +187,8 @@ func checkRestrictedRoom(t *testing.T, deployment complement.Deployment, alice *
 
 // Test joining a room with join rules restricted to membership in another room.
 func TestRestrictedRoomsLocalJoin(t *testing.T) {
+	// Venator: does not support room version 8 (>=v10 only)
+	runtime.SkipIf(t, runtime.Venator)
 	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 
@@ -218,11 +220,15 @@ func TestRestrictedRoomsRemoteJoin(t *testing.T) {
 // A server will do a remote join for a local user if it is unable to to issue
 // joins in a restricted room it is already participating in.
 func TestRestrictedRoomsRemoteJoinLocalUser(t *testing.T) {
+	// Venator: does not support room version 8 (>=v10 only)
+	runtime.SkipIf(t, runtime.Venator)
 	doTestRestrictedRoomsRemoteJoinLocalUser(t, "8", "restricted")
 }
 
 func doTestRestrictedRoomsRemoteJoinLocalUser(t *testing.T, roomVersion string, joinRule string) {
 	runtime.SkipIf(t, runtime.Dendrite) // FIXME: https://github.com/matrix-org/dendrite/issues/2801
+	// Venator: does not yet implement federation
+	runtime.SkipIf(t, runtime.Venator)
 
 	deployment := complement.Deploy(t, 2)
 	defer deployment.Destroy(t)

--- a/tests/room_hierarchy_test.go
+++ b/tests/room_hierarchy_test.go
@@ -18,6 +18,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/matrix-org/complement/runtime"
 	"github.com/tidwall/gjson"
 
 	"github.com/matrix-org/complement"
@@ -544,6 +545,8 @@ func TestClientSpacesSummaryJoinRules(t *testing.T) {
 // Tests that:
 // - Querying from root returns the entire graph
 func TestFederatedClientSpaces(t *testing.T) {
+	// Venator: does not yet implement federation
+	runtime.SkipIf(t, runtime.Venator)
 	deployment := complement.Deploy(t, 2)
 	defer deployment.Destroy(t)
 

--- a/tests/room_timestamp_to_event_test.go
+++ b/tests/room_timestamp_to_event_test.go
@@ -21,12 +21,15 @@ import (
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
+	"github.com/matrix-org/complement/runtime"
 	"github.com/matrix-org/gomatrixserverlib/spec"
 	"github.com/tidwall/gjson"
 	"golang.org/x/exp/slices"
 )
 
 func TestJumpToDateEndpoint(t *testing.T) {
+	// Venator: does not yet implement federation
+	runtime.SkipIf(t, runtime.Venator)
 	deployment := complement.OldDeploy(t, b.BlueprintHSWithApplicationService)
 	defer deployment.Destroy(t)
 

--- a/tests/unknown_endpoints_test.go
+++ b/tests/unknown_endpoints_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/match"
 	"github.com/matrix-org/complement/must"
+	"github.com/matrix-org/complement/runtime"
 )
 
 func queryUnknownEndpoint(t *testing.T, user *client.CSAPI, paths []string) {
@@ -73,7 +74,11 @@ func TestUnknownEndpoints(t *testing.T) {
 		// v3 should exist, but not v3/unknown.
 		queryUnknownEndpoint(t, alice, []string{"_matrix", "key", "v2", "unknown"})
 
-		queryUnknownMethod(t, alice, "PUT", []string{"_matrix", "key", "v2", "query"})
+		if runtime.Homeserver != runtime.Venator {
+			// Venator does not implement this endpoint at all - since it doesn't know what the expected methods are,
+			// it returns 404 M_UNRECOGNIZED, instead of 405 M_UNRECOGNIZED, which causes this to fail.
+			queryUnknownMethod(t, alice, "PUT", []string{"_matrix", "key", "v2", "query"})
+		}
 	})
 
 	// Unknown media endpoints.

--- a/tests/v12_test.go
+++ b/tests/v12_test.go
@@ -53,6 +53,9 @@ func TestMSC4289PrivilegedRoomCreators(t *testing.T) {
 	}
 
 	t.Run("PL event is missing creator in users map", func(t *testing.T) {
+		// Venator: default values (including empty) for power levels are skipped during marshalling, so this test
+		// flakes as the empty users object is not present (which is legal)
+		runtime.SkipIf(t, runtime.Venator)
 		roomID := alice.MustCreateRoom(t, map[string]interface{}{
 			"room_version": roomVersion12,
 		})

--- a/tests/v12_test.go
+++ b/tests/v12_test.go
@@ -136,6 +136,7 @@ func TestMSC4289PrivilegedRoomCreators(t *testing.T) {
 	// technically not a MSC4289 thing but implementations may set the creator PL to be
 	// above the value expressible in canonical JSON to implement "infinite".
 	t.Run("power level cannot be set beyond max canonical JSON int", func(t *testing.T) {
+		runtime.SkipIf(t, runtime.Venator)
 		roomID := alice.MustCreateRoom(t, map[string]interface{}{
 			"room_version": roomVersion12,
 			"preset":       "public_chat",
@@ -183,6 +184,8 @@ func TestMSC4289PrivilegedRoomCreators(t *testing.T) {
 		})
 	})
 	t.Run("admin with >PL100 sorts after the room creator for state resolution", func(t *testing.T) {
+		// Venator: does not yet implement federation
+		runtime.SkipIf(t, runtime.Venator)
 		srv := federation.NewServer(t, deployment,
 			federation.HandleKeyRequests(),
 			federation.HandleMakeSendJoinRequests(),
@@ -615,6 +618,8 @@ func TestMSC4291RoomIDAsHashOfCreateEvent(t *testing.T) {
 }
 
 func TestComplementCanCreateValidV12Rooms(t *testing.T) {
+	// Venator: does not yet implement federation
+	runtime.SkipIf(t, runtime.Venator)
 	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
@@ -645,6 +650,8 @@ func TestComplementCanCreateValidV12Rooms(t *testing.T) {
 }
 
 func TestMSC4291RoomIDAsHashOfCreateEvent_AuthEventsOmitsCreateEvent(t *testing.T) {
+	// Venator: does not yet implement federation
+	runtime.SkipIf(t, runtime.Venator)
 	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{})
@@ -915,6 +922,8 @@ func assertCreateEventIsRoomID(t ct.TestLike, client *client.CSAPI, roomID strin
 //     in other words we apply state resolution to (Alice leave, 250th Charlie display name change).
 func TestMSC4297StateResolutionV2_1_starts_from_empty_set(t *testing.T) {
 	runtime.SkipIf(t, runtime.Dendrite) // needs additional fixes
+	// Venator: does not yet implement federation
+	runtime.SkipIf(t, runtime.Venator)
 	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 	srv := federation.NewServer(t, deployment,
@@ -1096,6 +1105,8 @@ func TestMSC4297StateResolutionV2_1_starts_from_empty_set(t *testing.T) {
 
 func TestMSC4297StateResolutionV2_1_includes_conflicted_subgraph(t *testing.T) {
 	runtime.SkipIf(t, runtime.Dendrite) // needs additional fixes
+	// Venator: does not yet implement federation
+	runtime.SkipIf(t, runtime.Venator)
 	deployment := complement.Deploy(t, 1)
 	defer deployment.Destroy(t)
 	srv := federation.NewServer(t, deployment,
@@ -1340,6 +1351,8 @@ func asEventIDs(pdus []gomatrixserverlib.PDU) []string {
 
 func TestMSC4311FullCreateEventOnStrippedState(t *testing.T) {
 	runtime.SkipIf(t, runtime.Dendrite) // does not implement it yet
+	// Venator: does not yet implement federation
+	runtime.SkipIf(t, runtime.Venator)
 	deployment := complement.Deploy(t, 2)
 	defer deployment.Destroy(t)
 	alice := deployment.Register(t, "hs1", helpers.RegistrationOpts{LocalpartSuffix: "alice"})


### PR DESCRIPTION
Has a soft dependency on #896, otherwise only 6 tests can run against Venator.

Docs for running complement against Venator, in case it's interesting for the review process: https://demo.thefifthfleet.net/docs/contributing/testing.html

### Pull Request Checklist

- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)

