### PR TITLE
Fix missing time boundary guard in `TestJumpToDateEndpoint`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,8 +34,8 @@ jobs:
           DOCKER_BUILDKIT: 1
         run: |
           mkdir -p homeserver
-          # Latest official dendrite release is still using Debian Stretch as a base, hence the specific commit
-          wget -O - "https://github.com/matrix-org/dendrite/archive/0489d16f95a3d9f1f5bc532e2060bd2482d7b156.tar.gz" | tar -xz --strip-components=1 -C homeserver
+          # Dendrite is unmaintained to just pin to a known working commit
+          wget -O - "https://github.com/element-hq/dendrite/archive/08cac1ccf0a45471132ad24a29e3ec15643675fa.tar.gz" | tar -xz --strip-components=1 -C homeserver
           (cd homeserver && docker build -t complement-dendrite -f build/scripts/Complement.Dockerfile .)
           (cd cmd/homerunner/test && ./test.sh)
 

--- a/tests/room_timestamp_to_event_test.go
+++ b/tests/room_timestamp_to_event_test.go
@@ -362,7 +362,7 @@ func createTestRoom(t *testing.T, c *client.CSAPI) (roomID string, eventA, event
 	roomID = c.MustCreateRoom(t, map[string]interface{}{
 		"preset": "public_chat",
 	})
-
+	time.Sleep(tsBoundaryGuard) // ensure timeBeforeEventA is AFTER the initial creation events
 	timeBeforeEventA := time.Now()
 	time.Sleep(tsBoundaryGuard)
 	eventAID := c.SendEventSynced(t, roomID, b.Event{

--- a/tests/room_timestamp_to_event_test.go
+++ b/tests/room_timestamp_to_event_test.go
@@ -362,7 +362,9 @@ func createTestRoom(t *testing.T, c *client.CSAPI) (roomID string, eventA, event
 	roomID = c.MustCreateRoom(t, map[string]interface{}{
 		"preset": "public_chat",
 	})
-	time.Sleep(tsBoundaryGuard) // ensure timeBeforeEventA is AFTER the initial creation events
+	// timeBeforeEventA doubles as the initial creation events after-timestamp, so guard it on
+	// both sides to keep it between the two events.
+	time.Sleep(tsBoundaryGuard)
 	timeBeforeEventA := time.Now()
 	time.Sleep(tsBoundaryGuard)
 	eventAID := c.SendEventSynced(t, roomID, b.Event{


### PR DESCRIPTION
Whilst #872 tried to fix this, ~~the review process reintroduced the bug~~ for one specific scenario: when the initial room creation events are in the same millisecond as the event "before A". Without this extra sleep, `timeBeforeEventA` may actually be the "time exactly at the last initial creation events" which is Bad since it then messes up which events get returned.

### Pull Request Checklist

- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)

